### PR TITLE
Fix - wrong integration test project name

### DIFF
--- a/build/templates/run-integration-tests.yml
+++ b/build/templates/run-integration-tests.yml
@@ -26,7 +26,7 @@ steps:
   - template: test/run-integration-tests.yml@templates
     parameters:
       dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-      dockerProjectName: '$(Project).Tests.Integration'
+      projectName: '$(Project).Tests.Integration'
   - task: Bash@3
     inputs:
       targetType: 'inline'


### PR DESCRIPTION
The integration test template had a wrong project name resulting in the skipped running of the integration tests. 