### PR TITLE
Conditionally reference Packages or Framework, depending on the TargetFramework

### DIFF
--- a/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
+++ b/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>    
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>    
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <RepositoryType>Git</RepositoryType>
@@ -16,10 +16,16 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Guard.Net" Version="1.2.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Guard.Net" Version="1.2.0" />
+  </ItemGroup>
 </Project>

--- a/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
+++ b/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
The Arcus.WebApi.Logging pckage used the Microsoft.AspNetCore.Mvc.Core package.
In this PR, the reference has been changed to Microsoft.AspNetCore.Mvc 2.2.0 instead of Microsoft.AspNetCore.Mvc.Core 2.2.2, to be more in line with the other projects in Arcus.   Next to that, referencing Mvc.Core 2.2.2 caused issues in a project that I'm working on.

Also, as described in this [article](https://andrewlock.net/converting-a-netstandard-2-library-to-netcore-3/#libraries-that-depend-on-asp-net-core-nuget-packages), the Microsoft.Extensions.* and Microsoft.AspNetCore.* packages are only referenced when targetting .NET Core 2.x

Before these changes get approved or are merged into master, I'd like to test them in one of the projects I'm working on.   Is there a preliminary (preview) nuget package available for these kind of changes ?