### PR TITLE
fix: add extra null-check for HTTP status code range

### DIFF
--- a/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
@@ -306,6 +306,7 @@ namespace Arcus.WebApi.Logging
                     .Select(code => new StatusCodeRange((int) code))
                     .Concat(optionsTrackedStatusCodeRanges)
                     .Concat(attributeTrackedStatusCodes)
+                    .Where(range => range != null)
                     .Distinct().ToArray();
 
             bool allowedToTrackStatusCode = 

--- a/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
@@ -18,6 +18,7 @@ using Xunit;
 
 namespace Arcus.WebApi.Tests.Unit.Logging
 {
+    [Collection("Request tracking")]
     public class RequestTrackingMiddlewareTests : IDisposable
     {
         private const string RequestBodyKey = "RequestBody",

--- a/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
@@ -611,6 +611,25 @@ namespace Arcus.WebApi.Tests.Unit.Logging
                 Assert.Equal(headerValue, Assert.Contains(headerName, eventContext));
             }
         }
+
+        [Theory]
+        [InlineData(HttpStatusCode.InternalServerError)]
+        [InlineData(HttpStatusCode.OK)]
+        public async Task PostWithResponseNullStatusCodeRangeOptions_TracksAllRequest_ReturnsSuccess(HttpStatusCode responseStatusCode)
+        {
+            // Arrange
+            string headerName = $"x-custom-header-{Guid.NewGuid():N}", headerValue = _bogusGenerator.Lorem.Sentence();
+            _testServer.AddConfigure(app => app.UseRequestTracking(options => options.TrackedStatusCodeRanges.Add(null)));
+            string route = StubbedStatusCodeController.Route;
+            
+            // Act
+            using (HttpResponseMessage response = await PostRequestAsync(headerName, headerValue, ((int) responseStatusCode).ToString(), route, responseStatusCode))
+            {
+                // Assert
+                IDictionary<string, string> eventContext = GetLoggedEventContext();
+                Assert.Equal(headerValue, Assert.Contains(headerName, eventContext));
+            }
+        }
         
         private async Task PostTrackedRequestEchoAsync(string headerName, string headerValue, string requestBody)
         {


### PR DESCRIPTION
Add extra `null`-check before we check if the response status code is within the configured range.

Relates to #216 