### PR TITLE
FEAT: make correlation IDs consumer configurable

### DIFF
--- a/docs/features/correlation.md
+++ b/docs/features/correlation.md
@@ -74,7 +74,7 @@ public void ConfigureServices(IServiceCollection services)
 
         // The function that will generate the transaction ID, when the `.GenerateWhenNotSpecified` is set to `false` and the request doesn't contain the header.
         // (default: new `Guid`).
-        options.Transaction.GenerateId = () => $"Transaction-{Guid.NewGuid().ToString()}";
+        options.Transaction.GenerateId = () => $"Transaction-{Guid.NewGuid()}";
 
         // Configuration on the operation ID (`RequestId`) response header.
         // ----------------------------------------------------------------
@@ -87,7 +87,7 @@ public void ConfigureServices(IServiceCollection services)
 
         // The function that will generate the operation ID header value.
         // (default: new `Guid`).
-        options.Operation.GenerateId = () => Guid.NewGuid().ToString();
+        options.Operation.GenerateId = () => $"Operation-{Guid.NewGuid()}";
     });
 }
 ```

--- a/docs/features/correlation.md
+++ b/docs/features/correlation.md
@@ -74,7 +74,7 @@ public void ConfigureServices(IServiceCollection services)
 
         // The function that will generate the transaction ID, when the `.GenerateWhenNotSpecified` is set to `false` and the request doesn't contain the header.
         // (default: new `Guid`).
-        options.Transaction.GenerateId = () => Guid.NewGuid().ToString();
+        options.Transaction.GenerateId = () => $"Transaction-{Guid.NewGuid().ToString()}";
 
         // Configuration on the operation ID (`RequestId`) response header.
         // ----------------------------------------------------------------

--- a/docs/features/correlation.md
+++ b/docs/features/correlation.md
@@ -72,6 +72,10 @@ public void ConfigureServices(IServiceCollection services)
         // The header to look for in the HTTP request, and will be set in the HTTP response (default: X-Transaction-ID).
         options.Transaction.HeaderName = "X-Transaction-ID";
 
+        // The function that will generate the transaction ID, when the `.GenerateWhenNotSpecified` is set to `false` and the request doesn't contain the header.
+        // (default: new `Guid`).
+        options.Transaction.GenerateId = () => Guid.NewGuid().ToString();
+
         // Configuration on the operation ID (`RequestId`) response header.
         // ----------------------------------------------------------------
 
@@ -80,6 +84,10 @@ public void ConfigureServices(IServiceCollection services)
 
         // The header that will contain the operation ID in the HTTP response (default: RequestId).
         options.Operation.HeaderName = "RequestId";
+
+        // The function that will generate the operation ID header value.
+        // (default: new `Guid`).
+        options.Operation.GenerateId = () => Guid.NewGuid().ToString();
     });
 }
 ```

--- a/src/Arcus.WebApi.Correlation/CorrelationOptionsOperation.cs
+++ b/src/Arcus.WebApi.Correlation/CorrelationOptionsOperation.cs
@@ -1,4 +1,5 @@
-﻿using GuardNet;
+﻿using System;
+using GuardNet;
 
 namespace Arcus.WebApi.Correlation
 {
@@ -8,6 +9,7 @@ namespace Arcus.WebApi.Correlation
     public class CorrelationOptionsOperation
     {
         private string _headerName = "RequestId";
+        private Func<string> _generateId = Guid.NewGuid().ToString;
 
         /// <summary>
         /// Gets or sets whether to include the operation ID in the response.
@@ -27,6 +29,19 @@ namespace Arcus.WebApi.Correlation
             {
                 Guard.NotNullOrWhitespace(value, nameof(value), "Correlation operation header cannot be blank");
                 _headerName = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the function to generate the operation ID when the <see cref="IncludeInResponse"/> is set to <c>true</c> (default: <c>true</c>).
+        /// </summary>
+        public Func<string> GenerateId
+        {
+            get => _generateId;
+            set
+            {
+                Guard.NotNull(value, nameof(value), "Correlation function to generate an operation ID cannot be 'null'");
+                _generateId = value;
             }
         }
     }

--- a/src/Arcus.WebApi.Correlation/CorrelationOptionsTransaction.cs
+++ b/src/Arcus.WebApi.Correlation/CorrelationOptionsTransaction.cs
@@ -1,4 +1,5 @@
-﻿using GuardNet;
+﻿using System;
+using GuardNet;
 
 namespace Arcus.WebApi.Correlation
 {
@@ -8,6 +9,7 @@ namespace Arcus.WebApi.Correlation
     public class CorrelationOptionsTransaction
     {
         private string _headerName = "X-Transaction-ID";
+        private Func<string> _generateId = Guid.NewGuid().ToString;
 
         /// <summary>
         /// Get or sets whether the transaction ID can be specified in the request, and will be used throughout the request handling.
@@ -37,6 +39,22 @@ namespace Arcus.WebApi.Correlation
             {
                 Guard.NotNullOrWhitespace(value, nameof(value), "Correlation transaction header cannot be blank");
                 _headerName = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the function to generate the transaction ID when
+        /// (1) the request doesn't have already an transaction ID, and
+        /// (2) the <see cref="IncludeInResponse"/> is set to <c>true</c> (default: <c>true</c>), and
+        /// (3) the <see cref="GenerateWhenNotSpecified"/> is set to <c>true</c> (default: <c>true</c>).
+        /// </summary>
+        public Func<string> GenerateId
+        {
+            get => _generateId;
+            set
+            {
+                Guard.NotNull(value, nameof(value), "Correlation function to generate an transaction ID cannot be 'null'");
+                _generateId = value;
             }
         }
     }

--- a/src/Arcus.WebApi.Unit/Correlation/CorrelationTests.cs
+++ b/src/Arcus.WebApi.Unit/Correlation/CorrelationTests.cs
@@ -102,8 +102,8 @@ namespace Arcus.WebApi.Unit.Correlation
             // Arrange
             _testServer.AddServicesConfig(services => services.Configure<CorrelationOptions>(options => options.Operation.IncludeInResponse = false));
             
-            using (HttpClient client = _testServer.CreateClient())
-                // Act
+            using (HttpClient client = _testServer.CreateClient()) 
+            // Act
             using (HttpResponseMessage response = await client.GetAsync(Route))
             {
                 // Assert

--- a/src/Arcus.WebApi.Unit/Correlation/TraceIdentifierMiddleware.cs
+++ b/src/Arcus.WebApi.Unit/Correlation/TraceIdentifierMiddleware.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading.Tasks;
+using GuardNet;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace Arcus.WebApi.Unit.Correlation
+{
+    /// <summary>
+    /// Represents a component to disable the <see cref="HttpContext.TraceIdentifier"/> from the request information.
+    /// </summary>
+    public class TraceIdentifierMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly TraceIdentifierOptions _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TraceIdentifierMiddleware"/> class.
+        /// </summary>
+        public TraceIdentifierMiddleware(
+            RequestDelegate next,
+            IOptions<TraceIdentifierOptions> options)
+        {
+            _next = next;
+            Guard.NotNull(next, nameof(next), "Requires a continuation delegate");
+            Guard.NotNull(options, nameof(options), $"Requires a non-null '{nameof(TraceIdentifierOptions)}' options");
+            Guard.For<ArgumentException>(() => options.Value is null, $"Requires a value for the '{nameof(TraceIdentifierOptions)}' options");
+
+            _options = options.Value;
+        }
+
+        /// <summary>Request handling method.</summary>
+        /// <param name="httpContext">The <see cref="T:Microsoft.AspNetCore.Http.HttpContext" /> for the current request.</param>
+        /// <returns>A <see cref="T:System.Threading.Tasks.Task" /> that represents the execution of this middleware.</returns>
+        public async Task Invoke(HttpContext httpContext)
+        {
+            if (!_options.EnableTraceIdentifier)
+            {
+                httpContext.TraceIdentifier = String.Empty;
+            }
+
+            await _next(httpContext);
+        }
+    }
+}

--- a/src/Arcus.WebApi.Unit/Correlation/TraceIdentifierOptions.cs
+++ b/src/Arcus.WebApi.Unit/Correlation/TraceIdentifierOptions.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Arcus.WebApi.Unit.Correlation 
+{
+    /// <summary>
+    /// Represents the options available for the <see cref="TraceIdentifierMiddleware"/> component.
+    /// </summary>
+    public class TraceIdentifierOptions
+    {
+        /// <summary>
+        /// Gets or sets the value to indicate that the <see cref="HttpContext.TraceIdentifier"/> should be removed from the request information.
+        /// </summary>
+        public bool EnableTraceIdentifier { get; set; }
+    }
+}

--- a/src/Arcus.WebApi.Unit/Hosting/TestStartup.cs
+++ b/src/Arcus.WebApi.Unit/Hosting/TestStartup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Arcus.WebApi.Correlation;
+using Arcus.WebApi.Unit.Correlation;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -41,6 +42,7 @@ namespace Arcus.WebApi.Unit.Hosting
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+            app.UseMiddleware<TraceIdentifierMiddleware>();
             app.UseCorrelation();
 
             app.UseMvc();


### PR DESCRIPTION
Provide functions in the options to custommize the generation of the correlation ID's.

Closes #102 
Closes #103 