### PR TITLE
Feature - use `.LogSecurityEvent` for security types

### DIFF
--- a/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
+++ b/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.3.0" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.4.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="IdentityModel" Version="4.4.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.8.0" />

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
@@ -61,17 +61,17 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
                 bool isCertificateAllowed = await validator.IsCertificateAllowedAsync(clientCertificate, services);
                 if (isCertificateAllowed)
                 {
-                    LogSecurityEvent(logger, LogLevel.Trace, "Client certificate in request is considered allowed according to configured validation requirements");
+                    LogSecurityEvent(logger, "Client certificate in request is considered allowed according to configured validation requirements");
                 }
                 else
                 {
-                    LogSecurityEvent(logger, LogLevel.Trace, "Client certificate in request is not considered allowed according to the configured validation requirements", HttpStatusCode.Unauthorized);
+                    LogSecurityEvent(logger, "Client certificate in request is not considered allowed according to the configured validation requirements", HttpStatusCode.Unauthorized);
                     context.Result = new UnauthorizedObjectResult("Client certificate in request is not allowed");
                 }
             }
             else
             {
-                LogSecurityEvent(logger, LogLevel.Trace, "No client certificate is specified in the request while this authentication filter requires a certificate to validate on the configured validation requirements", HttpStatusCode.Unauthorized);
+                LogSecurityEvent(logger, "No client certificate is specified in the request while this authentication filter requires a certificate to validate on the configured validation requirements", HttpStatusCode.Unauthorized);
                 context.Result = new UnauthorizedObjectResult("No client certificate found in request");
             }
         }
@@ -117,11 +117,8 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
             return false;
         }
 
-        private static void LogSecurityEvent(ILogger logger, LogLevel level, string description, HttpStatusCode? responseStatusCode = null)
+        private static void LogSecurityEvent(ILogger logger, string description, HttpStatusCode? responseStatusCode = null)
         {
-            /* TODO: use 'Arcus.Observability.Telemetry.Core' 'LogSecurityEvent' instead once the SQL dependency is moved
-                       -> https://github.com/arcus-azure/arcus.observability/issues/131 */
-            
             var telemetryContext = new Dictionary<string, object>
             {
                 ["EventType"] = "Security",
@@ -134,7 +131,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
                 telemetryContext["StatusCode"] = responseStatusCode.ToString(); 
             }
 
-            logger.Log(level, "Events {EventName} (Context: {@EventContext})", "Authentication", telemetryContext);
+            logger.LogSecurityEvent("Authentication", telemetryContext);
         }
     }
 }

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationFilter.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationFilter.cs
@@ -5,15 +5,12 @@ using System.Net;
 using System.Threading.Tasks;
 using Arcus.Security.Core;
 using Arcus.Security.Core.Caching;
-using Arcus.WebApi.Security.Authentication.Certificates;
-using Arcus.WebApi.Security.Authorization;
 using GuardNet;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 
 namespace Arcus.WebApi.Security.Authentication.SharedAccessKey

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationFilter.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationFilter.cs
@@ -77,7 +77,7 @@ namespace Arcus.WebApi.Security.Authentication.SharedAccessKey
             if (!context.HttpContext.Request.Headers.ContainsKey(_headerName) 
                 && !context.HttpContext.Request.Query.ContainsKey(_queryParameterName))
             {
-                LogSecurityEvent(logger, LogLevel.Trace, $"Cannot verify shared access key because neither a request header '{_headerName}' or query parameter '{_queryParameterName}' was found in the incoming request that was configured for shared access authentication", HttpStatusCode.Unauthorized);
+                LogSecurityEvent(logger, $"Cannot verify shared access key because neither a request header '{_headerName}' or query parameter '{_queryParameterName}' was found in the incoming request that was configured for shared access authentication", HttpStatusCode.Unauthorized);
                 context.Result = new UnauthorizedResult();
             }
             else
@@ -127,17 +127,17 @@ namespace Arcus.WebApi.Security.Authentication.SharedAccessKey
             {
                 if (requestSecretHeaders.Any(headerValue => headerValue != foundSecret))
                 {
-                    LogSecurityEvent(logger, LogLevel.Trace, $"Shared access key in request header '{_headerName}' doesn't match expected access key", HttpStatusCode.Unauthorized);
+                    LogSecurityEvent(logger, $"Shared access key in request header '{_headerName}' doesn't match expected access key", HttpStatusCode.Unauthorized);
                     context.Result = new UnauthorizedObjectResult("Shared access key in request doesn't match expected access key");
                 }
                 else
                 {
-                    LogSecurityEvent(logger, LogLevel.Trace, $"Shared access key in request header '{_headerName}' matches expected access key");
+                    LogSecurityEvent(logger, $"Shared access key in request header '{_headerName}' matches expected access key");
                 }
             }
             else
             {
-                LogSecurityEvent(logger, LogLevel.Trace, $"No shared access key found in request header '{_headerName}'", HttpStatusCode.Unauthorized);
+                LogSecurityEvent(logger, $"No shared access key found in request header '{_headerName}'", HttpStatusCode.Unauthorized);
                 context.Result = new UnauthorizedObjectResult("No shared access key found in request");
             }
         }
@@ -153,25 +153,23 @@ namespace Arcus.WebApi.Security.Authentication.SharedAccessKey
             {
                 if (context.HttpContext.Request.Query[_queryParameterName] != foundSecret)
                 {
-                    LogSecurityEvent(logger, LogLevel.Trace, $"Shared access key in query parameter '{_queryParameterName}' doesn't match expected access key", HttpStatusCode.Unauthorized);
+                    LogSecurityEvent(logger, $"Shared access key in query parameter '{_queryParameterName}' doesn't match expected access key", HttpStatusCode.Unauthorized);
                     context.Result = new UnauthorizedObjectResult("Shared access key in request doesn't match expected access key");
                 }
                 else
                 {
-                    LogSecurityEvent(logger, LogLevel.Information, $"Shared access key in query parameter '{_queryParameterName}' matches expected access key");
+                    LogSecurityEvent(logger, $"Shared access key in query parameter '{_queryParameterName}' matches expected access key");
                 }
             }
             else
             {
-                LogSecurityEvent(logger, LogLevel.Trace, $"No shared access key found in query parameter '{_queryParameterName}'", HttpStatusCode.Unauthorized);
+                LogSecurityEvent(logger, $"No shared access key found in query parameter '{_queryParameterName}'", HttpStatusCode.Unauthorized);
                 context.Result = new UnauthorizedObjectResult("No shared access key found in request");
             }
         }
 
-        private static void LogSecurityEvent(ILogger logger, LogLevel level, string description, HttpStatusCode? responseStatusCode = null)
+        private static void LogSecurityEvent(ILogger logger, string description, HttpStatusCode? responseStatusCode = null)
         {
-            /* TODO: use 'Arcus.Observability.Telemetry.Core' 'LogSecurityEvent' instead once the SQL dependency is moved
-                       -> https://github.com/arcus-azure/arcus.observability/issues/131 */
             var telemetryContext = new Dictionary<string, object>
             {
                 ["EventType"] = "Security",
@@ -184,7 +182,7 @@ namespace Arcus.WebApi.Security.Authentication.SharedAccessKey
                 telemetryContext["StatusCode"] = responseStatusCode.ToString();
             }
 
-            logger.Log(level, "Events {EventName} (Context: {@EventContext})", "Authentication", telemetryContext);
+            logger.LogSecurityEvent("Authentication", telemetryContext);
         }
     }
 }

--- a/src/Arcus.WebApi.Security/Authorization/JwtTokenAuthorizationFilter .cs
+++ b/src/Arcus.WebApi.Security/Authorization/JwtTokenAuthorizationFilter .cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Linq;
-using System.Net.Mime;
 using System.Threading.Tasks;
 using Arcus.WebApi.Security.Authorization.Jwt;
 using GuardNet;
@@ -12,8 +11,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 
 namespace Arcus.WebApi.Security.Authorization

--- a/src/Arcus.WebApi.Security/Authorization/JwtTokenAuthorizationFilter .cs
+++ b/src/Arcus.WebApi.Security/Authorization/JwtTokenAuthorizationFilter .cs
@@ -77,7 +77,7 @@ namespace Arcus.WebApi.Security.Authorization
             }
             else
             {
-                LogSecurityEvent(logger, LogLevel.Trace, "No JWT MSI token was specified in the request", HttpStatusCode.Unauthorized);
+                LogSecurityEvent(logger, "No JWT MSI token was specified in the request", HttpStatusCode.Unauthorized);
                 context.Result = new UnauthorizedObjectResult("No JWT MSI token header found in request");
             }
         }
@@ -86,7 +86,7 @@ namespace Arcus.WebApi.Security.Authorization
         {
             if (String.IsNullOrWhiteSpace(jwtString))
             {
-                LogSecurityEvent(logger, LogLevel.Trace, "Cannot validate JWT MSI token because the token is blank", HttpStatusCode.Unauthorized);
+                LogSecurityEvent(logger, "Cannot validate JWT MSI token because the token is blank", HttpStatusCode.Unauthorized);
                 context.Result = new UnauthorizedObjectResult("Blank JWT MSI token");
                 
                 return;
@@ -94,7 +94,7 @@ namespace Arcus.WebApi.Security.Authorization
 
             if (!JwtRegex.IsMatch(jwtString))
             {
-                LogSecurityEvent(logger, LogLevel.Trace, "Cannot validate JWT MSI token because the token is in an invalid format", HttpStatusCode.Unauthorized);
+                LogSecurityEvent(logger, "Cannot validate JWT MSI token because the token is in an invalid format", HttpStatusCode.Unauthorized);
                 context.Result = new UnauthorizedObjectResult("Invalid JWT MSI token format");
                 
                 return;
@@ -103,20 +103,17 @@ namespace Arcus.WebApi.Security.Authorization
             bool isValidToken = await reader.IsValidTokenAsync(jwtString);
             if (isValidToken)
             {
-                LogSecurityEvent(logger, LogLevel.Trace, "JWT MSI token is valid");
+                LogSecurityEvent(logger, "JWT MSI token is valid");
             }
             else
             {
-                LogSecurityEvent(logger, LogLevel.Trace, "JWT MSI token is invalid", HttpStatusCode.Unauthorized);
+                LogSecurityEvent(logger, "JWT MSI token is invalid", HttpStatusCode.Unauthorized);
                 context.Result = new UnauthorizedObjectResult("Wrong JWT MSI token");
             }
         }
 
-        private static void LogSecurityEvent(ILogger logger, LogLevel level, string description, HttpStatusCode? responseStatusCode = null)
+        private static void LogSecurityEvent(ILogger logger, string description, HttpStatusCode? responseStatusCode = null)
         {
-            /* TODO: use 'Arcus.Observability.Telemetry.Core' 'LogSecurityEvent' instead once the SQL dependency is moved
-                       -> https://github.com/arcus-azure/arcus.observability/issues/131 */
-            
             var telemetryContext = new Dictionary<string, object>
             {
                 ["EventType"] = "Security",
@@ -129,7 +126,7 @@ namespace Arcus.WebApi.Security.Authorization
                 telemetryContext["StatusCode"] = responseStatusCode.ToString();
             }
 
-            logger.Log(level, "Events {EventName} (Context: {@EventContext})", "Authorization", telemetryContext);
+            logger.LogSecurityEvent("Authorization", telemetryContext);
         }
     }
 }


### PR DESCRIPTION
Now that we have extracted the SQL package in the Observability repo (https://github.com/arcus-azure/arcus.observability/issues/131), we can use the `.LogSecurityEvent` instead.