### PR TITLE
Feature - skip request tracking attribute

### DIFF
--- a/docs/preview/features/logging.md
+++ b/docs/preview/features/logging.md
@@ -78,6 +78,14 @@ public class Startup
 {
     public void Configure(IApplicationBuilder app, IWebHostEvironment env)
     {
+         // In versions less than .NET Core 3.0:
+        // make sure that the endpoint routing is specified before the `UseRequestRouting` if you want to make use of the `SkipRequestTrackingAttribute`.
+        app.UseEndpointRouting();
+
+        // In versions starting from .NET Core 3.0:
+        // make sure that the endpoint routing is specified before the `UseRequestRouting` if you want to make use of the `SkipRequestTrackingAttribute`.
+        app.UseRouting();
+
         app.UseRequestTracking();
 
         ...
@@ -98,6 +106,14 @@ public class Startup
 {
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
+        // In versions less than .NET Core 3.0:
+        // make sure that the endpoint routing is specified before the `UseRequestRouting` if you want to make use of the `SkipRequestTrackingAttribute`.
+        app.UseEndpointRouting();
+
+        // In versions starting from .NET Core 3.0:
+        // make sure that the endpoint routing is specified before the `UseRequestRouting` if you want to make use of the `SkipRequestTrackingAttribute`.
+        app.UseRouting();
+
         app.UseRequestTracking(options =>
         {
             // Whether or not the HTTP request body should be included in the request tracking logging emits.
@@ -114,10 +130,32 @@ public class Startup
         });
 
         ...
+
         app.UseMvc();
     }
 }
 ```
+
+**Skipping certain routes**
+
+The request tracking middleware can be disabled for certain endpoints (operation and/or controller level). This can come in handy if you have certain endpoints with rather large request bodies or want to boost performace.
+This can be achieved by placing the `SkipRequestTrackingAttribute` on the endpoint of your choosing.
+
+```csharp
+[ApiController]
+public class OrderController : ControllerBase
+{
+    [HttpPost]
+    [SkipRequestTracking]
+    public IActionResult BigPost()
+    {
+        Stream bigRequestBody = Request.Body;
+        return Ok();
+    }
+}
+```
+
+**Customization**
 
 Optionally, one can inherit from this middleware component and override the default request header sanitization to run some custom functionality during the filtering.
 
@@ -153,6 +191,14 @@ public class Startup
 {
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
+         // In versions less than .NET Core 3.0:
+        // make sure that the endpoint routing is specified before the `UseRequestRouting` if you want to make use of the `SkipRequestTrackingAttribute`.
+        app.UseEndpointRouting();
+
+        // In versions starting from .NET Core 3.0:
+        // make sure that the endpoint routing is specified before the `UseRequestRouting` if you want to make use of the `SkipRequestTrackingAttribute`.
+        app.UseRouting();
+
         app.UseRequestTracking<EmptyButNotOmitRequestTrackingMiddleware>(options => options.OmittedHeaderNames.Clear());
 
         ...

--- a/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
@@ -55,6 +55,13 @@ namespace Arcus.WebApi.Logging
 
             
             var endpoint = httpContext.Features.Get<IEndpointFeature>();
+            if (endpoint is null)
+            {
+                _logger.LogWarning(
+                    "Cannot determine whether or not the endpoint contains the '{Attribute}' because the endpoint tracking (`IApplicationBuilder.UseRouting()` or `.UseEndpointRouting()`) was not activated before the request tracking middleware",
+                    nameof(SkipRequestTrackingAttribute));
+            }
+            
             var skipRequestTrackingAttribute = endpoint?.Endpoint.Metadata.GetMetadata<SkipRequestTrackingAttribute>();
             if (skipRequestTrackingAttribute != null)
             {

--- a/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
@@ -52,8 +52,6 @@ namespace Arcus.WebApi.Logging
             Guard.NotNull(httpContext.Request, nameof(httpContext), "Requires a HTTP request in the context to track the request");
             Guard.NotNull(httpContext.Response, nameof(httpContext), "Requires a HTTP response in the context to track the request");
 
-
-            
             var endpoint = httpContext.Features.Get<IEndpointFeature>();
             if (endpoint is null)
             {
@@ -67,7 +65,6 @@ namespace Arcus.WebApi.Logging
             {
                 _logger.LogTrace("Skip request tracking for endpoint '{Endpoint}' due to the '{Attribute}' attribute on the endpoint", endpoint.Endpoint.DisplayName, nameof(SkipRequestTrackingAttribute));
                 await _next(httpContext);
-                
             }
             else
             {

--- a/src/Arcus.WebApi.Logging/SkipRequestTrackingAttribute.cs
+++ b/src/Arcus.WebApi.Logging/SkipRequestTrackingAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Arcus.WebApi.Logging
+{
+    /// <summary>
+    /// Represents an endpoint attribute that indicates which endpoints should be withhold from request tracking.
+    /// </summary>
+    public class SkipRequestTrackingAttribute : Attribute
+    {
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Hosting/EchoController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Hosting/EchoController.cs
@@ -13,7 +13,14 @@ namespace Arcus.WebApi.Tests.Unit.Hosting
 
         [HttpGet]
         [Route(Route)]
-        public IActionResult Get([FromBody] string body)
+        public IActionResult Get()
+        {
+            return Ok();
+        }
+        
+        [HttpPost]
+        [Route(Route)]
+        public IActionResult Post([FromBody] string body)
         {
             return Ok(body);
         }

--- a/src/Arcus.WebApi.Tests.Unit/Hosting/TestApiServer.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Hosting/TestApiServer.cs
@@ -12,6 +12,7 @@ using Arcus.WebApi.Tests.Unit.Logging;
 using GuardNet;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
@@ -157,16 +158,29 @@ namespace Arcus.WebApi.Tests.Unit.Hosting
 
             builder.Configure(app =>
             {
+                app.UseExceptionHandling();
+                app.UseMiddleware<TraceIdentifierMiddleware>();
+                app.UseHttpCorrelation();
+                
+#if NETCOREAPP3_1
+                app.UseRouting();
+                
+#else
+                app.UseEndpointRouting();
+#endif
+
                 foreach (Action<IApplicationBuilder> configure in _configures)
                 {
                     configure(app);
                 }
 
-                app.UseExceptionHandling();
-                app.UseMiddleware<TraceIdentifierMiddleware>();
+#if NETCOREAPP3_1
+                app.UseEndpoints(endpoints => endpoints.MapControllers());
+#endif
 
-                app.UseHttpCorrelation();
+#if !NETCOREAPP3_1
                 app.UseMvc();
+#endif
 
                 app.UseSwagger();
                 app.UseSwaggerUI(swaggerUiOptions =>
@@ -182,8 +196,10 @@ namespace Arcus.WebApi.Tests.Unit.Hosting
             {
 #if NETCOREAPP2_2
                 collection.AddMvc();
-#else
-                collection.AddMvc(options => options.EnableEndpointRouting = false);
+#endif
+#if NETCOREAPP3_1
+                collection.AddRouting();
+                collection.AddControllers(); 
 #endif
                 collection.AddHttpCorrelation();
 

--- a/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
@@ -200,15 +200,17 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             }
         }
 
-        [Fact]
-        public async Task GetRequestWithSkippedAttributeOnMethod_SkipsRequestTracking_ReturnsSuccess()
+        [Theory]
+        [InlineData(SkipRequestTrackingOnMethodController.Route)]
+        [InlineData(SkipRequestTrackingOnClassController.Route)]
+        public async Task GetRequestWithSkippedAttributeOnMethod_SkipsRequestTracking_ReturnsSuccess(string route)
         {
             // Arrange
             const string headerName = "x-custom-header", headerValue = "custom header value", body = "some body";
             _testServer.AddConfigure(app => app.UseRequestTracking());
             using (HttpClient client = _testServer.CreateClient())
             {
-                var request = new HttpRequestMessage(HttpMethod.Post, SkipRequestTrackingOnMethodController.Route)
+                var request = new HttpRequestMessage(HttpMethod.Post, route)
                 {
                     Headers = { {headerName, headerValue} },
                     Content = new StringContent($"\"{body}\"", Encoding.UTF8, "application/json")

--- a/src/Arcus.WebApi.Tests.Unit/Logging/SkipRequestTrackingOnClassController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/SkipRequestTrackingOnClassController.cs
@@ -1,0 +1,19 @@
+﻿using Arcus.WebApi.Logging;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Unit.Logging
+{
+    [ApiController]
+    [SkipRequestTracking]
+    public class SkipRequestTrackingOnClassController : ControllerBase
+    {
+        public const string Route = "requesttracking/skip-onclass";
+
+        [HttpPost]
+        [Route(Route)]
+        public IActionResult Post([FromBody] string body)
+        {
+            return Ok();
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/SkipRequestTrackingOnMethodController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/SkipRequestTrackingOnMethodController.cs
@@ -1,0 +1,19 @@
+﻿using Arcus.WebApi.Logging;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Unit.Logging
+{
+    [ApiController]
+    public class SkipRequestTrackingOnMethodController : ControllerBase
+    {
+        public const string Route = "requesttracking/skip-onmethod";
+
+        [HttpPost]
+        [Route(Route)]
+        [SkipRequestTracking]
+        public IActionResult Post([FromBody] string body)
+        {
+            return Ok();
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/VersionTrackingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/VersionTrackingMiddlewareTests.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Arcus.Observability.Telemetry.Core;
-using Arcus.Observability.Telemetry.Serilog.Enrichers;
 using Arcus.WebApi.Tests.Unit.Hosting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,12 +26,15 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             _testServer.AddConfigure(app => app.UseVersionTracking());
 
             using (HttpClient client = _testServer.CreateClient())
-            // Act
-            using (HttpResponseMessage response = await client.GetAsync(EchoController.Route))
             {
-                // Assert
-                Assert.True(response.Headers.TryGetValues(DefaultHeaderName, out IEnumerable<string> values));
-                Assert.Equal(expected, Assert.Single(values));
+                // Act
+                using (HttpResponseMessage response = await client.GetAsync(EchoController.Route))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    Assert.True(response.Headers.TryGetValues(DefaultHeaderName, out IEnumerable<string> values));
+                    Assert.Equal(expected, Assert.Single(values));
+                }
             }
         }
 
@@ -49,6 +52,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             using (HttpResponseMessage response = await client.GetAsync(EchoController.Route))
             {
                 // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 Assert.False(response.Headers.Contains(DefaultHeaderName));
                 Assert.True(response.Headers.TryGetValues(headerName, out IEnumerable<string> values));
                 Assert.Equal(expected, Assert.Single(values));


### PR DESCRIPTION
Adds a `SkipRequestTrackingAttribute` so consumers can pick and choose which endpoints should be tracked and which not.

Relates to #200 