### PR TITLE
Use non-obsolete types in unit-testing

### DIFF
--- a/src/Arcus.WebApi.Unit/Security/Authentication/SharedAccessKeyAuthenticationAttributeTests.cs
+++ b/src/Arcus.WebApi.Unit/Security/Authentication/SharedAccessKeyAuthenticationAttributeTests.cs
@@ -4,7 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Arcus.Security.Secrets.Core.Interfaces;
-using Arcus.WebApi.Security.Authentication;
+using Arcus.WebApi.Security.Authentication.SharedAccessKey;
 using Arcus.WebApi.Unit.Hosting;
 using Xunit;
 

--- a/src/Arcus.WebApi.Unit/Security/Authentication/SharedAccessKeyAuthenticationController.cs
+++ b/src/Arcus.WebApi.Unit/Security/Authentication/SharedAccessKeyAuthenticationController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
-using Arcus.WebApi.Security.Authentication;
+using Arcus.WebApi.Security.Authentication.SharedAccessKey;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Arcus.WebApi.Unit.Security.Authentication 


### PR DESCRIPTION
The unit-tests for the SharedAccessKeyFilter were using the obsolete types.
Modified this to use the non-obsolete types.