### PR TITLE
feat: add HTTP status code ranges to request tracking

### DIFF
--- a/src/Arcus.WebApi.Logging/RequestTrackingOptions.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingOptions.cs
@@ -58,10 +58,15 @@ namespace Arcus.WebApi.Logging
         }
         
         /// <summary>
-        /// Gets or sets the HTTP response status codes that should be tracked. If not defined, all HTTP status codes are considered included and will all be tracked.
+        /// Gets or sets the allowed HTTP response status codes that should be tracked. If not defined, all HTTP status codes are considered included and will all be tracked.
         /// </summary>
         public ICollection<HttpStatusCode> TrackedStatusCodes { get; set; } = new Collection<HttpStatusCode>();
 
+        /// <summary>
+        /// Gets or sets allowed HTTP response status code ranges that should be tracked. If not defined, all HTTP status codes are considered included and will all be tracked.
+        /// </summary>
+        public ICollection<StatusCodeRange> TrackedStatusCodeRanges { get; set; } = new Collection<StatusCodeRange>();
+        
         /// <summary>
         /// Gets or sets the HTTP request headers names that will be omitted during request tracking.
         /// </summary>

--- a/src/Arcus.WebApi.Logging/StatusCodeRange.cs
+++ b/src/Arcus.WebApi.Logging/StatusCodeRange.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using GuardNet;
+
+namespace Arcus.WebApi.Logging
+{
+    /// <summary>
+    /// Represents a HTTP status code range with a minimum and maximum threshold.
+    /// </summary>
+    public class StatusCodeRange : IEquatable<StatusCodeRange>
+    {
+        /// <summary>
+        /// <para>Initializes a new instance of the <see cref="StatusCodeRange" /> class with the same HTTP status code for both the minimum and maximum threshold.</para>
+        /// <para>Used when only a single HTTP status code is allowed in the range.</para>
+        /// </summary>
+        /// <param name="minimum">The minimum HTTP status code threshold.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="minimum"/> is less than 100.</exception>
+        public StatusCodeRange(int minimum) : this(minimum, minimum)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StatusCodeRange" /> class.
+        /// </summary>
+        /// <param name="minimum">The minimum HTTP status code threshold.</param>
+        /// <param name="maximum">The maximum HTTP status code threshold</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when the <paramref name="minimum"/> is less than 100,
+        ///     or the <paramref name="maximum"/> is greater than 599,
+        ///     or the <paramref name="minimum"/> is greater than the <paramref name="maximum"/>.
+        /// </exception>
+        public StatusCodeRange(int minimum, int maximum)
+        {
+            Guard.NotLessThan(minimum, 100, nameof(minimum), "Requires the minimum HTTP status code threshold not be less than 100");
+            Guard.NotGreaterThan(maximum, 599, nameof(maximum), "Requires the maximum HTTP status code threshold not be greater than 599");
+            Guard.NotGreaterThan(minimum, maximum, nameof(minimum), "Requires the minimum HTTP status code threshold to be less than the maximum HTTP status code threshold");
+            
+            Minimum = minimum;
+            Maximum = maximum;
+        }
+
+        /// <summary>
+        /// Gets the minimum HTTP status code threshold.
+        /// </summary>
+        public int Minimum { get; }
+
+        /// <summary>
+        /// Gets the maximum HTTP status code threshold.
+        /// </summary>
+        public int Maximum { get; }
+
+        /// <summary>
+        /// Determines whether or not a given <paramref name="statusCode"/> is within the range of this HTTP status code range (inconclusive).
+        /// </summary>
+        /// <param name="statusCode">The response HTTP status code..</param>
+        /// <returns>
+        ///     [true] if the <paramref name="statusCode"/> falls within this HTTP status code range; [false] otherwise.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="statusCode"/> is less than 100 or greater than 599.</exception>
+        public bool IsWithinRange(int statusCode)
+        {
+            Guard.NotLessThan(statusCode, 100, nameof(statusCode), "Requires the response HTTP status code not be less than 100");
+            Guard.NotGreaterThan(statusCode, 599, nameof(statusCode), "Requires the response HTTP status code not be greater than 599");
+            
+            return Minimum <= statusCode && statusCode <= Maximum;
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>true if the current object is equal to the <paramref name="other">other</paramref> parameter; otherwise, false.</returns>
+        public bool Equals(StatusCodeRange other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Minimum == other.Minimum && Maximum == other.Maximum;
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current object.</param>
+        /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj is StatusCodeRange other)
+            {
+                return Equals(other);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Serves as the default hash function.
+        /// </summary>
+        /// <returns>A hash code for the current object.</returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Minimum.GetHashCode() * 397) ^ Maximum.GetHashCode();
+            }
+        }
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            if (Minimum == Maximum)
+            {
+                return Minimum.ToString();
+            }
+
+            return $"{Minimum}-{Maximum}";
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/DiscardedStatusCodeOnClassController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/DiscardedStatusCodeOnClassController.cs
@@ -3,7 +3,7 @@ using System.Net;
 using Arcus.WebApi.Logging;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Arcus.WebApi.Tests.Unit.Logging
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
 {
     [ApiController]
     [RequestTracking(HttpStatusCode.OK)]

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/DiscardedStatusCodeOnMethodController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/DiscardedStatusCodeOnMethodController.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Net;
+using Arcus.WebApi.Logging;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
+{
+    [ApiController]
+    public class DiscardedStatusCodeOnMethodController : ControllerBase
+    {
+        public const string Route = "requesttracking/disgarded-statuscode/on-method";
+
+        [HttpPost]
+        [Route(Route)]
+        [RequestTracking(HttpStatusCode.OK)]
+        public IActionResult Post([FromBody] string responseStatusCode)
+        {
+            return StatusCode(Convert.ToInt32(responseStatusCode), $"response-{Guid.NewGuid()}");
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/ExcludeFilterIgnoredWhileExcludedOnClassController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/ExcludeFilterIgnoredWhileExcludedOnClassController.cs
@@ -1,7 +1,7 @@
 ﻿using Arcus.WebApi.Logging;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Arcus.WebApi.Tests.Unit.Logging
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
 {
     [ApiController]
     [ExcludeRequestTracking]

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/ExcludeFilterRequestTrackingOnMethodController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/ExcludeFilterRequestTrackingOnMethodController.cs
@@ -1,7 +1,7 @@
 ﻿using Arcus.WebApi.Logging;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Arcus.WebApi.Tests.Unit.Logging
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
 {
     [ApiController]
     public class ExcludeFilterRequestTrackingOnMethodController : ControllerBase

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/ExcludeFilterUsedWhileExcludedOnClassController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/ExcludeFilterUsedWhileExcludedOnClassController.cs
@@ -1,7 +1,7 @@
 ﻿using Arcus.WebApi.Logging;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Arcus.WebApi.Tests.Unit.Logging
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
 {
     [ApiController]
     [RequestTracking(Exclude.ResponseBody)]

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/ExcludeRequestTrackingOnClassController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/ExcludeRequestTrackingOnClassController.cs
@@ -1,7 +1,7 @@
 ﻿using Arcus.WebApi.Logging;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Arcus.WebApi.Tests.Unit.Logging
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
 {
     [ApiController]
     [ExcludeRequestTracking]

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/ExcludeRequestTrackingOnMethodController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/ExcludeRequestTrackingOnMethodController.cs
@@ -1,8 +1,7 @@
-﻿using System.IO;
-using Arcus.WebApi.Logging;
+﻿using Arcus.WebApi.Logging;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Arcus.WebApi.Tests.Unit.Logging
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
 {
     [ApiController]
     public class ExcludeRequestTrackingOnMethodController : ControllerBase

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/StubbedStatusCodeController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/StubbedStatusCodeController.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
+{
+    [ApiController]
+    public class StubbedStatusCodeController : ControllerBase
+    {
+        public const string Route = "requesttracking/stubbed-statuscode";
+
+        [HttpPost]
+        [Route(Route)]
+        public IActionResult Post([FromBody] string responseStatusCode)
+        {
+            return StatusCode(Convert.ToInt32(responseStatusCode), $"response-{Guid.NewGuid()}");
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/TrackedClientErrorStatusCodesOnClassController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/TrackedClientErrorStatusCodesOnClassController.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Arcus.WebApi.Logging;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
+{
+    [ApiController]
+    [RequestTracking(400, 499)]
+    public class TrackedClientErrorStatusCodesOnClassController : ControllerBase
+    {
+        public const string Route = "requesttracking/tracked-client-errors/on-class";
+
+        [HttpPost]
+        [Route(Route)]
+        public IActionResult Post([FromBody] string responseStatusCode)
+        {
+            return StatusCode(Convert.ToInt32(responseStatusCode), $"response-{Guid.NewGuid()}");
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/TrackedNotFoundAndClientErrorsSubsetStatusCodesOnClassController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/TrackedNotFoundAndClientErrorsSubsetStatusCodesOnClassController.cs
@@ -3,16 +3,17 @@ using System.Net;
 using Arcus.WebApi.Logging;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Arcus.WebApi.Tests.Unit.Logging
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
 {
     [ApiController]
-    public class DiscardedStatusCodeOnMethodController : ControllerBase
+    [RequestTracking(HttpStatusCode.NotFound)]
+    [RequestTracking(450, 499)]
+    public class TrackedNotFoundAndClientErrorsSubsetStatusCodesOnClassController : ControllerBase
     {
-        public const string Route = "requesttracking/disgarded-statuscode/on-method";
+        public const string Route = "requesttracking/tracked-notfound-and-subset-clienterrors/on-class";
 
         [HttpPost]
         [Route(Route)]
-        [RequestTracking(HttpStatusCode.OK)]
         public IActionResult Post([FromBody] string responseStatusCode)
         {
             return StatusCode(Convert.ToInt32(responseStatusCode), $"response-{Guid.NewGuid()}");

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/TrackedNotFoundStatusCodeOnClassController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/TrackedNotFoundStatusCodeOnClassController.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Arcus.WebApi.Logging;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
+{
+    [ApiController]
+    [RequestTracking(404)]
+    public class TrackedNotFoundStatusCodeOnClassController : ControllerBase
+    {
+        public const string Route = "requesttracking/client-errors-notfound/on-class";
+
+        [HttpPost]
+        [Route(Route)]
+        public IActionResult Post([FromBody] string responseStatusCode)
+        {
+            return StatusCode(Convert.ToInt32(responseStatusCode), $"response-{Guid.NewGuid()}");
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/TrackedServerErrorStatusCodesOnMethodController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/TrackedServerErrorStatusCodesOnMethodController.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Net;
+using Arcus.WebApi.Logging;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
+{
+    [ApiController]
+    public class TrackedServerErrorStatusCodesOnMethodController : ControllerBase
+    {
+        public const string RouteWithMinMax = "requesttracking/tracked/server-errors-minmax/on-method",
+                            RouteWithFixed = "requesttracking/tracked/server-errors-fixed/on-method",
+                            RouteWithCombined = "requesttracking/tracked/server-errors-combined/on-method",
+                            RouteWithAll = "requesttracking/tracked-server-errors-all/on-method";
+
+        [HttpPost]
+        [Route(RouteWithMinMax)]
+        [RequestTracking(500, 599)]
+        public IActionResult PostMinMax([FromBody] string responseStatusCode)
+        {
+            return StatusCode(responseStatusCode);
+        }
+
+        [HttpPost]
+        [Route(RouteWithFixed)]
+        [RequestTracking(500)]
+        public IActionResult PostFixed([FromBody] string responseStatusCode)
+        {
+            return StatusCode(responseStatusCode);
+        }
+
+        [HttpPost]
+        [Route(RouteWithCombined)]
+        [RequestTracking(500, 549)]
+        [RequestTracking(550, 599)]
+        public IActionResult PostCombined([FromBody] string responseStatusCode)
+        {
+            return StatusCode(responseStatusCode);
+        }
+
+        [HttpPost]
+        [Route(RouteWithAll)]
+        [RequestTracking(550, 599)]
+        [RequestTracking(Exclude.RequestBody)]
+        [RequestTracking(HttpStatusCode.InternalServerError)]
+        public IActionResult PostAll([FromBody] string responseStatusCode)
+        {
+            return StatusCode(responseStatusCode);
+        }
+        
+        private IActionResult StatusCode(string responseStatusCode)
+        {
+            return StatusCode(Convert.ToInt32(responseStatusCode), $"response-{Guid.NewGuid()}");
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/TrackedStatusCodeOnClassController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/TrackedStatusCodeOnClassController.cs
@@ -2,7 +2,7 @@
 using Arcus.WebApi.Logging;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Arcus.WebApi.Tests.Unit.Logging
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
 {
     [ApiController]
     [RequestTracking(HttpStatusCode.OK)]

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/TrackedStatusCodeOnMethodController.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Controllers/TrackedStatusCodeOnMethodController.cs
@@ -2,7 +2,7 @@
 using Arcus.WebApi.Logging;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Arcus.WebApi.Tests.Unit.Logging
+namespace Arcus.WebApi.Tests.Unit.Logging.Controllers
 {
     [ApiController]
     public class TrackedStatusCodeOnMethodController : ControllerBase

--- a/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingAttributeTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingAttributeTests.cs
@@ -1,12 +1,15 @@
 ﻿using System;
 using System.Net;
 using Arcus.WebApi.Logging;
+using Bogus;
 using Xunit;
 
 namespace Arcus.WebApi.Tests.Unit.Logging
 {
     public class RequestTrackingAttributeTests
     {
+        private static readonly Faker BogusGenerator = new Faker();
+        
         [Theory]
         [InlineData(Exclude.None)]
         [InlineData(Exclude.RequestBody | Exclude.ResponseBody)]
@@ -17,11 +20,35 @@ namespace Arcus.WebApi.Tests.Unit.Logging
         }
         
         [Theory]
-        [InlineData(HttpStatusCode.Created | HttpStatusCode.AlreadyReported)]
+        [InlineData((HttpStatusCode) 40)]
         [InlineData((HttpStatusCode) 600)]
         public void CreateAttribute_WithHttpStatusCodeOutOfExpectedRange_Fails(HttpStatusCode statusCode)
         {
             Assert.ThrowsAny<ArgumentException>(() => new RequestTrackingAttribute(statusCode));
+        }
+
+        [Fact]
+        public void CreateAttribute_WithMinimumStatusCodeOutOfExpectedRange_Fails()
+        {
+            // Arrange
+            int minimumStatusCode = BogusGenerator.Random.Int(max: 99);
+            int maximumStatusCode = BogusGenerator.Random.Int(100, 599);
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => new RequestTrackingAttribute(minimumStatusCode, maximumStatusCode));
+        }
+        
+        [Fact]
+        public void CreateAttribute_WithMaximumStatusCodeOutOfExpectedRange_Fails()
+        {
+            // Arrange
+            int minimumStatusCode = BogusGenerator.Random.Int(100, 599);
+            int maximumStatusCode = BogusGenerator.Random.Int(min: 600);
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => new RequestTrackingAttribute(minimumStatusCode, maximumStatusCode));
         }
     }
 }

--- a/src/Arcus.WebApi.Tests.Unit/Logging/StatusCodeRangeTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/StatusCodeRangeTests.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using Arcus.WebApi.Logging;
+using Bogus;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Logging
+{
+    public class StatusCodeRangeTests
+    {
+        private static readonly Faker BogusGenerator = new Faker();
+
+        [Fact]
+        public void CreateRange_WithSingleThresholdOutOfMinimumRange_Fails()
+        {
+            // Arrange
+            int statusCode = BogusGenerator.Random.Int(max: 99);
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => new StatusCodeRange(statusCode));
+        }
+        
+        [Fact]
+        public void CreateRange_WithSingleThresholdOutOfMaximumRange_Fails()
+        {
+            // Arrange
+            int statusCode = BogusGenerator.Random.Int(min: 600);
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => new StatusCodeRange(statusCode));
+        }
+        
+        [Fact]
+        public void CreateRange_WithMinimumThresholdOutOfRange_Fails()
+        {
+            // Arrange
+            int minimum = BogusGenerator.Random.Int(max: 99);
+            int maximum = BogusGenerator.Random.Int(100, 599);
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => new StatusCodeRange(minimum, maximum));
+        }
+
+        [Fact]
+        public void CreateRange_WithMaximumThresholdOutOfRange_Fails()
+        {
+            // Arrange
+            int minimum = BogusGenerator.Random.Int(100, 599);
+            int maximum = BogusGenerator.Random.Int(min: 600);
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => new StatusCodeRange(minimum, maximum));
+        }
+
+        [Fact]
+        public void CreateRange_WithExpectedSingleThreshold_IsWithinRangeSucceeds()
+        {
+            // Arrange
+            int statusCode = BogusGenerator.Random.Int(100, 599);
+            var range = new StatusCodeRange(statusCode);
+
+            // Act
+            bool isWithinRange = range.IsWithinRange(statusCode);
+            
+            // Assert
+            Assert.True(isWithinRange);
+        }
+        
+        [Fact]
+        public void CreateRange_WithOutsideExpectedSingleThreshold_IsWithinRangeFails()
+        {
+            // Arrange
+            int threshold = BogusGenerator.Random.Int(400, 599);
+            int statusCode = BogusGenerator.Random.Int(200, 399);
+            var range = new StatusCodeRange(threshold);
+
+            // Act
+            bool isWithinRange = range.IsWithinRange(statusCode);
+            
+            // Assert
+            Assert.False(isWithinRange);
+        }
+        
+        [Fact]
+        public void CreateRange_WithExpectedThresholds_IsWithinRangeSucceeds()
+        {
+            // Arrange
+            int statusCode = BogusGenerator.Random.Int(min: 500, max: 599);
+            var range = new StatusCodeRange(500, 599);
+
+            // Act
+            bool isWithinRange = range.IsWithinRange(statusCode);
+            
+            // Assert
+            Assert.True(isWithinRange);
+        }
+
+        [Fact]
+        public void CreateRange_WithOutsideExpectedThresholds_IsWithinRangeFails()
+        {
+            // Arrange
+            int statusCode = BogusGenerator.Random.Int(min: 200, max: 299);
+            var range = new StatusCodeRange(500, 599);
+
+            // Act
+            bool isWithinRange = range.IsWithinRange(statusCode);
+            
+            // Assert
+            Assert.False(isWithinRange);
+        }
+    }
+}


### PR DESCRIPTION
Provide the capability to add a range of HTTP status codes on both the request tracking options as in the `[RequestTracking]` attirbute.

Closes #216 