### PR TITLE
docs: add app tracking to landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ For more granular packages we recommend reading the documentation.
 - **Logging**
     - [Logging unhandled exceptions](features/logging#logging-unhandled-exceptions)
     - [Logging incoming requests](features/logging#logging-incoming-requests)
+    - [Tracking application version](features/logging#tracking-application-version)
 - **OpenAPI**
     - [Exposing security information in Swashbuckle documentation](features/openapi/security-definitions)
 

--- a/docs/preview/index.md
+++ b/docs/preview/index.md
@@ -32,6 +32,7 @@ For more granular packages we recommend reading the documentation.
 - **Logging**
     - [Logging unhandled exceptions](features/logging#logging-unhandled-exceptions)
     - [Logging incoming requests](features/logging#logging-incoming-requests)
+    - [Tracking application version](features/logging#tracking-application-version)
 - **OpenAPI**
     - [Exposing security information in Swashbuckle documentation](features/openapi/security-definitions)
 

--- a/docs/v1.1.0/index.md
+++ b/docs/v1.1.0/index.md
@@ -32,6 +32,7 @@ For more granular packages we recommend reading the documentation.
 - **Logging**
     - [Logging unhandled exceptions](features/logging#logging-unhandled-exceptions)
     - [Logging incoming requests](features/logging#logging-incoming-requests)
+    - [Tracking application version](features/logging#tracking-application-version)
 - **OpenAPI**
     - [Exposing security information in Swashbuckle documentation](features/openapi/security-definitions)
 

--- a/docs/v1.2.0/index.md
+++ b/docs/v1.2.0/index.md
@@ -32,6 +32,7 @@ For more granular packages we recommend reading the documentation.
 - **Logging**
     - [Logging unhandled exceptions](features/logging#logging-unhandled-exceptions)
     - [Logging incoming requests](features/logging#logging-incoming-requests)
+    - [Tracking application version](features/logging#tracking-application-version)
 - **OpenAPI**
     - [Exposing security information in Swashbuckle documentation](features/openapi/security-definitions)
 

--- a/docs/v1.3.0/index.md
+++ b/docs/v1.3.0/index.md
@@ -35,6 +35,7 @@ For more granular packages we recommend reading the documentation.
 - **Logging**
     - [Logging unhandled exceptions](features/logging#logging-unhandled-exceptions)
     - [Logging incoming requests](features/logging#logging-incoming-requests)
+    - [Tracking application version](features/logging#tracking-application-version)
 - **OpenAPI**
     - [Exposing security information in Swashbuckle documentation](features/openapi/security-definitions)
 


### PR DESCRIPTION
Adds missing 'Tracking application version' logging section to the index landing pages of all the versions that included this.