### PR TITLE
chore: omit (by default) API Management default subscription key header

### DIFF
--- a/src/Arcus.WebApi.Logging/RequestTrackingOptions.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingOptions.cs
@@ -59,6 +59,6 @@ namespace Arcus.WebApi.Logging
         /// <summary>
         /// Gets or sets the HTTP request headers names that will be omitted during request tracking.
         /// </summary>
-        public ICollection<string> OmittedHeaderNames { get; set; } = new Collection<string> { "Authentication", "X-Api-Key", "X-ARR-ClientCert" };
+        public ICollection<string> OmittedHeaderNames { get; set; } = new Collection<string> { "Authentication", "X-Api-Key", "X-ARR-ClientCert", "Ocp-Apim-Subscription-Key" };
     }
 }

--- a/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
@@ -61,6 +61,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
         [InlineData("Authentication")]
         [InlineData("X-Api-Key")]
         [InlineData("X-ARR-ClientCert")]
+        [InlineData("Ocp-Apim-Subscription-Key")]
         public async Task GetRequestWithDefaultOmittedHeader_TracksRequestWithoutHeader_ReturnsSuccess(string omittedHeaderName)
         {
             // Arrange


### PR DESCRIPTION
Seems like a good idea to omit this Azure API Management default subscription key header in our request tracking middleware.