### PR TITLE
Improve documentation on authentication key filter

### DIFF
--- a/docs/features/security/auth/shared-access-key.md
+++ b/docs/features/security/auth/shared-access-key.md
@@ -57,7 +57,7 @@ The authentication requires an `ICachedSecretProvider` or `ISecretProvider` depe
 ```csharp
 public void ConfigureServices(IServiceCollections services)
 {
-    services.AddScoped<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(new MySecretProvider()));
+    services.AddSingleton<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(new MySecretProvider()));
     services.AddMvc();
 }
 ```

--- a/docs/features/security/auth/shared-access-key.md
+++ b/docs/features/security/auth/shared-access-key.md
@@ -38,7 +38,7 @@ Once this is done, the `SharedAccessKeyAuthenticationFilter` can be added to the
 ```csharp
 public void ConfigureServices(IServiceCollections services)
 {
-    services.AddScoped<ICachedSecretProvider>(serviceProvider => new MyCachedSecretProvider());
+    services.AddSingleton<ICachedSecretProvider>(serviceProvider => new MyCachedSecretProvider());
     services.AddMvc(options => options.Filters.Add(new SharedAccessKeyAuthenticationFilter(headerName: "http-request-header-name", secretName: "shared-access-key-name")));
 }
 ```


### PR DESCRIPTION
The `ICachedSecretProvider `should be a Singleton service instead of scoped per request.

#73 