### PR TITLE
feat: omit routes in request tracking

### DIFF
--- a/docs/preview/features/logging.md
+++ b/docs/preview/features/logging.md
@@ -139,6 +139,10 @@ public class Startup
             // Size of the response body buffer (in bytes) hwhich should be tracked. Response bodies greater than this buffer will only be partly present in the telemetry.
             // (default: no limit)
             options.ResponseBodyBufferSize = 10 * 1024 * 1024; // 10MB
+
+            // All omitted HTTP routes that should be excluded from the request tracking logging emits.
+            // (default: no routes).
+            options.OmittedRoutes.Add("/api/v1/health");
         });
 
         ...

--- a/src/Arcus.WebApi.Logging/RequestTrackingOptions.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingOptions.cs
@@ -60,5 +60,10 @@ namespace Arcus.WebApi.Logging
         /// Gets or sets the HTTP request headers names that will be omitted during request tracking.
         /// </summary>
         public ICollection<string> OmittedHeaderNames { get; set; } = new Collection<string> { "Authentication", "Authorization", "X-Api-Key", "X-ARR-ClientCert", "Ocp-Apim-Subscription-Key" };
+
+        /// <summary>
+        /// Gets or sets the HTTP endpoint routes that will be omitted during request tracking.
+        /// </summary>
+        public ICollection<string> OmittedRoutes { get; set; } = new Collection<string>();
     }
 }

--- a/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
@@ -380,6 +380,23 @@ namespace Arcus.WebApi.Tests.Unit.Logging
         }
 
         [Theory]
+        [InlineData(EchoController.Route)]
+        [InlineData("/echo")]
+        public async Task RequestWithOmittedRouteWithBody_DoesntTracksRequest_ReturnsSuccess(string omittedRoute)
+        {
+            // Arrange
+            const string headerName = "x-custom-header", headerValue = "custom header value";
+            string body = $"body-{Guid.NewGuid()}";
+            _testServer.AddConfigure(app => app.UseRequestTracking(options => options.OmittedRoutes.Add(omittedRoute)));
+
+            // Act
+            await PostTrackedRequestEchoAsync(headerName, headerValue, body);
+            
+            // Assert
+            Assert.False(ContainsLoggedEventContext(), "No event context should be logged when the omitted route is applied");
+        }
+
+        [Theory]
         [InlineData("apiz")]
         [InlineData("/")]
         [InlineData(null)]

--- a/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
@@ -31,7 +31,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             _testServer.AddConfigure(app => app.UseRequestTracking());
             
             // Act
-            await PostTrackedRequestAsync(headerName, headerValue, body);
+            await PostTrackedRequestEchoAsync(headerName, headerValue, body);
             
             // Assert
             IDictionary<string, string> eventContext = GetLoggedEventContext();
@@ -48,7 +48,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             _testServer.AddConfigure(app => app.UseRequestTracking<NoHeadersRequestTrackingMiddleware>());
            
             // Act
-            await PostTrackedRequestAsync(headerName, headerValue, body);
+            await PostTrackedRequestEchoAsync(headerName, headerValue, body);
             
             // Assert
             IDictionary<string, string> eventContext = GetLoggedEventContext();
@@ -69,7 +69,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             _testServer.AddConfigure(app => app.UseRequestTracking());
             
             // Act
-            await PostTrackedRequestAsync(customHeaderName, customHeaderValue, body);
+            await PostTrackedRequestEchoAsync(customHeaderName, customHeaderValue, body);
             
             // Assert
             IDictionary<string, string> eventContext = GetLoggedEventContext();
@@ -87,7 +87,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             _testServer.AddConfigure(app => app.UseRequestTracking(options => options.OmittedHeaderNames.Add(customHeaderName)));
             
             // Act
-            await PostTrackedRequestAsync(customHeaderName, customHeaderValue, body);
+            await PostTrackedRequestEchoAsync(customHeaderName, customHeaderValue, body);
             
             // Assert
             IDictionary<string, string> eventContext = GetLoggedEventContext();
@@ -104,7 +104,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             _testServer.AddConfigure(app => app.UseRequestTracking(options => options.IncludeRequestHeaders = false));
             
             // Act
-            await PostTrackedRequestAsync(headerName, headerValue, body);
+            await PostTrackedRequestEchoAsync(headerName, headerValue, body);
             
             // Assert
             IDictionary<string, string> eventContext = GetLoggedEventContext();
@@ -121,7 +121,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             _testServer.AddConfigure(app => app.UseRequestTracking(options => options.IncludeRequestBody = true));
             
             // Act
-            await PostTrackedRequestAsync(headerName, headerValue, body);
+            await PostTrackedRequestEchoAsync(headerName, headerValue, body);
             
             // Assert
             IDictionary<string, string> eventContext = GetLoggedEventContext();
@@ -144,7 +144,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             }));
             
             // Act
-            await PostTrackedRequestAsync(headerName, headerValue, requestBody);
+            await PostTrackedRequestEchoAsync(headerName, headerValue, requestBody);
             
             // Assert
             IDictionary<string, string> eventContext = GetLoggedEventContext();
@@ -167,7 +167,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             }));
 
             // Act
-            await PostTrackedRequestAsync(headerName, headerValue, requestBody);
+            await PostTrackedRequestEchoAsync(headerName, headerValue, requestBody);
             
             // Assert
             IDictionary<string, string> eventContext = GetLoggedEventContext();
@@ -190,7 +190,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             }));
             
             // Act
-            await PostTrackedRequestAsync(headerName, headerValue, requestBody);
+            await PostTrackedRequestEchoAsync(headerName, headerValue, requestBody);
             
             // Assert
             IDictionary<string, string> eventContext = GetLoggedEventContext();
@@ -215,7 +215,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             }));
 
             // Act
-            await PostTrackedRequestAsync(headerName, headerValue, body);
+            await PostTrackedRequestEchoAsync(headerName, headerValue, body);
             
             // Assert
             IDictionary<string, string> eventContext = GetLoggedEventContext();
@@ -240,7 +240,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             }));
             
             // Act
-            await PostTrackedRequestAsync(headerName, headerValue, requestBody);
+            await PostTrackedRequestEchoAsync(headerName, headerValue, requestBody);
             
             // Assert
             IDictionary<string, string> eventContext = GetLoggedEventContext();
@@ -359,7 +359,53 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             }
         }
 
-        private async Task PostTrackedRequestAsync(string headerName, string headerValue, string requestBody)
+        [Theory]
+        [InlineData(HealthController.Route)]
+        [InlineData("/api/v1")]
+        [InlineData("/api")]
+        [InlineData("api")]
+        public async Task RequestWithOmittedRoute_DoesntTracksRequest_ReturnsSuccess(string omittedRoute)
+        {
+            // Arrange
+            _testServer.AddConfigure(app => app.UseRequestTracking(options => options.OmittedRoutes.Add(omittedRoute)));
+
+            // Act
+            using (HttpClient client = _testServer.CreateClient())
+            using (HttpResponseMessage response = await client.GetAsync(HealthController.Route))
+            {
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.False(ContainsLoggedEventContext(), "No event context should be logged when the omitted route is applied");
+            }
+        }
+
+        [Theory]
+        [InlineData("apiz")]
+        [InlineData("/")]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task RequestWithWrongOmittedRoute_TracksRequest_ReturnsSuccess(string omittedRoute)
+        {
+            // Arrange
+            const string headerName = "x-custom-header", headerValue = "custom header value";
+            _testServer.AddConfigure(app => app.UseRequestTracking(options => options.OmittedRoutes.Add(omittedRoute)));
+
+            // Act
+            using (HttpClient client = _testServer.CreateClient())
+            using (var request = new HttpRequestMessage(HttpMethod.Get, HealthController.Route))
+            {
+                request.Headers.Add(headerName, headerValue);
+                using (HttpResponseMessage response = await client.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    IDictionary<string, string> eventContext = GetLoggedEventContext();
+                    Assert.Equal(headerValue, Assert.Contains(headerName, eventContext));
+                }
+            }
+        }
+
+        private async Task PostTrackedRequestEchoAsync(string headerName, string headerValue, string requestBody)
         {
             using (HttpClient client = _testServer.CreateClient())
             using (var requestContents = new StringContent($"\"{requestBody}\"", Encoding.UTF8, "application/json"))
@@ -376,7 +422,11 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             }
         }
 
-        private async Task<HttpResponseMessage> PostRequestAsync(string headerName, string headerValue, string requestBody, string route = EchoController.Route)
+        private async Task<HttpResponseMessage> PostRequestAsync(
+            string headerName, 
+            string headerValue, 
+            string requestBody, 
+            string route = EchoController.Route)
         {
             using (HttpClient client = _testServer.CreateClient())
             using (var requestContents = new StringContent($"\"{requestBody}\"", Encoding.UTF8, "application/json"))


### PR DESCRIPTION
Make sure that we can exclude entire HTTP routes from the request tracking options instead of using attributes.

Closes #217 