### PR TITLE
feat: add mvc json formatting extensions

### DIFF
--- a/docs/preview/features/correlation.md
+++ b/docs/preview/features/correlation.md
@@ -1,0 +1,206 @@
+---
+title: "Correlate between HTTP requests/responses via ASP.NET Core middleware"
+layout: default
+---
+
+# Correlation Between HTTP Requests
+
+The `Arcus.WebApi.Correlation` library provides a way to add correlation between HTTP requests. 
+
+This correlation is based the `RequestId` and `X-Transaction-ID` HTTP request/response headers, however, you can fully configure different headers in case you need to.
+
+## How This Works
+
+When an application is configured to use the default configuration of the correlation, each HTTP response will get an extra header called `RequestId` containing an unique identifier to distinguish between requests/responses.
+
+The `X-Transaction-ID` can be overriden by the request, meaning: if the HTTP request already contains a `X-Transaction-ID` header, the same header+value will be used in the HTTP response.
+
+Additional [configuration](#configuration) is available to tweak this functionality.
+
+## Installation
+
+This feature requires to install our NuGet package:
+
+```shell
+PM > Install-Package Arcus.WebApi.Logging
+```
+
+## Usage
+
+To make sure the correlation is added to the HTTP response, following additions have to be made in the `.ConfigureServices` and `Configure` methods:
+
+```csharp
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddHttpCorrelation();
+    }
+
+    public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+    {
+        app.UseHttpCorrelation();
+
+        app.UseMvc();
+    }
+}
+```
+
+Note: because the correlation is based on <span>ASP.NET</span> Core middleware, it's recommended to place it before the `.UseMvc` call.
+
+## Configuration
+
+Some extra options are available to alter the functionality of the correlation:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddHttpCorrelation(options =>
+        {
+            // Configuration on the transaction ID (`X-Transaction-ID`) request/response header.
+            // ---------------------------------------------------------------------------------
+
+            // Whether the transaction ID can be specified in the request, and will be used throughout the request handling.
+            // The request will return early when the `.AllowInRequest` is set to `false` and the request does contain the header (default: true).
+            options.Transaction.AllowInRequest = true;
+
+            // Whether or not the transaction ID should be generated when there isn't any transaction ID found in the request.
+            // When the `.GenerateWhenNotSpecified` is set to `false` and the request doesn't contain the header, no value will be available for the transaction ID; 
+            // otherwise a GUID will be generated (default: true).
+            options.Transaction.GenerateWhenNotSpecified = true;
+
+            // Whether to include the transaction ID in the response (default: true).
+            options.Transaction.IncludeInResponse = true;
+
+            // The header to look for in the HTTP request, and will be set in the HTTP response (default: X-Transaction-ID).
+            options.Transaction.HeaderName = "X-Transaction-ID";
+
+            // The function that will generate the transaction ID, when the `.GenerateWhenNotSpecified` is set to `false` and the request doesn't contain the header.
+            // (default: new `Guid`).
+            options.Transaction.GenerateId = () => $"Transaction-{Guid.NewGuid()}";
+
+            // Configuration on the operation ID (`RequestId`) response header.
+            // ----------------------------------------------------------------
+
+            // Whether to include the operation ID in the response (default: true).
+            options.Operation.IncludeInResponse = true;
+
+            // The header that will contain the operation ID in the HTTP response (default: RequestId).
+            options.Operation.HeaderName = "RequestId";
+
+            // The function that will generate the operation ID header value.
+            // (default: new `Guid`).
+            options.Operation.GenerateId = () => $"Operation-{Guid.NewGuid()}";
+
+            // Configuration on operation parent ID request header (`Request-Id`).
+            // ------------------------------------------------------------------
+
+            // Whether to extract the operation parent ID from the incoming request following W3C Trace-Context standard (default: true).
+            // More information on operation ID and operation parent ID, see [this documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/app/correlation).
+            options.UpstreamService.ExtractFromRequest = false;
+
+            // The header that will contain the operation parent ID in the HTTP request (default: Request-Id).
+            options.UpstreamService.OperationParentIdHeaderName = "x-request-id";
+        });
+    }
+}
+```
+
+## Logging
+
+As an additional feature, we provide an extension to use the HTTP correlation directly in a [Serilog](https://serilog.net/) configuration:
+
+```csharp
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Serilog;
+
+public class Startup
+{
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        app.UseHttpCorrelation();
+        
+        Log.Logger = new LoggerConfiguration()
+            .Enrich.WithHttpCorrelationInfo()
+            .WriteTo.Console()
+            .CreateLogger();
+    }
+}
+```
+
+## Using secret store within Azure Functions
+
+### Installation
+
+For this feature, the following package needs to be installed:
+
+```shell
+PM > Install-Package Arcus.WebApi.Logging.AzureFunctions
+```
+
+### Usage
+
+To make sure the correlation is added to the HTTP response, following additions have to be made in the `.Configure` methods of the function's startup:
+
+```csharp
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: FunctionsStartup(typeof(Startup))]
+
+namespace MyHttpAzureFunction
+{
+    public class Startup : FunctionsStartup
+    {
+        public override void Configure(IFunctionsHostBuilder builder)
+        {
+            builder.AddHttpCorrelation();
+        }
+    }
+}
+```
+
+When this addition is added, you can use the `HttpCorrelation` inside your function to call the correlation functionality and use the `ICorrelationInfoAccessor` (like before) to have access to the `CorrelationInfo` of the HTTP request.
+
+```csharp
+using Arcus.WebApi.Logging.Correlation;
+
+public class MyHttpFunction
+{
+    private readonly HttpCorrelation _httpCorrelation;
+
+    public MyHttpFunction(HttpCorrelation httpCorrelation)
+    {
+        _httpCorrelation = httpCorrelation;
+    }
+
+    [FunctionName("HTTP-Correlation-Example")]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req,
+        ILogger log)
+    {
+        if (_httpCorrelation.TryHttpCorrelate(out string errorMessage))
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            // Easily access correlation information in your application
+            CorrelationInfo correlationInfo = _httpCorrelation.GetCorrelationInfo();
+            return new OkObjectResult("This HTTP triggered function executed successfully.");
+        }
+
+        return new BadRequestObjectResult(errorMessage);
+    }
+```
+
+> Note that the `HttpCorrelation` already has the registered `ICorrelationInfoAccessor` embedded but nothing stops you from injecting the `ICorrelationInfoAccessor` yourself and use that one. Behind the scenes, both instances will be the same.
+
+[&larr; back](/)

--- a/docs/preview/features/hosting/formatting.md
+++ b/docs/preview/features/hosting/formatting.md
@@ -1,0 +1,55 @@
+---
+title: "JSON formatting"
+layout: default
+---
+
+# JSON formatting
+The `Arcus.WebApi.Hosting` library provides a way to restrict and configure the JSON input and output formatting of your application.
+This allows for a easier and more secure formatting when working with JSON types.
+
+## Installation
+These features require to install our NuGet package:
+
+```shell
+PM > Install-Package Arcus.WebApi.Hosting
+```
+
+## Restricting JSON format
+We have provided an extension that will allow you to restrict your input and output formatting to only JSON formatting. This means that all other incoming content will will result in `UnsupportedMediaType` failures and outcoming content will fail to serialize back to the sender. With this functionality, you'll be sure that you only have to deal with JSON.
+
+Following example shows you where you can configure this:
+
+```csharp
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddMvc(mvcOptions => mvcOptions.OnlyAllowJsonFormatting());
+    }
+}
+```
+
+## Configure JSON format
+We have provided an extension that will allow you to configure the input and output JSON formatting in one go. This means that any options you configure in this extension will automatically apply to the incoming model as well as the outgoing model. This makes the JSON formatting more streamlined and easier to maintain.
+
+Following example shows you where you can configure these options:
+
+```csharp
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddMvc(mvcOptions => mvcOptions.ConfigureJsonFormatting(jsonOptions =>
+        {
+            jsonOptions.IgnoreNullValues = true;
+            jsonOptions.Converters.Add(new JsonStringEnumConverter());
+        }));
+    }
+}

--- a/docs/preview/features/openapi/security-definitions.md
+++ b/docs/preview/features/openapi/security-definitions.md
@@ -1,0 +1,122 @@
+---
+title: "Adding security information to OpenAPI documentation"
+layout: default
+---
+
+# Adding OAuth security definition to API operations
+
+When an API is secured via OAuth, [Shared Access Key authentication](../../features/security/auth/shared-access-key), [Certificate authentication](../../features/security/auth/certificate), it is helpful if the Open API documentation makes this clear via a security scheme and the API operations that require authorization automatically inform the consumer that it is possible that a 401 Unauthorized or 403 Forbidden response is returned.
+
+These `IOperationFilter`'s that are part of this package exposes this functionality:
+- [`CertificateAuthenticationOperationFilter`](#certificate)
+- [`OAuthAuthorizeOperationFilter`](#oauth)
+- [`SharedAccessKeyAuthenticationOperationFilter`](#sharedaccesskey)
+
+## Installation
+
+This feature requires to install our NuGet package
+
+```shell
+PM > Install-Package Arcus.WebApi.OpenApi.Extensions
+```
+
+## Usage
+
+### Certificate
+
+To indicate that an API is protected by [Certificate authentication](../../features/security/auth/certificate), you need to add `CertificateAuthenticationOperationFilter` as an `IOperationFilter` when configuring Swashbuckles Swagger generation:
+
+```csharp
+using Arcus.WebApi.OpenApi.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddSwaggerGen(setupAction =>
+        {
+            setupAction.SwaggerDoc("v1", new OpenApiInfo { Title = "My API v1", Version = "v1" });
+
+            string securitySchemaName = "my-certificate";
+            setupAction.AddSecurityDefinition(securitySchemaName, new OpenApiSecurityScheme
+            {
+                Type = SecuritySchemeType.ApiKey
+             });
+
+             setupAction.OperationFilter<CertificateAuthenticationOperationFilter>(securitySchemaName);
+        });
+    }
+}
+```
+
+> Note: the `CertificateAuthenticationOperationFilter` has by default `"certificate"` as `securitySchemaName`.
+
+### OAuth
+
+To indicate that an API is protected by OAuth, you need to add `OAuthAuthorizeOperationFilter` as an `IOperationFilter` when configuring Swashbuckles Swagger generation:
+
+```csharp
+using Arcus.WebApi.OpenApi.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddSwaggerGen(setupAction =>
+        {
+            setupAction.SwaggerDoc("v1", new Info { Title = "My API v1", Version = "v1" });
+
+            string securitySchemaName = "my-oauth2";
+            setupAction.AddSecurityDefinition(securitySchemaName, new OAuth2Scheme
+            {
+                Flow = "implicit",
+                AuthorizationUrl = $"{authorityUrl}connect/authorize",
+                Scopes = scopes
+            });
+
+            setupAction.OperationFilter<OAuthAuthorizeOperationFilter>(securitySchemaName, new object[] { new[] { "myApiScope1", "myApiScope2" } });
+        });
+    }
+}
+```
+
+> Note: the `OAuthAuthorizeOperationFilter` has by default `"oauth2"` as `securitySchemaName`.
+
+### Shared Access Key
+
+To indicate that an API is protected by [Shared Access Key authentication](../../features/security/auth/shared-access-key), you need to add `SharedAccessKeyAuthenticationOperationFilter` as an `IOperationFilter` when configuring Swashbuckles Swagger generation:
+
+```csharp
+using Arcus.WebApi.OpenApi.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddSwaggerGen(setupAction =>
+        {
+            setupAction.SwaggerDoc("v1", new new OpenApiInfo { Title = "My API v1", Version = "v1" });
+
+            string securitySchemaName = "my-sharedaccesskey";
+            setupAction.AddSecurityDefinition(securitySchemaName, new OpenApiSecurityScheme
+            {
+                Name = "X-API-Key",
+                Type = SecuritySchemeType.ApiKey,
+                In = ParameterLocation.Header
+             });
+
+             setupAction.OperationFilter<SharedAccessKeyAuthenticationOperationFilter>(securitySchemaName);
+        });
+    }
+}
+```
+
+> Note: the `SharedAccessKeyAuthenticationOperationFilter` has by default `"sharedaccesskey"` as `securitySchemaName`.
+
+[&larr; back](/)

--- a/docs/preview/features/telemetry.md
+++ b/docs/preview/features/telemetry.md
@@ -1,0 +1,40 @@
+---
+title: "Telemetry Enrichment"
+layout: default
+---
+
+# Telemetry Enrichment
+
+## Serilog Correlation Enrichment
+
+The `Arcus.WebApi.Telemetry.Serilog` library provides a [Serilog enricher](https://github.com/serilog/serilog/wiki/Enrichment) 
+that adds the correlation information of the current request to the log event as a log property called `TransactionId` and `OperationId`.
+
+**Example**
+
+- `TransactionId`: `A5E90591-ADB0-4A56-818A-AC5C02FBFF5F`
+- `OperationId`: `79BB196A-B0CC-4F5C-B48A-AB87850346AF`
+
+**Usage**
+
+The enricher requires access to the application services so it can get the correlation information.
+Following example shows how the Serilog logger is configured in the `Startup.cs` file.
+
+```csharp
+using Arcus.Observability.Correlation;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Serilog;
+
+public class Startup
+{
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        Log.Logger = new LoggerConfiguration()
+            .Enrich.With(new CorrelationInfoEnricher(app.ApplicationServices))
+            .CreateLogger();
+    }
+}
+```
+
+[&larr; back](/)

--- a/docs/preview/index.md
+++ b/docs/preview/index.md
@@ -30,6 +30,8 @@ For more granular packages we recommend reading the documentation.
         - [JWT authorization](features/security/auth/jwt)
 - **Correlation**
     - [Provide request and/or transaction correlation ids](features/correlation)
+- **Hosting**
+    - [JSON formatting](features/hosting/formatting)
 - **Telemetry**
     - [Enrich with telemetry information](features/telemetry)
 - **Logging**

--- a/src/Arcus.WebApi.Hosting/Arcus.WebApi.Hosting.csproj
+++ b/src/Arcus.WebApi.Hosting/Arcus.WebApi.Hosting.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Authors>Arcus</Authors>
+    <Company>Arcus</Company>
+    <RepositoryType>Git</RepositoryType>
+    <PackageTags>Azure;WebAPI;App Services;Web App;Web;API</PackageTags>
+    <Description>Provides capabilities for Web API hosting running in Azure.</Description>
+    <Copyright>Copyright (c) Arcus</Copyright>
+    <PackageLicenseUrl>https://github.com/arcus-azure/arcus.webapi/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/arcus-azure/arcus.webapi</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/arcus-azure/arcus.webapi</RepositoryUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5125;NU5048</NoWarn>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Guard.Net" Version="1.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Arcus.WebApi.Hosting/Formatting/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Hosting/Formatting/Extensions/MvcOptionsExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq;
+using System.Text.Json;
+using GuardNet;
+using Microsoft.AspNetCore.Mvc.Formatters;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.AspNetCore.Mvc
+{
+    /// <summary>
+    /// Extensions on reusable JSON formatting configurations.
+    /// </summary>
+    public static class MvcOptionsExtensions
+    {
+        /// <summary>
+        /// Restrict the MVC formatting to only allow JSON formatting during receiving and sending.
+        /// </summary>
+        /// <param name="options">The MVC options where the input and output formatting will be restricted to JSON formatting.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        public static MvcOptions OnlyAllowJsonFormatting(this MvcOptions options)
+        {
+            Guard.NotNull(options, nameof(options), "Requires MVC options to restrict the formatting to only JSON formatting");
+            
+            IInputFormatter[] allButJsonInputFormatters = 
+                options.InputFormatters.Where(formatter => !(formatter is SystemTextJsonInputFormatter))
+                       .ToArray();
+
+            foreach (IInputFormatter inputFormatter in allButJsonInputFormatters)
+            {
+                options.InputFormatters.Remove(inputFormatter);
+            }
+
+            // Removing for text/plain, see https://docs.microsoft.com/en-us/aspnet/core/web-api/advanced/formatting?view=aspnetcore-3.0#special-case-formatters
+            options.OutputFormatters.RemoveType<StringOutputFormatter>();
+
+            return options;
+        }
+        
+        /// <summary>
+        /// Configure the MVC JSON formatters for both receiving and sending.
+        /// </summary>
+        /// <param name="options">The MVC options where the JSON formatters will be configured.</param>
+        /// <param name="configureOptions">The function to configure the input and output JSON formatters in the MVC <paramref name="options"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> or <paramref name="configureOptions"/> is <c>null</c>.</exception>
+        public static MvcOptions ConfigureJsonFormatting(this MvcOptions options, Action<JsonSerializerOptions> configureOptions)
+        {
+            Guard.NotNull(options, nameof(options), "Requires MVC options to configure the JSON formatters");
+            Guard.NotNull(configureOptions, nameof(configureOptions), "Requires a function to configure the JSON formatters in the MVC options");
+            
+            SystemTextJsonInputFormatter[] onlyJsonInputFormatters = 
+                options.InputFormatters.OfType<SystemTextJsonInputFormatter>()
+                       .ToArray();
+            
+            foreach (SystemTextJsonInputFormatter inputFormatter in onlyJsonInputFormatters)
+            {
+                configureOptions(inputFormatter.SerializerOptions);
+            }
+
+            SystemTextJsonOutputFormatter[] onlyJsonOutputFormatters = 
+                options.OutputFormatters.OfType<SystemTextJsonOutputFormatter>()
+                       .ToArray();
+            
+            foreach (SystemTextJsonOutputFormatter outputFormatter in onlyJsonOutputFormatters)
+            {
+                configureOptions(outputFormatter.SerializerOptions);
+            }
+
+            return options;
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
+++ b/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Arcus.WebApi.Hosting\Arcus.WebApi.Hosting.csproj" />
     <ProjectReference Include="..\Arcus.WebApi.Logging.Core\Arcus.WebApi.Logging.Core.csproj" />
     <ProjectReference Include="..\Arcus.WebApi.Logging\Arcus.WebApi.Logging.csproj" />
     <ProjectReference Include="..\Arcus.WebApi.OpenApi.Extensions\Arcus.WebApi.OpenApi.Extensions.csproj" />

--- a/src/Arcus.WebApi.Tests.Integration/Fixture/HttpRequestBuilder.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Fixture/HttpRequestBuilder.cs
@@ -86,7 +86,21 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         public HttpRequestBuilder WithJsonBody(string json)
         {
             Guard.NotNullOrWhitespace(json, nameof(json), "Requires non-blank JSON request body to add the content to the HTTP request builder instance");
-            _createContent = () => new StringContent($"\"{json}\"", Encoding.UTF8, "application/json");
+            _createContent = () => new StringContent(json, Encoding.UTF8, "application/json");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a plain text body to the HTTP request.
+        /// </summary>
+        /// <remarks>This is a non-accumulative method, multiple calls will override the request body, not append to it.</remarks>
+        /// <param name="text">The plain text request body.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="text"/> is blank.</exception>
+        public HttpRequestBuilder WithTextBody(string text)
+        {
+            Guard.NotNullOrWhitespace(text, nameof(text), "Requires a non-blank text input for the request body");
+            _createContent = () => new StringContent(text, Encoding.UTF8, "text/plain");
 
             return this;
         }

--- a/src/Arcus.WebApi.Tests.Integration/Hosting/Formatting/Controllers/CountryController.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Hosting/Formatting/Controllers/CountryController.cs
@@ -1,0 +1,26 @@
+﻿using Arcus.WebApi.Tests.Integration.Hosting.Formatting.Fixture;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Integration.Hosting.Formatting.Controllers
+{
+    [ApiController]
+    public class CountryController : ControllerBase
+    {
+        public const string GetPlainTextRoute = "api/v1/country/text",
+                            GetJsonRoute = "api/v1/country/json";
+        
+        [HttpGet]
+        [Route(GetPlainTextRoute)]
+        public IActionResult GetPlainText([FromBody] string country)
+        {
+            return Ok(country);
+        }
+
+        [HttpGet]
+        [Route(GetJsonRoute)]
+        public IActionResult GetJson([FromBody] Country country)
+        {
+            return Ok(country);
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Hosting/Formatting/Fixture/Country.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Hosting/Formatting/Fixture/Country.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Arcus.WebApi.Tests.Integration.Hosting.Formatting.Fixture
+{
+    public class Country
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("code")]
+        public CountryCode Code { get; set; }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Hosting/Formatting/Fixture/CountryCode.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Hosting/Formatting/Fixture/CountryCode.cs
@@ -1,0 +1,4 @@
+﻿namespace Arcus.WebApi.Tests.Integration.Hosting.Formatting.Fixture
+{
+    public enum CountryCode { BE, NL, FR, UK, PT, CH, LU, MT }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Hosting/Formatting/Fixture/PlainTextInputFormatter.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Hosting/Formatting/Fixture/PlainTextInputFormatter.cs
@@ -1,0 +1,45 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Formatters;
+
+namespace Arcus.WebApi.Tests.Integration.Hosting.Formatting.Fixture
+{
+    /// <summary>
+    /// Represents an <see cref="IInputFormatter"/> that can parse the incoming HTTP request's body as plain text.
+    /// </summary>
+    public class PlainTextInputFormatter : InputFormatter
+    {
+        private const string PlainTextContentType = "text/plain";
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlainTextInputFormatter" /> class.
+        /// </summary>
+        public PlainTextInputFormatter()
+        {
+            SupportedMediaTypes.Add(PlainTextContentType);
+        }
+
+        /// <inheritdoc />
+        public override bool CanRead(InputFormatterContext context)
+        {
+            string contentType = context.HttpContext.Request.ContentType;
+            return contentType?.StartsWith(PlainTextContentType) == true;
+        }
+
+        /// <summary>
+        /// Reads an object from the request body.
+        /// </summary>
+        /// <param name="context">The <see cref="T:Microsoft.AspNetCore.Mvc.Formatters.InputFormatterContext" />.</param>
+        /// <returns>A <see cref="T:System.Threading.Tasks.Task" /> that on completion deserializes the request body.</returns>
+        public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+            HttpRequest request = context.HttpContext.Request;
+            using (var reader = new StreamReader(request.Body))
+            {
+                string content = await reader.ReadToEndAsync();
+                return InputFormatterResult.Success(content);
+            }
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Hosting/Formatting/MvcOptionsExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Hosting/Formatting/MvcOptionsExtensionsTests.cs
@@ -1,0 +1,196 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Arcus.Testing.Logging;
+using Arcus.WebApi.Tests.Integration.Fixture;
+using Arcus.WebApi.Tests.Integration.Hosting.Formatting.Controllers;
+using Arcus.WebApi.Tests.Integration.Hosting.Formatting.Fixture;
+using Bogus;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+using JsonSerializer = System.Text.Json.JsonSerializer;
+
+namespace Arcus.WebApi.Tests.Integration.Hosting.Formatting
+{
+    [Collection("Integration")]
+    public class MvcOptionsExtensionsTests
+    {
+        private readonly ILogger _logger;
+
+        private static readonly Faker BogusGenerator = new Faker();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MvcOptionsExtensionsTests" /> class.
+        /// </summary>
+        public MvcOptionsExtensionsTests(ITestOutputHelper outputWriter)
+        {
+            _logger = new XunitTestLogger(outputWriter);
+        }
+
+        [Fact]
+        public async Task IncomingText_WithoutOnlyAllowJsonFormatting_Succeeds()
+        {
+            // Arrange
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services => services.AddMvc(opt =>
+                {
+                    opt.InputFormatters.Add(new PlainTextInputFormatter());
+                }));
+
+            string sentence = BogusGenerator.Lorem.Sentence();
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                var request = HttpRequestBuilder
+                    .Get(EchoController.GetPlainTextRoute)
+                    .WithTextBody(sentence);
+                
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+                    string actual = await response.Content.ReadAsStringAsync();
+                    Assert.Equal(sentence, actual);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task IncomingText_WithOnlyAllowJsonFormatting_Fails()
+        {
+            // Arrange
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services => services.AddMvc(opt =>
+                {
+                    opt.InputFormatters.Add(new PlainTextInputFormatter());
+                    opt.OnlyAllowJsonFormatting();
+                }));
+
+            string sentence = BogusGenerator.Lorem.Sentence();
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                var request = HttpRequestBuilder
+                    .Get(EchoController.GetPlainTextRoute)
+                    .WithTextBody(sentence);
+                
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task IncomingJson_WithOnlyAllowJsonFormatting_Succeeds()
+        {
+            // Arrange
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services => services.AddMvc(opt =>
+                {
+                    opt.InputFormatters.Add(new PlainTextInputFormatter());
+                    opt.OnlyAllowJsonFormatting();
+                }));
+            
+            var country = new Country
+            {
+                Name = BogusGenerator.Address.Country(),
+                Code = BogusGenerator.Random.Enum<CountryCode>()
+            };
+
+            string json = JsonSerializer.Serialize(country);
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                var request = HttpRequestBuilder
+                    .Get(EchoController.GetJsonRoute)
+                    .WithJsonBody(json);
+                
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
+                    string content = await response.Content.ReadAsStringAsync();
+                    Assert.Equal(json, content);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task IncomingModel_WithoutConfigureJsonFormattingOnEnums_SerializesAsIntegers()
+        {
+            // Arrange
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services => services.AddMvc(mvcOptions =>
+                {
+                    mvcOptions.ConfigureJsonFormatting(jsonOptions => { });
+                }));
+
+            var country = new Country
+            {
+                Name = BogusGenerator.Address.Country(),
+                Code = BogusGenerator.Random.Enum<CountryCode>()
+            };
+
+            string json = JsonSerializer.Serialize(country);
+            
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                var request = HttpRequestBuilder
+                    .Get(EchoController.GetJsonRoute)
+                    .WithJsonBody(json);
+                
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    string actual = await response.Content.ReadAsStringAsync();
+                    Assert.Contains($"{(int)country.Code}", actual);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task IncomingModel_WithConfigureJsonFormattingOnEnums_SerializeAsStrings()
+        {
+            // Arrange
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services => services.AddMvc(mvcOptions =>
+                {
+                    mvcOptions.ConfigureJsonFormatting(jsonOptions => jsonOptions.Converters.Add(new JsonStringEnumConverter()));
+                }));
+
+            var country = new Country
+            {
+                Name = BogusGenerator.Address.Country(),
+                Code = BogusGenerator.Random.Enum<CountryCode>()
+            };
+
+            string json = JsonSerializer.Serialize(country);
+            
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                var request = HttpRequestBuilder
+                    .Get(EchoController.GetJsonRoute)
+                    .WithJsonBody(json);
+                
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    string actual = await response.Content.ReadAsStringAsync();
+                    Assert.Contains(country.Code.ToString(), actual);
+                }
+            }
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Arcus.WebApi.Tests.Unit.csproj
+++ b/src/Arcus.WebApi.Tests.Unit/Arcus.WebApi.Tests.Unit.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Arcus.WebApi.Hosting\Arcus.WebApi.Hosting.csproj" />
     <ProjectReference Include="..\Arcus.WebApi.Logging\Arcus.WebApi.Logging.csproj" />
     <ProjectReference Include="..\Arcus.WebApi.OpenApi.Extensions\Arcus.WebApi.OpenApi.Extensions.csproj" />
     <ProjectReference Include="..\Arcus.WebApi.Security\Arcus.WebApi.Security.csproj" />

--- a/src/Arcus.WebApi.Tests.Unit/Hosting/Formatting/MvcOptionsExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Hosting/Formatting/MvcOptionsExtensionsTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Hosting.Formatting
+{
+    public class MvcOptionsExtensionsTests
+    {
+        [Fact]
+        public void ConfigureJsonFormatting_WithoutConfigureFunction_Fails()
+        {
+            // Arrange
+            var options = new MvcOptions();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.ConfigureJsonFormatting(configureOptions: null));
+        }
+    }
+}

--- a/src/Arcus.WebApi.sln
+++ b/src/Arcus.WebApi.sln
@@ -23,7 +23,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.WebApi.Logging.AzureF
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.WebApi.Tests.Runtimes.AzureFunction", "Arcus.WebApi.Tests.Runtimes.AzureFunction\Arcus.WebApi.Tests.Runtimes.AzureFunction.csproj", "{4F89D835-E4C0-409F-A54B-3551E0D99D82}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.WebApi.Tests.Core", "Arcus.WebApi.Tests.Core\Arcus.WebApi.Tests.Core.csproj", "{1681A643-EE1A-4F8E-96C1-17ABEF475C77}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.WebApi.Tests.Core", "Arcus.WebApi.Tests.Core\Arcus.WebApi.Tests.Core.csproj", "{1681A643-EE1A-4F8E-96C1-17ABEF475C77}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.WebApi.Hosting", "Arcus.WebApi.Hosting\Arcus.WebApi.Hosting.csproj", "{EBF29771-0205-48BD-9F2A-7789080377B0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -71,6 +73,10 @@ Global
 		{1681A643-EE1A-4F8E-96C1-17ABEF475C77}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1681A643-EE1A-4F8E-96C1-17ABEF475C77}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1681A643-EE1A-4F8E-96C1-17ABEF475C77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBF29771-0205-48BD-9F2A-7789080377B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBF29771-0205-48BD-9F2A-7789080377B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBF29771-0205-48BD-9F2A-7789080377B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBF29771-0205-48BD-9F2A-7789080377B0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds extensions on the `MvcOptions` to restrict and configure the JSON formatting.
Will later be used in our project templates for more easier maintanence.

Closes #250