### PR TITLE
feat: add operation parent ID to correlation middleware

### DIFF
--- a/docs/preview/features/correlation.md
+++ b/docs/preview/features/correlation.md
@@ -104,6 +104,7 @@ public class Startup
             // ------------------------------------------------------------------
 
             // Whether to extract the operation parent ID from the incoming request (default: true).
+            // We currently only support the W3C HTTP correlation standard for the `RequestId` ([see more info about this topic](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/HttpCorrelationProtocol.md))
             // More information on operation ID and operation parent ID, see [this documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/app/correlation).
             options.UpstreamService.ExtractFromRequest = false;
 

--- a/docs/preview/features/correlation.md
+++ b/docs/preview/features/correlation.md
@@ -104,7 +104,6 @@ public class Startup
             // ------------------------------------------------------------------
 
             // Whether to extract the operation parent ID from the incoming request following W3C Trace-Context standard (default: true).
-            // We currently only support the W3C HTTP correlation standard for the `RequestId` ([see more info about this topic](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/HttpCorrelationProtocol.md))
             // More information on operation ID and operation parent ID, see [this documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/app/correlation).
             options.UpstreamService.ExtractFromRequest = false;
 

--- a/docs/preview/features/correlation.md
+++ b/docs/preview/features/correlation.md
@@ -103,9 +103,9 @@ public class Startup
             // Configuration on operation parent ID request header (`Request-Id`).
             // ------------------------------------------------------------------
 
-            // Whether to extract the operation parent ID from the incoming request (default: true).
+            // Whether to extract the operation parent ID from the incoming request (default: false).
             // More information on operation ID and operation parent ID, see [this documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/app/correlation).
-            options.UpstreamService.ExtractFromRequest = false;
+            options.UpstreamService.ExtractFromRequest = true;
 
             // The header that will contain the operation parent ID in the HTTP request (default: Request-Id).
             options.UpstreamService.OperationParentIdHeaderName = "x-request-id";

--- a/docs/preview/features/correlation.md
+++ b/docs/preview/features/correlation.md
@@ -103,9 +103,9 @@ public class Startup
             // Configuration on operation parent ID request header (`Request-Id`).
             // ------------------------------------------------------------------
 
-            // Whether to extract the operation parent ID from the incoming request (default: false).
+            // Whether to extract the operation parent ID from the incoming request (default: true).
             // More information on operation ID and operation parent ID, see [this documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/app/correlation).
-            options.UpstreamService.ExtractFromRequest = true;
+            options.UpstreamService.ExtractFromRequest = false;
 
             // The header that will contain the operation parent ID in the HTTP request (default: Request-Id).
             options.UpstreamService.OperationParentIdHeaderName = "x-request-id";

--- a/docs/preview/features/correlation.md
+++ b/docs/preview/features/correlation.md
@@ -99,6 +99,16 @@ public class Startup
             // The function that will generate the operation ID header value.
             // (default: new `Guid`).
             options.Operation.GenerateId = () => $"Operation-{Guid.NewGuid()}";
+
+            // Configuration on operation parent ID request header (`Request-Id`).
+            // ------------------------------------------------------------------
+
+            // Whether to extract the operation parent ID from the incoming request (default: true).
+            // More information on operation ID and operation parent ID, see [this documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/app/correlation).
+            options.UpstreamService.ExtractFromRequest = false;
+
+            // The header that will contain the operation parent ID in the HTTP request (default: Request-Id).
+            options.UpstreamService.OperationParentIdHeaderName = "x-request-id";
         });
     }
 }

--- a/docs/preview/features/correlation.md
+++ b/docs/preview/features/correlation.md
@@ -103,7 +103,7 @@ public class Startup
             // Configuration on operation parent ID request header (`Request-Id`).
             // ------------------------------------------------------------------
 
-            // Whether to extract the operation parent ID from the incoming request (default: true).
+            // Whether to extract the operation parent ID from the incoming request following W3C Trace-Context standard (default: true).
             // We currently only support the W3C HTTP correlation standard for the `RequestId` ([see more info about this topic](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/HttpCorrelationProtocol.md))
             // More information on operation ID and operation parent ID, see [this documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/app/correlation).
             options.UpstreamService.ExtractFromRequest = false;

--- a/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
+++ b/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.1,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.1,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.2.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.2.0,3.0.0)" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
   </ItemGroup>
 

--- a/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
+++ b/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.2.0,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.2.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.2.1,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.2.1,3.0.0)" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
   </ItemGroup>
 

--- a/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Arcus.Observability.Correlation;
+using GuardNet;
+
+namespace Arcus.WebApi.Logging.Core.Correlation
+{
+    /// <summary>
+    /// Correlation options specific to the upstream services, used in the <see cref="CorrelationInfoOptions"/>.
+    /// </summary>
+    public class CorrelationInfoUpstreamServiceOptions
+    {
+        private string _operationParentIdHeaderName = "Request-Id";
+
+        /// <summary>
+        /// Gets or sets the flag indicating whether or not the upstream service information should be extracted from the <see cref="OperationParentIdHeaderName"/>. 
+        /// </summary>
+        public bool ExtractFromRequest { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the request header name where te operation parent ID is located (default: <c>"Request-Id"</c>).
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
+        public string OperationParentIdHeaderName
+        {
+            get => _operationParentIdHeaderName;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the operation parent ID request header name");
+                _operationParentIdHeaderName = value;
+            }
+        }
+    }
+}

--- a/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
@@ -14,7 +14,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         /// <summary>
         /// Gets or sets the flag indicating whether or not the upstream service information should be extracted from the <see cref="OperationParentIdHeaderName"/>. 
         /// </summary>
-        public bool ExtractFromRequest { get; set; } = true;
+        public bool ExtractFromRequest { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the request header name where te operation parent ID is located (default: <c>"Request-Id"</c>).

--- a/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
@@ -12,7 +12,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         private string _operationParentIdHeaderName = "Request-Id";
 
         /// <summary>
-        /// Gets or sets the flag indicating whether or not the upstream service information should be extracted from the <see cref="OperationParentIdHeaderName"/>. 
+        /// Gets or sets the flag indicating whether or not the upstream service information should be extracted from the <see cref="OperationParentIdHeaderName"/> following the W3C Trace-Context standard. 
         /// </summary>
         public bool ExtractFromRequest { get; set; } = true;
 

--- a/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
@@ -14,7 +14,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         /// <summary>
         /// Gets or sets the flag indicating whether or not the upstream service information should be extracted from the <see cref="OperationParentIdHeaderName"/>. 
         /// </summary>
-        public bool ExtractFromRequest { get; set; } = false;
+        public bool ExtractFromRequest { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the request header name where te operation parent ID is located (default: <c>"Request-Id"</c>).

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelation.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelation.cs
@@ -245,7 +245,7 @@ namespace Arcus.WebApi.Logging.Correlation
             // Ex. Request-Id=|7515DCD2-6340-41A9-AA4F-0E1DD28055B6.
             //     returns: 7515DCD2-6340-41A9-AA4F-0E1DD28055B6
             
-            _logger.LogTrace("Extracting operation ID from operation parent ID '{OperationParentId}' from the upstream service", operationParentId);
+            _logger.LogTrace("Extracting operation ID from operation parent ID '{OperationParentId}' from the upstream service according to W3C Trace-Context standard", operationParentId);
             
             int rootStart;
             if (operationParentId[0] == '|')

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelation.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelation.cs
@@ -241,7 +241,7 @@ namespace Arcus.WebApi.Logging.Correlation
                 return null;
             }
             
-            // Returns the root ID from the '|' to the first '.' if any.
+            // Returns the root ID from the '|' to the first '.' if any, according to W3C Trace-Context standard
             // Ex. Request-Id=|7515DCD2-6340-41A9-AA4F-0E1DD28055B6.
             //     returns: 7515DCD2-6340-41A9-AA4F-0E1DD28055B6
             

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoOptions.cs
@@ -1,0 +1,15 @@
+﻿using Arcus.Observability.Correlation;
+
+namespace Arcus.WebApi.Logging.Core.Correlation
+{
+    /// <summary>
+    ///  Options for handling correlation ID on incoming HTTP requests.
+    /// </summary>
+    public class HttpCorrelationInfoOptions : CorrelationInfoOptions
+    {
+        /// <summary>
+        /// Gets the correlation options specific for the upstream service.
+        /// </summary>
+        public CorrelationInfoUpstreamServiceOptions UpstreamService { get; } = new CorrelationInfoUpstreamServiceOptions();
+    }
+}

--- a/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
+++ b/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
@@ -31,10 +31,10 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.2.0,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="[2.2.0,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.2.0,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.2.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.2.1,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="[2.2.1,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.2.1,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.2.1,3.0.0)" />
   </ItemGroup>
 
    <ItemGroup>

--- a/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
+++ b/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
@@ -31,10 +31,10 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.1,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="[2.0.1,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.1,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.0.1,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.2.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="[2.2.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.2.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.2.0,3.0.0)" />
   </ItemGroup>
 
    <ItemGroup>

--- a/src/Arcus.WebApi.Tests.Integration/Logging/RequestTrackingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/RequestTrackingMiddlewareTests.cs
@@ -998,7 +998,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
                 testSink.DequeueLogEvents()
                         .SelectMany(ev => ev.Properties);
 
-            var eventContexts = properties.Where(prop => prop.Key == ContextProperties.TelemetryContext);
+            var eventContexts = properties.Where(prop => prop.Key == ContextProperties.RequestTracking.RequestLogEntry);
             return eventContexts.Any();
         }
 
@@ -1008,9 +1008,13 @@ namespace Arcus.WebApi.Tests.Integration.Logging
                 testSink.DequeueLogEvents()
                         .SelectMany(ev => ev.Properties);
 
-            var eventContexts = properties.Where(prop => prop.Key == ContextProperties.TelemetryContext);
-            (string key, LogEventPropertyValue eventContext) = Assert.Single(eventContexts);
-            var dictionaryValue = Assert.IsType<DictionaryValue>(eventContext);
+            var logEntries = properties.Where(prop => prop.Key == ContextProperties.RequestTracking.RequestLogEntry);
+            (string key, LogEventPropertyValue logEntry) = Assert.Single(logEntries);
+            var requestLogEntry = Assert.IsType<StructureValue>(logEntry);
+            
+            LogEventProperty eventContext = 
+                Assert.Single(requestLogEntry.Properties, property => property.Name == ContextProperties.TelemetryContext);
+            var dictionaryValue = Assert.IsType<DictionaryValue>(eventContext.Value);
 
             return dictionaryValue.Elements.ToDictionary(
                 item => item.Key.ToStringValue(), 

--- a/src/Arcus.WebApi.Tests.Integration/Logging/TelemetryCorrelationTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/TelemetryCorrelationTests.cs
@@ -11,13 +11,17 @@ using Arcus.WebApi.Tests.Integration.Logging.Controllers;
 using Arcus.WebApi.Tests.Integration.Logging.Fixture;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Serilog;
 using Serilog.Configuration;
+using Serilog.Core;
 using Serilog.Events;
 using Xunit;
 using Xunit.Abstractions;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+#pragma warning disable 618 // disable obsolete warnings (for now) regarding the '.AddHttpCorrelation' extension.
 
 namespace Arcus.WebApi.Tests.Integration.Logging
 {

--- a/src/Arcus.WebApi.Tests.Unit/Arcus.WebApi.Tests.Unit.csproj
+++ b/src/Arcus.WebApi.Tests.Unit/Arcus.WebApi.Tests.Unit.csproj
@@ -29,4 +29,7 @@
     <ProjectReference Include="..\Arcus.WebApi.Security\Arcus.WebApi.Security.csproj" />
     <ProjectReference Include="..\Arcus.WebApi.Tests.Core\Arcus.WebApi.Tests.Core.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Logging\Fixture\" />
+  </ItemGroup>
 </Project>

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationTests.cs
@@ -1,11 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 using Arcus.Observability.Correlation;
 using Arcus.WebApi.Logging.Core.Correlation;
 using Arcus.WebApi.Logging.Correlation;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;
 
@@ -13,6 +16,108 @@ namespace Arcus.WebApi.Tests.Unit.Logging
 {
     public class HttpCorrelationTests
     {
+        [Theory]
+        [InlineData("|", ".")]
+        [InlineData("", ".")]
+        [InlineData("|", "")]
+        [InlineData("", "")]
+        [InlineData("|", ".other-id.")]
+        [InlineData("|", ".other-id")]
+        public void TryCorrelate_WithCorrectOperationParentId_SetsOperationId(string prefix, string postfix)
+        {
+            // Arrange
+            var operationId = $"operation-{Guid.NewGuid()}";
+            string operationParentId = prefix + operationId + postfix;
+            var headers = new Dictionary<string, StringValues>
+            {
+                ["Request-Id"] = operationParentId
+            };
+
+            HttpContext context = CreateHttpContext(headers);
+            var contextAccessor = new Mock<IHttpContextAccessor>();
+            contextAccessor.Setup(accessor => accessor.HttpContext).Returns(context);
+            var correlationAccessor = new DefaultCorrelationInfoAccessor();
+            
+            var options = Options.Create(new HttpCorrelationInfoOptions());
+            var correlation = new HttpCorrelation(options, contextAccessor.Object, correlationAccessor, NullLogger<HttpCorrelation>.Instance);
+            
+            // Act
+            bool isCorrelated = correlation.TryHttpCorrelate(out string errorMessage);
+            
+            // Assert
+            Assert.True(isCorrelated);
+            Assert.Null(errorMessage);
+            var correlationInfo = context.Features.Get<CorrelationInfo>();
+            Assert.Equal(operationId, correlationInfo.OperationId);
+            Assert.Equal(operationParentId, correlationInfo.OperationParentId);
+        }
+
+        [Theory]
+        [InlineData("||", "")]
+        [InlineData("|", "..")]
+        [InlineData(".", "|")]
+        [InlineData("|", ".other-id..")]
+        public void TryCorrelate_WithIncorrectOperationParentId_DoesntSetOperationId(string prefix, string postfix)
+        {
+            // Arrange
+            var operationId = $"operation-{Guid.NewGuid()}";
+            var headers = new Dictionary<string, StringValues>
+            {
+                ["Request-Id"] = prefix + operationId + postfix
+            };
+            
+            HttpContext context = CreateHttpContext(headers);
+            var contextAccessor = new Mock<IHttpContextAccessor>();
+            contextAccessor.Setup(accessor => accessor.HttpContext).Returns(context);
+            var correlationAccessor = new DefaultCorrelationInfoAccessor();
+            
+            var options = Options.Create(new HttpCorrelationInfoOptions());
+            var correlation = new HttpCorrelation(options, contextAccessor.Object, correlationAccessor, NullLogger<HttpCorrelation>.Instance);
+            
+            // Act / Assert
+            Assert.False(correlation.TryHttpCorrelate(out string errorMessage));
+            Assert.NotNull(errorMessage);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void TryCorrelate_WithBlankOperationParentId_DoesntSetOperationId(string operationParentId)
+        {
+            // Arrange
+            var operationId = $"operation-{Guid.NewGuid()}";
+            var headers = new Dictionary<string, StringValues>
+            {
+                ["Request-Id"] = operationParentId
+            };
+            
+            HttpContext context = CreateHttpContext(headers);
+            var contextAccessor = new Mock<IHttpContextAccessor>();
+            contextAccessor.Setup(accessor => accessor.HttpContext).Returns(context);
+            var correlationAccessor = new DefaultCorrelationInfoAccessor();
+            
+            var options = Options.Create(new HttpCorrelationInfoOptions());
+            var correlation = new HttpCorrelation(options, contextAccessor.Object, correlationAccessor, NullLogger<HttpCorrelation>.Instance);
+            
+            // Act / Assert
+            Assert.False(correlation.TryHttpCorrelate(out string errorMessage));
+            Assert.NotNull(errorMessage);
+        }
+
+        private static HttpContext CreateHttpContext(Dictionary<string, StringValues> requestHeaders)
+        {
+            var request = new Mock<HttpRequest>();
+            request.Setup(r => r.Headers).Returns(new HeaderDictionary(requestHeaders));
+            var response = new Mock<HttpResponse>();
+            response.Setup(r => r.Headers).Returns(new HeaderDictionary());
+            var context = new Mock<HttpContext>();
+            context.Setup(c => c.Request).Returns(request.Object);
+            context.Setup(c => c.Response).Returns(response.Object);
+            var features = new FeatureCollection();
+            context.Setup(c => c.Features).Returns(features);
+
+            return context.Object;
+        }
+        
         [Fact]
         public void Correlation_GetCorrelationInfo_UsesStubbedCorrelation()
         {

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationTests.cs
@@ -38,7 +38,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             contextAccessor.Setup(accessor => accessor.HttpContext).Returns(context);
             var correlationAccessor = new DefaultCorrelationInfoAccessor();
             
-            var options = Options.Create(new HttpCorrelationInfoOptions());
+            var options = Options.Create(new HttpCorrelationInfoOptions { UpstreamService = { ExtractFromRequest = true} });
             var correlation = new HttpCorrelation(options, contextAccessor.Object, correlationAccessor, NullLogger<HttpCorrelation>.Instance);
             
             // Act
@@ -71,7 +71,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             contextAccessor.Setup(accessor => accessor.HttpContext).Returns(context);
             var correlationAccessor = new DefaultCorrelationInfoAccessor();
             
-            var options = Options.Create(new HttpCorrelationInfoOptions());
+            var options = Options.Create(new HttpCorrelationInfoOptions { UpstreamService = { ExtractFromRequest = true} });
             var correlation = new HttpCorrelation(options, contextAccessor.Object, correlationAccessor, NullLogger<HttpCorrelation>.Instance);
             
             // Act / Assert
@@ -95,7 +95,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             contextAccessor.Setup(accessor => accessor.HttpContext).Returns(context);
             var correlationAccessor = new DefaultCorrelationInfoAccessor();
             
-            var options = Options.Create(new HttpCorrelationInfoOptions());
+            var options = Options.Create(new HttpCorrelationInfoOptions { UpstreamService = { ExtractFromRequest = true} });
             var correlation = new HttpCorrelation(options, contextAccessor.Object, correlationAccessor, NullLogger<HttpCorrelation>.Instance);
             
             // Act / Assert

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Arcus.Observability.Correlation;
+using Arcus.WebApi.Logging.Core.Correlation;
+using Arcus.WebApi.Logging.Correlation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Logging
+{
+    public class HttpCorrelationTests
+    {
+        [Fact]
+        public void Correlation_GetCorrelationInfo_UsesStubbedCorrelation()
+        {
+            // Arrange
+            var expected = new CorrelationInfo($"operation-{Guid.NewGuid()}", $"transaction-{Guid.NewGuid()}");
+            var correlationAccessor = new DefaultCorrelationInfoAccessor();
+            correlationAccessor.SetCorrelationInfo(expected);
+
+            IOptions<HttpCorrelationInfoOptions> options = Options.Create(new HttpCorrelationInfoOptions());
+            IHttpContextAccessor contextAccessor = Mock.Of<IHttpContextAccessor>();
+            ILogger<HttpCorrelation> logger = NullLogger<HttpCorrelation>.Instance;
+            var correlation = new HttpCorrelation(options, contextAccessor, correlationAccessor, logger);
+
+            // Act
+            CorrelationInfo actual = correlation.GetCorrelationInfo();
+            
+            // Assert
+            Assert.Same(expected, actual);
+        }
+
+        [Fact]
+        public void Correlation_SetCorrelationInfo_SetsNewCorrelation()
+        {
+            // Arrange
+            var original = new CorrelationInfo($"operation-{Guid.NewGuid()}", $"transaction-{Guid.NewGuid()}");
+            var correlationAccessor = new DefaultCorrelationInfoAccessor();
+            correlationAccessor.SetCorrelationInfo(original);
+
+            IOptions<HttpCorrelationInfoOptions> options = Options.Create(new HttpCorrelationInfoOptions());
+            IHttpContextAccessor contextAccessor = Mock.Of<IHttpContextAccessor>();
+            ILogger<HttpCorrelation> logger = NullLogger<HttpCorrelation>.Instance;
+            var correlation = new HttpCorrelation(options, contextAccessor, correlationAccessor, logger);
+
+            var expected = new CorrelationInfo($"operation-{Guid.NewGuid()}", $"transaction-{Guid.NewGuid()}");
+            
+            // Act
+            correlation.SetCorrelationInfo(expected);
+            
+            // Assert
+            CorrelationInfo actual = correlation.GetCorrelationInfo();
+            Assert.NotSame(original, actual);
+            Assert.Same(expected, actual);
+        }
+        
+        [Fact]
+        public void Create_WithoutOptions_Fails()
+        {
+            // Arrange
+            ICorrelationInfoAccessor correlationAccessor = new DefaultCorrelationInfoAccessor();
+            IHttpContextAccessor contextAccessor = Mock.Of<IHttpContextAccessor>();
+            ILogger<HttpCorrelation> logger = NullLogger<HttpCorrelation>.Instance;
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                new HttpCorrelation(options: null, httpContextAccessor: contextAccessor, correlationInfoAccessor: correlationAccessor, logger: logger));
+        }
+
+        [Fact]
+        public void Create_WithoutHttpContextAccessor_Fails()
+        {
+            // Arrange
+            IOptions<HttpCorrelationInfoOptions> options = Options.Create(new HttpCorrelationInfoOptions());
+            ICorrelationInfoAccessor correlationAccessor = new DefaultCorrelationInfoAccessor();
+            ILogger<HttpCorrelation> logger = NullLogger<HttpCorrelation>.Instance;
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                new HttpCorrelation(options, httpContextAccessor: null, correlationInfoAccessor: correlationAccessor, logger: logger));
+        }
+
+        [Fact]
+        public void Create_WithoutCorrelationInfoAccessor_Fails()
+        {
+            // Arrange
+            IOptions<HttpCorrelationInfoOptions> options = Options.Create(new HttpCorrelationInfoOptions());
+            IHttpContextAccessor contextAccessor = Mock.Of<IHttpContextAccessor>();
+            ILogger<HttpCorrelation> logger = NullLogger<HttpCorrelation>.Instance;
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                new HttpCorrelation(options, contextAccessor, correlationInfoAccessor: null, logger: logger));
+        }
+    }
+}


### PR DESCRIPTION
Adding an operation parent ID functionality to the correlation middleware to extract based on configured options the combination 'operation parent ID/operation ID' from the request header, and registering it as the scoped correlation info of the request.

Relates to https://github.com/arcus-azure/arcus.webapi/issues/233