### PR TITLE
fix: use Arcus NuGet version ranges

### DIFF
--- a/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
+++ b/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.0,3.0.0" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.0,3.0.0]" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.0,3.0.0)" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
   </ItemGroup>
 

--- a/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
+++ b/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.0.0" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="2.0.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.0,3.0.0" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.0,3.0.0]" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
   </ItemGroup>
 

--- a/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
+++ b/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.0,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.1,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.1,3.0.0)" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
   </ItemGroup>
 

--- a/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
+++ b/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
@@ -30,10 +30,10 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.0,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="[2.0.0,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.0,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.0.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.1,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="[2.0.1,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.1,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.0.1,3.0.0)" />
   </ItemGroup>
 
    <ItemGroup>

--- a/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
+++ b/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
@@ -30,10 +30,10 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.0.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="2.0.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="2.0.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.0,3.0.0]" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="[2.0.0,3.0.0]" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.0,3.0.0]" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.0.0,3.0.0]" />
   </ItemGroup>
 
    <ItemGroup>

--- a/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
+++ b/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
@@ -30,10 +30,10 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.0,3.0.0]" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="[2.0.0,3.0.0]" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.0,3.0.0]" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.0.0,3.0.0]" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="[2.0.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.0.0,3.0.0)" />
   </ItemGroup>
 
    <ItemGroup>

--- a/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
+++ b/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[1.4.0,2.0.0]" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[1.4.0,2.0.0)" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="IdentityModel" Version="4.4.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.8.0" />

--- a/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
+++ b/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.4.0" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[1.4.0,2.0.0]" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="IdentityModel" Version="4.4.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.8.0" />

--- a/src/Arcus.WebApi.Tests.Integration/Logging/RequestTrackingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/RequestTrackingMiddlewareTests.cs
@@ -853,7 +853,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
 
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
             {
-                var responseStatusCode = _bogusGenerator.Random.Enum(trackedStatusCode);
+                var responseStatusCode = _bogusGenerator.Random.Int(201, 403);
                 var request = HttpRequestBuilder
                     .Post(StubbedStatusCodeController.PostRoute)
                     .WithHeader(headerName, headerValue)
@@ -902,7 +902,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
         [Theory]
         [InlineData(500, 599, 200)]
         [InlineData(450, 599, 315)]
-        [InlineData(100, 598, 599)]
+        [InlineData(200, 598, 599)]
         [InlineData(200, 399, 500)]
         public async Task PostWithResponseOutsideStatusCodeRangesOptions_TracksRequest_ReturnsSuccess(int minimumThreshold, int maximumThreshold, int responseStatusCode)
         {
@@ -935,7 +935,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
         [InlineData(500, 599, 550)]
         [InlineData(500, 500, 500)]
         [InlineData(200, 399, 202)]
-        [InlineData(100, 599, 315)]
+        [InlineData(200, 599, 315)]
         public async Task PostWithResponseInsideStatusCodeRangesOptions_TracksRequest_ReturnsSuccess(int minimumThreshold, int maximumThreshold, int responseStatusCode)
         {
             // Arrange


### PR DESCRIPTION
Let's use NuGet version ranges to include Arcus dependencies so we can more easily support multiple Arcus packages in a single project.

Relates to https://github.com/arcus-azure/arcus/issues/129