### PR TITLE
fix: handle invalid endpoint features in request tracking

### DIFF
--- a/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
@@ -64,14 +64,14 @@ namespace Arcus.WebApi.Logging
             else
             {
                 var endpoint = httpContext.Features.Get<IEndpointFeature>();
-                if (endpoint is null)
+                if (endpoint?.Endpoint?.Metadata is null)
                 {
                     _logger.LogTrace("Cannot determine whether or not the endpoint contains the '{Attribute}' because the endpoint tracking (`IApplicationBuilder.UseRouting()` or `.UseEndpointRouting()`) was not activated before the request tracking middleware", nameof(ExcludeRequestTrackingAttribute));
                     await TrackRequest(httpContext, Exclude.None, Array.Empty<StatusCodeRange>());
                 }
                 else if (endpoint.Endpoint.Metadata.GetMetadata<ExcludeRequestTrackingAttribute>() != null)
                 {
-                    _logger.LogTrace("Skip request tracking for endpoint '{Endpoint}' due to the '{Attribute}' attribute on the endpoint", endpoint?.Endpoint?.DisplayName, nameof(ExcludeRequestTrackingAttribute));
+                    _logger.LogTrace("Skip request tracking for endpoint '{Endpoint}' due to the '{Attribute}' attribute on the endpoint", endpoint.Endpoint.DisplayName, nameof(ExcludeRequestTrackingAttribute));
                     await _next(httpContext);
                 }
                 else
@@ -108,7 +108,7 @@ namespace Arcus.WebApi.Logging
 
         private RequestTrackingAttribute[] DetermineAppliedAttributes(IEndpointFeature endpoint)
         {
-            if (endpoint is null)
+            if (endpoint?.Endpoint?.Metadata is null)
             {
                 _logger.LogTrace("Cannot determine whether or not the endpoint contains the '{OptionsAttribute}' because the endpoint tracking (`IApplicationBuilder.UseRouting()` or `.UseEndpointRouting()`) was not activated before the request tracking middleware", nameof(RequestTrackingAttribute));
                 return Array.Empty<RequestTrackingAttribute>();

--- a/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
@@ -66,7 +66,7 @@ namespace Arcus.WebApi.Logging
                 var endpoint = httpContext.Features.Get<IEndpointFeature>();
                 if (endpoint?.Endpoint?.Metadata is null)
                 {
-                    _logger.LogTrace("Cannot determine whether or not the endpoint contains the '{Attribute}' because the endpoint tracking (`IApplicationBuilder.UseRouting()` or `.UseEndpointRouting()`) was not activated before the request tracking middleware", nameof(ExcludeRequestTrackingAttribute));
+                    _logger.LogTrace("Cannot determine whether or not the endpoint contains the '{Attribute}' because the endpoint tracking (`IApplicationBuilder.UseRouting()` or `.UseEndpointRouting()`) was not activated before the request tracking middleware; or the route was not found", nameof(ExcludeRequestTrackingAttribute));
                     await TrackRequest(httpContext, Exclude.None, Array.Empty<StatusCodeRange>());
                 }
                 else if (endpoint.Endpoint.Metadata.GetMetadata<ExcludeRequestTrackingAttribute>() != null)
@@ -110,7 +110,7 @@ namespace Arcus.WebApi.Logging
         {
             if (endpoint?.Endpoint?.Metadata is null)
             {
-                _logger.LogTrace("Cannot determine whether or not the endpoint contains the '{OptionsAttribute}' because the endpoint tracking (`IApplicationBuilder.UseRouting()` or `.UseEndpointRouting()`) was not activated before the request tracking middleware", nameof(RequestTrackingAttribute));
+                _logger.LogTrace("Cannot determine whether or not the endpoint contains the '{OptionsAttribute}' because the endpoint tracking (`IApplicationBuilder.UseRouting()` or `.UseEndpointRouting()`) was not activated before the request tracking middleware; or the route was not found", nameof(RequestTrackingAttribute));
                 return Array.Empty<RequestTrackingAttribute>();
             }
             

--- a/src/Arcus.WebApi.Tests.Unit/Hosting/EmptyApiServer.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Hosting/EmptyApiServer.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using GuardNet;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Arcus.WebApi.Tests.Unit.Hosting
+{
+    /// <summary>
+    /// Represents an empty API server to test features from scratch.
+    /// </summary>
+    public class EmptyApiServer : WebApplicationFactory<TestStartup>
+    {
+        private readonly ICollection<Action<IServiceCollection>> _configureServices;
+        private readonly ICollection<Action<IApplicationBuilder>> _configures;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmptyApiServer" /> class.
+        /// </summary>
+        public EmptyApiServer()
+        {
+            _configureServices = new Collection<Action<IServiceCollection>>();
+            _configures = new Collection<Action<IApplicationBuilder>>();
+        }
+
+        /// <summary>
+        /// Gives a fixture an opportunity to configure the application before it gets built.
+        /// </summary>
+        /// <param name="builder">The <see cref="T:Microsoft.AspNetCore.Hosting.IWebHostBuilder" /> for the application.</param>
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                foreach (Action<IServiceCollection> configureService in _configureServices)
+                {
+                    configureService(services);
+                }
+            });
+
+            builder.Configure(app =>
+            {
+                foreach (Action<IApplicationBuilder> configure in _configures)
+                {
+                    configure(app);
+                }
+            });
+        }
+
+#if NETCOREAPP2_2
+        /// <summary>
+        /// Creates a <see cref="T:Microsoft.AspNetCore.Hosting.IWebHostBuilder" /> used to set up <see cref="T:Microsoft.AspNetCore.TestHost.TestServer" />.
+        /// </summary>
+        /// <remarks>
+        /// The default implementation of this method looks for a <c>public static IWebHostBuilder CreateWebHostBuilder(string[] args)</c>
+        /// method defined on the entry point of the assembly of <typeparamref name="TEntryPoint" /> and invokes it passing an empty string
+        /// array as arguments.
+        /// </remarks>
+        /// <returns>A <see cref="T:Microsoft.AspNetCore.Hosting.IWebHostBuilder" /> instance.</returns>
+        protected override IWebHostBuilder CreateWebHostBuilder()
+        {
+            return new WebHostBuilder().ConfigureKestrel(options => options.AddServerHeader = false);
+        }
+#endif
+
+#if NETCOREAPP3_1
+      protected override IHostBuilder CreateHostBuilder()
+        {
+            return Host.CreateDefaultBuilder();
+        }  
+#endif
+
+        /// <summary>
+        /// Adds a 'Configure' method functionality on the <see cref="IApplicationBuilder"/> instance during the creation of the hosted test server.
+        /// </summary>
+        /// <param name="configure">The action to execute.</param>
+        public void AddConfigure(Action<IApplicationBuilder> configure)
+        {
+            Guard.NotNull(configure, nameof(configure), "Action cannot be 'null'");
+
+            _configures.Add(configure);
+        }
+        
+        /// <summary>
+        /// Adds a configuration of the <see cref="IServiceCollection"/> to the test server.
+        /// </summary>
+        public void AddServicesConfig(Action<IServiceCollection> configureServices)
+        {
+            Guard.NotNull(configureServices, nameof(configureServices));
+
+            _configureServices.Add(configureServices);
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Hosting/TestApiServer.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Hosting/TestApiServer.cs
@@ -158,7 +158,6 @@ namespace Arcus.WebApi.Tests.Unit.Hosting
 
             builder.Configure(app =>
             {
-                app.UseExceptionHandling();
                 app.UseMiddleware<TraceIdentifierMiddleware>();
                 app.UseHttpCorrelation();
 
@@ -172,6 +171,8 @@ namespace Arcus.WebApi.Tests.Unit.Hosting
                 {
                     configure(app);
                 }
+                
+                app.UseExceptionHandling();
 
 #if NETCOREAPP3_1
                 app.UseEndpoints(endpoints => endpoints.MapControllers());

--- a/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/RequestTrackingMiddlewareTests.cs
@@ -54,7 +54,6 @@ namespace Arcus.WebApi.Tests.Unit.Logging
                 using (HttpResponseMessage response = await client.SendAsync(request))
                 {
                     // Assert
-                    Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
                     IDictionary<string, string> eventContext = GetLoggedEventContext();
                     Assert.Equal(headerValue, Assert.Contains(headerName, eventContext));
                 }


### PR DESCRIPTION
In this test project, the in-memory hosting functionality wasn't acting the same way as the 'real-life' hosting. Meaning, that the `IEndpointFeature` wasn't always the same structure, or available in the same way the test project was.
This was discovered by releasing the v1.3 version.

This can be reproduced by adding an 'invalid' endpoint feature to the in-memory hosting project. This allows us to see what's wrong: the request tracking middleware wasn't correctly handling `null` values completely.

 It's worth noting that we should invest in maybe a more 'real life' approach where we use the `Host.CreateDefaultBuilder` directly to limit the gap between testing and production.