### PR TITLE
Feature - add version tracking middleware

### DIFF
--- a/docs/preview/features/logging.md
+++ b/docs/preview/features/logging.md
@@ -146,7 +146,7 @@ The `Arcus.WebApi.Logging` library allows you to add application version trackin
 This functionality uses the `IAppVersion`, available in the [Arcus.Observability](https://observability.arcus-azure.net/features/telemetry-enrichment#version-enricher) library, for retrieving the current application version.
 Such an instance **needs** to be registered in order for the version tracking to work correctly.
 
-<div markdown="span" class="alert alert-danger" role="alert"><i class="fa fa-exclamation-circle"></i> <b>WARNING:</b> only use the version tracking for non-public endpoints otherwise can the leakage of the application version be used in unintended malicious purposes.</div>
+> ⚠ **Warning:** only use the version tracking for non-public endpoints otherwise can the leakage of the application version be used in unintended malicious purposes.
 
 Adding the version tracking can be done by the following:
 

--- a/docs/preview/features/logging.md
+++ b/docs/preview/features/logging.md
@@ -9,6 +9,7 @@ The `Arcus.WebApi.Logging` package provides a way to log several kinds of inform
 
 - [Logging unhandled exceptions](#logging-unhandled-exceptions)
 - [Logging incoming requests](#logging-incoming-requests)
+- [Tracking application version](#tracking-application-version)
 
 To send the logging information to Application Insights, see [this explanation](#application-insights).
 
@@ -137,6 +138,33 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 So the resulting log message becomes:
 
 `HTTP Request POST http://localhost:5000/weatherforecast completed with 200 in 00:00:00.0191554 at 03/23/2020 10:12:55 +00:00 - (Context: [X-Api-Key,])`
+
+## Tracking application version
+
+The `Arcus.WebApi.Logging` library allows you to add application version tracking to your <span>ASP.NET</span> application which will include your application version to a configurable response header.
+
+This functionality uses the `IAppVersion`, available in the [Arcus.Observability]() library, for retrieving the current application version.
+Such an instance **needs** to be registered in order for the version tracking to work correctly.
+
+<div markdown="span" class="alert alert-danger" role="alert"><i class="fa fa-exclamation-circle"></i> <b>WARNING:</b> only use the version tracking for non-public endpoints otherwise can the leakage of the application version be used in unintended malicious purposes.</div>
+
+Adding the version tracking can be done by the following:
+
+```csharp
+public void ConfigureServices(IServcieCollection services)
+{
+    services.AddSingleton<IAppVersion, MyAppVersion>();
+}
+
+public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+{
+    // Uses the previously registered `IAppVersion` service to include the application to the default `X-Version` response header.
+    app.UseVersionTracking();
+
+    // Uses the previously registered `IAppVersion` service to include the application to the custom `X-My-Version` response header.
+    app.UseVersionTracking(options => options.Header = "X-My-Version");
+}
+```
 
 ## Application Insights
 

--- a/docs/preview/features/logging.md
+++ b/docs/preview/features/logging.md
@@ -151,7 +151,7 @@ Such an instance **needs** to be registered in order for the version tracking to
 Adding the version tracking can be done by the following:
 
 ```csharp
-public void ConfigureServices(IServcieCollection services)
+public void ConfigureServices(IServiceCollection services)
 {
     services.AddSingleton<IAppVersion, MyAppVersion>();
 }

--- a/docs/preview/features/logging.md
+++ b/docs/preview/features/logging.md
@@ -144,7 +144,7 @@ So the resulting log message becomes:
 The `Arcus.WebApi.Logging` library allows you to add application version tracking to your <span>ASP.NET</span> application which will include your application version to a configurable response header.
 
 This functionality uses the `IAppVersion`, available in the [Arcus.Observability](https://observability.arcus-azure.net/features/telemetry-enrichment#version-enricher) library, for retrieving the current application version.
-Such an instance **needs** to be registered in order for the version tracking to work correctly.
+Such an instance **must** be registered in order for the version tracking to work correctly.
 
 > ⚠ **Warning:** only use the version tracking for non-public endpoints otherwise can the leakage of the application version be used in unintended malicious purposes.
 

--- a/docs/preview/features/logging.md
+++ b/docs/preview/features/logging.md
@@ -143,7 +143,7 @@ So the resulting log message becomes:
 
 The `Arcus.WebApi.Logging` library allows you to add application version tracking to your <span>ASP.NET</span> application which will include your application version to a configurable response header.
 
-This functionality uses the `IAppVersion`, available in the [Arcus.Observability]() library, for retrieving the current application version.
+This functionality uses the `IAppVersion`, available in the [Arcus.Observability](https://observability.arcus-azure.net/features/telemetry-enrichment#version-enricher) library, for retrieving the current application version.
 Such an instance **needs** to be registered in order for the version tracking to work correctly.
 
 <div markdown="span" class="alert alert-danger" role="alert"><i class="fa fa-exclamation-circle"></i> <b>WARNING:</b> only use the version tracking for non-public endpoints otherwise can the leakage of the application version be used in unintended malicious purposes.</div>

--- a/docs/preview/features/logging.md
+++ b/docs/preview/features/logging.md
@@ -146,7 +146,7 @@ The `Arcus.WebApi.Logging` library allows you to add application version trackin
 This functionality uses the `IAppVersion`, available in the [Arcus.Observability](https://observability.arcus-azure.net/features/telemetry-enrichment#version-enricher) library, for retrieving the current application version.
 Such an instance **must** be registered in order for the version tracking to work correctly.
 
-> ⚠ **Warning:** only use the version tracking for non-public endpoints otherwise can the leakage of the application version be used in unintended malicious purposes.
+> ⚠ **Warning:** Only use the version tracking for non-public endpoints otherwise the version information is leaked and it can be used for unintended malicious purposes.
 
 Adding the version tracking can be done by the following:
 

--- a/src/Arcus.WebApi.Logging/Correlation/CorrelationMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/Correlation/CorrelationMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿    using System;
 using System.Threading.Tasks;
 using Arcus.Observability.Correlation;
 using GuardNet;

--- a/src/Arcus.WebApi.Logging/Correlation/CorrelationMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/Correlation/CorrelationMiddleware.cs
@@ -1,4 +1,4 @@
-﻿    using System;
+using System;
 using System.Threading.Tasks;
 using Arcus.Observability.Correlation;
 using GuardNet;

--- a/src/Arcus.WebApi.Logging/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Arcus.WebApi.Logging/Extensions/IApplicationBuilderExtensions.cs
@@ -65,5 +65,26 @@ namespace Microsoft.AspNetCore.Builder
 
             return app.UseMiddleware<CorrelationMiddleware>();
         }
+
+        /// <summary>
+        /// Adds the <see cref="VersionTrackingMiddleware"/> component to the application request's pipeline to automatically include the application version to the response.
+        /// </summary>
+        /// <param name="app">The builder to configure the application's request pipeline.</param>
+        /// <param name="configureOptions">
+        ///     The optional function to configure the version tracking options that will influence the behavior of the version tracking functionality.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="app"/> is <c>null</c>.</exception>
+        /// <remarks>
+        ///     WARNING: only use in non-publicly endpoints so the application version is not leaked and can be used for malicious purposes.
+        /// </remarks>
+        public static IApplicationBuilder UseVersionTracking(this IApplicationBuilder app, Action<VersionTrackingOptions> configureOptions = null)
+        {
+            Guard.NotNull(app, nameof(app), "Requires an application builder to add the version tracking middleware");
+
+            var options = new VersionTrackingOptions();
+            configureOptions?.Invoke(options);
+
+            return app.UseMiddleware<VersionTrackingMiddleware>(options);
+        }
     }
 }

--- a/src/Arcus.WebApi.Logging/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Arcus.WebApi.Logging/Extensions/IApplicationBuilderExtensions.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Builder
         /// </param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="app"/> is <c>null</c>.</exception>
         /// <remarks>
-        ///     WARNING: only use in non-publicly endpoints so the application version is not leaked and can be used for malicious purposes.
+        ///     WARNING: Only use the version tracking for non-public endpoints otherwise the version information is leaked and it can be used for unintended malicious purposes.
         /// </remarks>
         public static IApplicationBuilder UseVersionTracking(this IApplicationBuilder app, Action<VersionTrackingOptions> configureOptions = null)
         {

--- a/src/Arcus.WebApi.Logging/VersionTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/VersionTrackingMiddleware.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Threading.Tasks;
+using Arcus.Observability.Telemetry.Serilog.Enrichers;
+using GuardNet;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Arcus.WebApi.Logging
+{
+    /// <summary>
+    /// Version tracking middleware component to automatically add the version of the application to the response.
+    /// </summary>
+    /// <remarks>
+    ///     WARNING: only use in non-publicly endpoints so the application version is not leaked and can be used for malicious purposes.
+    /// </remarks>
+    public class VersionTrackingMiddleware
+    {
+        private readonly IAppVersion _appVersion;
+        private readonly VersionTrackingOptions _options;
+        private readonly RequestDelegate _next;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VersionTrackingMiddleware"/> class.
+        /// </summary>
+        /// <param name="appVersion">The instance to retrieve the current application version.</param>
+        /// <param name="options">The configurable options to specify how the version should be tracked in the response.</param>
+        /// <param name="next">The next functionality in the request pipeline to be executed.</param>
+        /// <param name="logger">The logger to write diagnostic trace messages during the addition of the application version to the response.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="appVersion"/>, <paramref name="options"/>, or <paramref name="next"/> is <c>null</c>.</exception>
+        public VersionTrackingMiddleware(
+            IAppVersion appVersion,
+            VersionTrackingOptions options,
+            RequestDelegate next,
+            ILogger<VersionTrackingMiddleware> logger)
+        {
+            Guard.NotNull(appVersion, nameof(appVersion), "Requires an instance to retrieve the current application version to add the version to the response");
+            Guard.NotNull(next, nameof(next), "Requires a continuation delegate to move towards the next functionality in the request pipeline");
+            Guard.NotNull(options, nameof(options), "Requires version tracking options to specify how the application version should be tracked in the response");
+
+            _appVersion = appVersion;
+            _options = options;
+            _next = next;
+            _logger = logger ?? NullLogger<VersionTrackingMiddleware>.Instance;
+        }
+
+        /// <summary>
+        /// Invoke the middleware to include the version of the application.
+        /// </summary>
+        /// <param name="context">The context for the current HTTP request.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="context"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="context"/> doesn't contain a response.</exception>
+        public async Task Invoke(HttpContext context)
+        {
+            Guard.NotNull(context, nameof(context), "Requires a HTTP context to add the application version to the response");
+            Guard.For(() => context.Response is null, new ArgumentException("Requires a HTTP context with a response to add the application version", nameof(context)));
+            
+            _logger.LogTrace("Prepare for adding current application version to response");
+            context.Response.OnStarting(() =>
+            {
+                string version = _appVersion.GetVersion();
+                if (String.IsNullOrWhiteSpace(version))
+                {
+                    _logger.LogWarning("Setting current application version halted because the '{Type}' got a blank version", _appVersion.GetType().Name);
+                }
+                else
+                {
+                    _logger.LogTrace("Setting current application version response header '{HeaderName}' to '{Version}'", _options.HeaderName, version);
+                    context.Response.Headers[_options.HeaderName] = version;
+                }
+
+                return Task.CompletedTask;
+            });
+
+            await _next(context);
+        }
+    }
+}

--- a/src/Arcus.WebApi.Logging/VersionTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/VersionTrackingMiddleware.cs
@@ -12,7 +12,7 @@ namespace Arcus.WebApi.Logging
     /// Version tracking middleware component to automatically add the version of the application to the response.
     /// </summary>
     /// <remarks>
-    ///     WARNING: only use in non-publicly endpoints so the application version is not leaked and can be used for malicious purposes.
+    ///     WARNING: Only use the version tracking for non-public endpoints otherwise the version information is leaked and it can be used for unintended malicious purposes.
     /// </remarks>
     public class VersionTrackingMiddleware
     {
@@ -55,8 +55,7 @@ namespace Arcus.WebApi.Logging
         {
             Guard.NotNull(context, nameof(context), "Requires a HTTP context to add the application version to the response");
             Guard.For(() => context.Response is null, new ArgumentException("Requires a HTTP context with a response to add the application version", nameof(context)));
-            
-            _logger.LogTrace("Prepare for adding current application version to response");
+
             context.Response.OnStarting(() =>
             {
                 string version = _appVersion.GetVersion();

--- a/src/Arcus.WebApi.Logging/VersionTrackingOptions.cs
+++ b/src/Arcus.WebApi.Logging/VersionTrackingOptions.cs
@@ -1,0 +1,25 @@
+﻿using GuardNet;
+
+namespace Arcus.WebApi.Logging
+{
+    /// <summary>
+    /// Represents the user-configurable options to control how the <see cref="VersionTrackingMiddleware"/> should track the current application version in the response.
+    /// </summary>
+    public class VersionTrackingOptions
+    {
+        private string _headerName = "X-Version";
+
+        /// <summary>
+        /// Gets or sets the header name on which the current application version should be added.
+        /// </summary>
+        public string HeaderName
+        {
+            get => _headerName;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank header name to add the current application version to the response");
+                _headerName = value;
+            }
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/StubAppVersion.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/StubAppVersion.cs
@@ -1,0 +1,30 @@
+﻿using Arcus.Observability.Telemetry.Serilog.Enrichers;
+
+namespace Arcus.WebApi.Tests.Unit.Logging
+{
+    /// <summary>
+    /// Stub representation of the <see cref="IAppVersion"/>.
+    /// </summary>
+    /// <seealso cref="IAppVersion"/>
+    public class StubAppVersion : IAppVersion
+    {
+        private readonly string _version;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StubAppVersion"/> class.
+        /// </summary>
+        /// <param name="version">The current version of the application.</param>
+        public StubAppVersion(string version)
+        {
+            _version = version;
+        }
+
+        /// <summary>
+        /// Gets the current version of the application.
+        /// </summary>
+        public string GetVersion()
+        {
+            return _version;
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/VersionTrackingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/VersionTrackingMiddlewareTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Arcus.Observability.Telemetry.Serilog.Enrichers;
+using Arcus.WebApi.Tests.Unit.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Logging
+{
+    public class VersionTrackingMiddlewareTests : IDisposable
+    {
+        private const string DefaultHeaderName = "X-Version";
+
+        private readonly TestApiServer _testServer = new TestApiServer();
+
+        [Fact]
+        public async Task SendRequest_WithVersionTracking_AddsApplicationVersionToResponse()
+        {
+            // Arrange
+            string expected = $"version-{Guid.NewGuid()}";
+            _testServer.AddServicesConfig(services => services.AddSingleton<IAppVersion>(provider => new StubAppVersion(expected)));
+            _testServer.AddConfigure(app => app.UseVersionTracking());
+
+            using (HttpClient client = _testServer.CreateClient())
+            // Act
+            using (HttpResponseMessage response = await client.GetAsync(EchoController.Route))
+            {
+                // Assert
+                Assert.True(response.Headers.TryGetValues(DefaultHeaderName, out IEnumerable<string> values));
+                Assert.Equal(expected, Assert.Single(values));
+            }
+        }
+
+        [Fact]
+        public async Task SendRequest_WithVersionTrackingOnCustomHeaderName_AddsApplicationVersionToResponse()
+        {
+            // Arrange
+            string headerName = $"header-name-{Guid.NewGuid()}";
+            string expected = $"version-{Guid.NewGuid()}";
+            _testServer.AddServicesConfig(services => services.AddSingleton<IAppVersion>(provider => new StubAppVersion(expected)));
+            _testServer.AddConfigure(app => app.UseVersionTracking(options => options.HeaderName = headerName));
+
+            using (HttpClient client = _testServer.CreateClient())
+            // Act
+            using (HttpResponseMessage response = await client.GetAsync(EchoController.Route))
+            {
+                // Assert
+                Assert.False(response.Headers.Contains(DefaultHeaderName));
+                Assert.True(response.Headers.TryGetValues(headerName, out IEnumerable<string> values));
+                Assert.Equal(expected, Assert.Single(values));
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        public async Task SendRequest_WithVersionTrackingForBlankVersion_DoesntAddApplicationVersionToResponse(string version)
+        {
+            // Arrange
+            _testServer.AddServicesConfig(services => services.AddSingleton<IAppVersion>(provider => new StubAppVersion(version)));
+            _testServer.AddConfigure(app => app.UseVersionTracking());
+
+            using (HttpClient client = _testServer.CreateClient())
+            // Act
+            using (HttpResponseMessage response = await client.GetAsync(EchoController.Route))
+            {
+                // Assert
+                Assert.False(response.Headers.Contains(DefaultHeaderName));
+            }
+        }
+
+        [Fact]
+        public void SetupApi_WithoutApplicationVersion_Throws()
+        {
+            // Arrange
+            _testServer.AddConfigure(app => app.UseVersionTracking());
+
+            // Act / Assert
+            Assert.Throws<InvalidOperationException>(() => _testServer.CreateClient());
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            _testServer.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Adds version tracking middleware with the necessary extension and options to influence its behavior.
Plus, the required tests to check if we can indeed customize the header name and application version.

Also tried to made it '_in-your-face_'-clear that it's a feature that should be handled with care.

Closes #180 