### PR TITLE
Refer to correct setting-names

### DIFF
--- a/docs/features/logging.md
+++ b/docs/features/logging.md
@@ -38,4 +38,4 @@ WebHost.CreateDefaultBuilder(args)
 To be able to use the `AddApplicationInsights` extension method, the Microsoft.Extensions.Logging.ApplicationInsights package must be installed.
 
 
-If the parameter-less `AddApplicationInsights` method is used, the configurationsetting `ApplicationInsights:TelemetryKey` must be specified and the value of the telemetry-key of the Application Insights resource must be set.
+If the parameter-less `AddApplicationInsights` method is used, the configurationsetting `ApplicationInsights:InstrumentationKey` must be specified and the value of the instrumentation-key of the Application Insights resource must be set.


### PR DESCRIPTION
I refered to `ApplicationSettings:TelemetryKey` instead of `ApplicationSettings:InstrumentationKey`