### PR TITLE
Official releases should use Package.Version as build version

### DIFF
--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -1,4 +1,4 @@
-name: $(date:yyyyMMdd)$(rev:.r)
+name: $(Package.Version)
 
 trigger: none
 pr: none


### PR DESCRIPTION
Official releases should use Package.Version as build version instead of based on time & revision