### PR TITLE
Feature - bypass API security filters with attributes

### DIFF
--- a/docs/preview/features/security/auth/certificate.md
+++ b/docs/preview/features/security/auth/certificate.md
@@ -130,7 +130,7 @@ public class SystemController : ControllerBase
 {
     [HttpGet]
     [BypassCertificateAuthentication]
-    public IActionResult Get()
+    public IActionResult GetHealth()
     {
         return Ok();
     }

--- a/docs/preview/features/security/auth/certificate.md
+++ b/docs/preview/features/security/auth/certificate.md
@@ -126,7 +126,7 @@ This works with adding one of these attributes to the respectively endpoint:
 ```csharp
 [ApiController]
 [CertificateAuthentication]
-public class MyController : ControllerBase
+public class SystemController : ControllerBase
 {
     [HttpGet]
     [BypassCertificateAuthentication]

--- a/docs/preview/features/security/auth/certificate.md
+++ b/docs/preview/features/security/auth/certificate.md
@@ -128,7 +128,7 @@ This works with adding one of these attributes to the respectively endpoint:
 [CertificateAuthentication]
 public class SystemController : ControllerBase
 {
-    [HttpGet]
+    [HttpGet('api/v1/health')]
     [BypassCertificateAuthentication]
     public IActionResult GetHealth()
     {

--- a/docs/preview/features/security/auth/certificate.md
+++ b/docs/preview/features/security/auth/certificate.md
@@ -16,6 +16,7 @@ This authentication process consists of following parts:
 The package allows two ways to configure this type of authentication mechanism in an <span>ASP.NET</span> application:
 - [Globally enforce certificate authentication](#Globally-enforce-certificate-authentication)
 - [Enforce certificate authentication per controller or operation](#Enforce-certificate-authentication-per-controller-or-operation)
+- [Bypassing authentication](#bypassing-authentication)
 
 ## Installation
 
@@ -112,5 +113,29 @@ public class MyApiController : ControllerBase
     }
 }
 ```
+
+## Bypassing authentication
+
+The package supports a way to bypass the certificate authentication for certain endponts.
+This works with adding one of these attributes to the respectively endpoint:
+- `BypassCertificateAuthentication`
+- `AllowAnonymous`
+
+> Works on both method and controller level, using either the certificate filter or attribute.
+
+```csharp
+[ApiController]
+[CertificateAuthentication]
+public class MyController : ControllerBase
+{
+    [HttpGet]
+    [BypassCertificateAuthentication]
+    public IActionResult Get()
+    {
+        return Ok();
+    }
+}
+```
+
 
 [&larr; back](/)

--- a/docs/preview/features/security/auth/jwt.md
+++ b/docs/preview/features/security/auth/jwt.md
@@ -11,7 +11,12 @@ This authorization process consists of the following parts:
 1. Find the OpenID server endpoint to request the correct access token
 2. Determine the request header name you want to use where the access token should be available
 
-## Installation
+- [Globally enforce JWT authorization](#globally-enforce-jwt-authorization)
+- [Bypassing authorization](#bypassing-authorization)
+
+## Globally enforce JWT authorization
+
+### Installation
 
 This feature requires to install our NuGet package:
 
@@ -19,7 +24,7 @@ This feature requires to install our NuGet package:
 PM > Install-Package Arcus.WebApi.Security
 ```
 
-## Usage
+### Usage
 
 The `JwtTokenAuthorizationFilter` can be added to the request filters in an <span>ASP.NET</span> Core application.
 This filter will then add authorization to all endpoints via the configured properties on the filter itself.
@@ -60,6 +65,28 @@ public class Startup
             string endpoint = "https://localhost:5000/.well-known/openid-configuration";
             mvcOptions.Filters.AddJwtTokenAuthorization(options => options.JwtTokenReader = new JwtTokenReader(parameters, endpoint));
         });
+    }
+}
+```
+
+## Bypassing authentication
+
+The package supports a way to bypass the JWT authorization for certain endponts.
+This works with adding one of these attributes to the respectively endpoint:
+- `BypassJwtAuthorization`
+- `AllowAnonymous`
+
+> Works on both method and controller level.
+
+```csharp
+[ApiController]
+public class MyController : ControllerBase
+{
+    [HttpGet]
+    [BypassJwtAuthorization]
+    public IActionResult Get()
+    {
+        return Ok();
     }
 }
 ```

--- a/docs/preview/features/security/auth/jwt.md
+++ b/docs/preview/features/security/auth/jwt.md
@@ -80,11 +80,11 @@ This works with adding one of these attributes to the respectively endpoint:
 
 ```csharp
 [ApiController]
-public class MyController : ControllerBase
+public class SystemController : ControllerBase
 {
-    [HttpGet]
+    [HttpGet('api/v1/health')]
     [BypassJwtAuthorization]
-    public IActionResult Get()
+    public IActionResult GetHealth()
     {
         return Ok();
     }

--- a/docs/preview/features/security/auth/shared-access-key.md
+++ b/docs/preview/features/security/auth/shared-access-key.md
@@ -125,11 +125,11 @@ This works with adding one of these attributes to the respectively endpoint:
 ```csharp
 [ApiController]
 [SharedAccessKeyAuthentication("MySecret", "MyHeader")]
-public class MyController : ControllerBase
+public class SystemController : ControllerBase
 {
-    [HttpGet]
+    [HttpGet('api/v1/health')]
     [BypassSharedAccessKeyAuthentication]
-    public IActionResult Get()
+    public IActionResult GetHealth()
     {
         return Ok();
     }

--- a/docs/preview/features/security/auth/shared-access-key.md
+++ b/docs/preview/features/security/auth/shared-access-key.md
@@ -14,6 +14,8 @@ This authentication process consists of two parts:
 The package allows two ways to configure this type of authentication mechanmism in an <span>ASP.NET</span> application:
 - [Global Shared access key authentication](#globally-enforce-shared-access-key-authentication)
 - [Shared access key authentication per controller or operation](#enforce-shared-access-key-authentication-per-controller-or-operation)
+- [Behavior in validating shared access key parameter](#behavior-in-validating-shared-access-key-parameter)
+- [Bypassing authentication](#bypassing-authentication)
 
 ## Installation
 
@@ -111,5 +113,27 @@ public void ConfigureServices(IServiceCollections services)
 ```
 If both header and query parameter are specified, they must both be valid or an `Unauthorized` will be returned.
 <br/>
+
+## Bypassing authentication
+The package supports a way to bypass the shared access key authentication for certain endponts.
+This works with adding one of these attributes to the respectively endpoint:
+- `BypassSharedAccessKeyAuthentication`
+- `AllowAnonymous`
+
+> Works on both method and controller level, using either the shared access key filter or attribute.
+
+```csharp
+[ApiController]
+[SharedAccessKeyAuthentication("MySecret", "MyHeader")]
+public class MyController : ControllerBase
+{
+    [HttpGet]
+    [BypassSharedAccessKeyAuthentication]
+    public IActionResult Get()
+    {
+        return Ok();
+    }
+}
+```
 
 [&larr; back](/)

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/BypassCertificateAuthenticationAttribute.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/BypassCertificateAuthenticationAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Arcus.WebApi.Security.Authentication.Certificates
+{
+    /// <summary>
+    /// Attribute to circumvent the certificate authentication.
+    /// </summary>
+    public class BypassCertificateAuthenticationAttribute : Attribute 
+    {
+    }
+}

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using GuardNet;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -34,6 +36,12 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
 
             IServiceProvider services = context.HttpContext.RequestServices;
             ILogger logger = GetLoggerOrDefault(services);
+
+            if (context.ActionDescriptor?.EndpointMetadata?.Any(m => m is BypassCertificateAuthenticationAttribute || m is AllowAnonymousAttribute) == true)
+            {
+                logger.LogTrace("Bypass certificate authentication because '{SpecificAttribute}' or '{GeneralAttribute}' was found", nameof(BypassCertificateAuthenticationAttribute), nameof(AllowAnonymousAttribute));
+                return;
+            }
 
             X509Certificate2 clientCertificate = GetOrLoadClientCertificateFromRequest(context.HttpContext, logger);
             if (clientCertificate == null)

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/BypassSharedAccessKeyAuthenticationAttribute.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/BypassSharedAccessKeyAuthenticationAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Arcus.WebApi.Security.Authentication.SharedAccessKey
+{
+    /// <summary>
+    /// Attribute to circumvent the shared access key authentication.
+    /// </summary>
+    public class BypassSharedAccessKeyAuthenticationAttribute : Attribute
+    {
+    }
+}

--- a/src/Arcus.WebApi.Security/Authorization/BypassJwtTokenAuthorizationAttribute.cs
+++ b/src/Arcus.WebApi.Security/Authorization/BypassJwtTokenAuthorizationAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Arcus.WebApi.Security.Authorization
+{
+    /// <summary>
+    /// Attribute to circumvent the JWT token authorization.
+    /// </summary>
+    public class BypassJwtTokenAuthorizationAttribute : Attribute
+    {
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authentication/AllowAnonymousCertificateController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authentication/AllowAnonymousCertificateController.cs
@@ -1,0 +1,21 @@
+﻿using Arcus.WebApi.Security.Authentication.Certificates;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Unit.Security.Authentication
+{
+    [ApiController]
+    [AllowAnonymous]
+    public class AllowAnonymousCertificateController : ControllerBase
+    {
+        public const string Route = "authz/certificate/anonymous/controller";
+
+        [HttpGet]
+        [Route(Route)]
+        [CertificateAuthentication]
+        public IActionResult Anonymous()
+        {
+            return Ok();
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authentication/AllowAnonymousSharedAccessKeyController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authentication/AllowAnonymousSharedAccessKeyController.cs
@@ -1,0 +1,21 @@
+﻿using Arcus.WebApi.Security.Authentication.SharedAccessKey;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Unit.Security.Authentication
+{
+    [ApiController]
+    [AllowAnonymous]
+    public class AllowAnonymousSharedAccessKeyController : ControllerBase
+    {
+        public const string Route = "authz/sharedaccesskey/anonymous/controller";
+
+        [HttpGet]
+        [Route(Route)]
+        [SharedAccessKeyAuthentication("MySecret", "MyHeader")]
+        public IActionResult AllowAnymous()
+        {
+            return Ok();
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authentication/BypassCertificateController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authentication/BypassCertificateController.cs
@@ -1,0 +1,20 @@
+﻿using Arcus.WebApi.Security.Authentication.Certificates;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Unit.Security.Authentication
+{
+    [ApiController]
+    [BypassCertificateAuthentication]
+    public class BypassCertificateController : ControllerBase
+    {
+        public const string BypassOverAuthenticationRoute = "authz/bypass/over/certificate";
+
+        [HttpGet]
+        [Route(BypassOverAuthenticationRoute)]
+        [CertificateAuthentication]
+        public IActionResult BypassOverAuthentiation()
+        {
+            return Ok();
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authentication/BypassSharedAccessKeyController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authentication/BypassSharedAccessKeyController.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Arcus.WebApi.Security.Authentication.SharedAccessKey;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Unit.Security.Authentication
+{
+    [ApiController]
+    [BypassSharedAccessKeyAuthentication]
+    public class BypassSharedAccessKeyController : ControllerBase
+    {
+        public const string BypassOverAuthenticationRoute = "authz/bypass/over/sharedaccesskey",
+                            SecretName = "MySecret",
+                            HeaderName = "x-shared-access-key";
+
+        [HttpGet]
+        [Route(BypassOverAuthenticationRoute)]
+        [SharedAccessKeyAuthentication(SecretName, HeaderName)]
+        public IActionResult BypassOverAuthentication()
+        {
+            return Ok();
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authentication/SharedAccessKeyAuthenticationAttributeTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authentication/SharedAccessKeyAuthenticationAttributeTests.cs
@@ -340,6 +340,23 @@ namespace Arcus.WebApi.Tests.Unit.Security.Authentication
             }
         }
 
+        [Theory]
+        [InlineData(BypassOnMethodController.SharedAccessKeyRoute)]
+        [InlineData(BypassSharedAccessKeyController.BypassOverAuthenticationRoute)]
+        [InlineData(AllowAnonymousSharedAccessKeyController.Route)]
+        public async Task SharedAccessKeyAuthorizedRoute_WithBypassAttributeOnMethod_SkipsAuthentication(string route)
+        {
+            // Arrange
+            _testServer.AddFilter(new SharedAccessKeyAuthenticationFilter(HeaderName, queryParameterName: null, SecretName));
+            
+            // Act
+            using (HttpResponseMessage response = await SendAuthorizedHttpRequest(route, headerValue: null))
+            {
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+
         private async Task<HttpResponseMessage> SendAuthorizedHttpRequest(string route, string headerName = null, string headerValue = null, string parameterName = null, string parameterValue = null)
         {
             return await SendAuthorizedHttpRequest(route, headerName, new[] { headerValue }, parameterName, parameterValue);

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authorization/BypassJwtTokenAuthorizationController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authorization/BypassJwtTokenAuthorizationController.cs
@@ -1,0 +1,19 @@
+﻿using Arcus.WebApi.Security.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Unit.Security.Authorization
+{
+    [ApiController]
+    [BypassJwtTokenAuthorization]
+    public class BypassJwtTokenAuthorizationController : ControllerBase
+    {
+        public const string BypassOverAuthorizationRoute = "authz/bypass/over/jwt";
+
+        [HttpGet]
+        [Route(BypassOverAuthorizationRoute)]
+        public IActionResult BypassOverAuthorization()
+        {
+            return Ok();
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Security/BypassOnMethodController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/BypassOnMethodController.cs
@@ -1,0 +1,49 @@
+﻿using Arcus.WebApi.Security.Authentication.Certificates;
+using Arcus.WebApi.Security.Authentication.SharedAccessKey;
+using Arcus.WebApi.Security.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Unit.Security
+{
+    [ApiController]
+    public class BypassOnMethodController : ControllerBase
+    {
+        public const string SharedAccessKeyRoute = "authz/bypass/sharedaccesskey",
+                            CertificateRoute = "authz/bypass/certificate",
+                            JwtRoute = "authz/bypass/jwt",
+                            AllowAnonymousRoute = "authz/bypass/anonymous";
+
+        [HttpGet]
+        [Route(SharedAccessKeyRoute)]
+        [BypassSharedAccessKeyAuthentication]
+        public IActionResult SharedAccessKey()
+        {
+            return Ok();
+        }
+
+        [HttpGet]
+        [Route(CertificateRoute)]
+        [BypassCertificateAuthentication]
+        public IActionResult Certifcate()
+        {
+            return Ok();
+        }
+
+        [HttpGet]
+        [Route(JwtRoute)]
+        [BypassJwtTokenAuthorization]
+        public IActionResult Jwt()
+        {
+            return Ok();
+        }
+
+        [HttpGet]
+        [Route(AllowAnonymousRoute)]
+        [AllowAnonymous]
+        public IActionResult Anonymous()
+        {
+            return Ok();
+        }
+    }
+}


### PR DESCRIPTION
Provide the capability to bypass authentication and authorization with specific attributes and with the default `AllowAnonymous` attribute.

> Maybe it's good to merge later with #176 because it also adds logging to the API filters + provides an extension to safely retrieve a logger.

Closes #184 