### PR TITLE
Add middleware to log unhandled exceptions to various targets

### DIFF
--- a/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
+++ b/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
@@ -6,7 +6,7 @@
     <Company>Arcus</Company>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>Azure;WebAPI;App Services;Web App;Web;API</PackageTags>
-    <Description>Provides capabilities to easily build Web APIs running in Azure.</Description>
+    <Description>Provides capabilities for easily integrating logging when building Web APIs running in Azure.</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.webapi/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/arcus-azure/arcus.webapi</PackageProjectUrl>

--- a/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
+++ b/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>    
+    <Authors>Arcus</Authors>
+    <Company>Arcus</Company>
+    <RepositoryType>Git</RepositoryType>
+    <PackageTags>Azure;WebAPI;App Services;Web App;Web;API</PackageTags>
+    <Description>Provides capabilities to easily build Web APIs running in Azure.</Description>
+    <Copyright>Copyright (c) Arcus</Copyright>
+    <PackageLicenseUrl>https://github.com/arcus-azure/arcus.webapi/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/arcus-azure/arcus.webapi</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/arcus-azure/arcus.webapi</RepositoryUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
+++ b/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
@@ -13,6 +13,7 @@
     <RepositoryUrl>https://github.com/arcus-azure/arcus.webapi</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.WebApi.Logging/ExceptionHandlingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/ExceptionHandlingMiddleware.cs
@@ -32,7 +32,7 @@ namespace Arcus.WebApi.Logging
             var logger = loggerFactory.CreateLogger("");
             logger.LogCritical(ex, ex.Message);
 
-            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError; ;
+            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
         }
     }
 }

--- a/src/Arcus.WebApi.Logging/ExceptionHandlingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/ExceptionHandlingMiddleware.cs
@@ -9,10 +9,35 @@ namespace Arcus.WebApi.Logging
     public class ExceptionHandlingMiddleware
     {
         private readonly RequestDelegate _next;
+        private readonly Func<string> _getLoggingCategory;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExceptionHandlingMiddleware"/> class.
+        /// </summary>
+        /// <param name="next"></param>
         public ExceptionHandlingMiddleware(RequestDelegate next)
+            : this(next, string.Empty)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExceptionHandlingMiddleware"/> class.
+        /// </summary>
+        /// <param name="next"></param>
+        /// <param name="categoryName">The category-name for messages produced by the logger.</param>
+        public ExceptionHandlingMiddleware(RequestDelegate next, string categoryName)
+            : this(next, () => categoryName)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExceptionHandlingMiddleware"/> class.
+        /// </summary>
+        /// <param name="next"></param>
+        /// <param name="getLoggingCategory">The function that returns the category-name that must be used by the logger
+        /// when writing log messages.</param>
+        public ExceptionHandlingMiddleware(RequestDelegate next, Func<string> getLoggingCategory)
         {
             _next = next;
+            _getLoggingCategory = getLoggingCategory;
         }
 
         public async Task Invoke(HttpContext context, ILoggerFactory loggerFactory)
@@ -27,9 +52,9 @@ namespace Arcus.WebApi.Logging
             }
         }
 
-        private static void HandleException(HttpContext context, Exception ex, ILoggerFactory loggerFactory)
+        private void HandleException(HttpContext context, Exception ex, ILoggerFactory loggerFactory)
         {
-            var logger = loggerFactory.CreateLogger("");
+            var logger = loggerFactory.CreateLogger(_getLoggingCategory());
             logger.LogCritical(ex, ex.Message);
 
             context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;

--- a/src/Arcus.WebApi.Logging/ExceptionHandlingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.WebApi.Logging
+{
+    public class ExceptionHandlingMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public ExceptionHandlingMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext context, ILoggerFactory loggerFactory)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch (Exception ex)
+            {
+                HandleException(context, ex, loggerFactory);
+            }
+        }
+
+        private static void HandleException(HttpContext context, Exception ex, ILoggerFactory loggerFactory)
+        {
+            var logger = loggerFactory.CreateLogger("");
+            logger.LogCritical(ex, ex.Message);
+
+            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError; ;
+        }
+    }
+}

--- a/src/Arcus.WebApi.Logging/ExceptionHandlingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/ExceptionHandlingMiddleware.cs
@@ -54,7 +54,9 @@ namespace Arcus.WebApi.Logging
 
         private void HandleException(HttpContext context, Exception ex, ILoggerFactory loggerFactory)
         {
-            var logger = loggerFactory.CreateLogger(_getLoggingCategory());
+            string categoryName = _getLoggingCategory() ?? string.Empty;
+
+            var logger = loggerFactory.CreateLogger(categoryName);
             logger.LogCritical(ex, ex.Message);
 
             context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;

--- a/src/Arcus.WebApi.sln
+++ b/src/Arcus.WebApi.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28010.2036
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.WebApi.All", "Arcus.WebApi.All\Arcus.WebApi.All.csproj", "{19B02A8B-2E0C-44B6-A086-88FE2091D27C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.WebApi.All", "Arcus.WebApi.All\Arcus.WebApi.All.csproj", "{19B02A8B-2E0C-44B6-A086-88FE2091D27C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.WebApi.Logging", "Arcus.WebApi.Logging\Arcus.WebApi.Logging.csproj", "{1112242E-FD86-4531-90A3-94B37D0131DA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{19B02A8B-2E0C-44B6-A086-88FE2091D27C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19B02A8B-2E0C-44B6-A086-88FE2091D27C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{19B02A8B-2E0C-44B6-A086-88FE2091D27C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1112242E-FD86-4531-90A3-94B37D0131DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1112242E-FD86-4531-90A3-94B37D0131DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1112242E-FD86-4531-90A3-94B37D0131DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1112242E-FD86-4531-90A3-94B37D0131DA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Description
This is the minimal functionality that I require for the moment in an ASP.NET API.   This functionality allows to log exceptions to multiple targets.
It surely needs to be extended to allow to add correlation-id's or other (custom) information.

## Documentation

I don't know what we're doing regarding documentation ?  
Anyway, usage of this middleware:

In `Startup.Configure` , this middleware can be added to the pipeline:

```csharp
public void Configure(IApplicationBuilder app, IHostingEnvironment env)
{
   app.UseMiddleware<Arcus.WebApi.Logging.ExceptionHandlingMiddleware>();
}
```
The above statement will make sure that all unhandled exceptions are logged to all configured loggers.
To get the exceptions logged in AppInsights, logging should be configured like this when configuring the `IWebHost` (in Program.cs):

```csharp
WebHost.CreateDefaultBuilder(args)
              .UseApplicationInsights()
              .ConfigureLogging(loggers => loggers.AddApplicationInsights())
              .UseStartup<Startup>();
```

To be able to use the `AddApplicationInsights` extension method, the `Microsoft.Extensions.Logging.ApplicationInsights` package must be installed.

If the parameter-less `AddApplicationInsights` method is used, the configurationsetting `ApplicationInsights:TelemetryKey` must be specified and the value of the telemetry-key of the ApplicationInsights resource must be set.

#14 