### PR TITLE
CHORE: use build YAML template with version property

### DIFF
--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -27,15 +27,10 @@ stages:
         pool:
           vmImage: 'ubuntu-16.04'
         steps:
-          - task: DotNetCoreInstaller@0
-            displayName: 'Import .NET Core SDK ($(DotNet.Sdk.Version))'
-            inputs:
-              version: '$(DotNet.Sdk.Version)'
-          - task: DotNetCoreCLI@2
-            displayName: 'Compile'
-            inputs:
-              projects: 'src/*.sln'
-              arguments: '--configuration $(Build.Configuration) /property:Version=$(Build.BuildNumber)'
+          - template: build/build-solution.yml@templates
+            parameters:
+              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
+              version: $(Build.BuildNumber)
           - task: CopyFiles@2
             displayName: 'Copy build artifacts'
             inputs:


### PR DESCRIPTION
Uses the YAML build template with the version property.

Relates to [#7](https://github.com/arcus-azure/azure-devops-templates/issues/7)