### PR TITLE
feat: add jwt bearer token extension for secret store

### DIFF
--- a/docs/preview/features/security/auth/jwt.md
+++ b/docs/preview/features/security/auth/jwt.md
@@ -14,6 +14,7 @@ This authorization process consists of the following parts:
 - [Globally enforce JWT authorization](#globally-enforce-jwt-authorization)
 - [Custom claim validation](#custom-claim-validation)
 - [Bypassing authorization](#bypassing-authorization)
+- [Accessing secret store on JWT Bearer token authentication](#accessing-secret-store-on-JWT-Bearer-token-authentication)
 
 ## Globally enforce JWT authorization
 
@@ -152,5 +153,27 @@ public class SystemController : ControllerBase
     {
         return Ok();
     }
+}
+```
+
+## Accessing secret store on JWT Bearer token authentication
+
+This package also provides an extra extension to access the [Arcus secret store](https://security.arcus-azure.net/features/secret-store/) while configuring JWT Bearer token authentication.
+Access to the secret store will help to provide, for example, issuer symmetric keys.
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddAuthentication(...)
+            .AddJwtBearer((options, serviceProvider) =>
+            {
+                var secretProvider = serviceProvider.GetRequiredService<ISecretProvider>();
+                string key = secretProvider.GetRawSecretAsync("JwtSigningKey").GetAwaiter().GetResult();
+
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                   IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key)),
+                };
+            })
 }
 ```

--- a/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
+++ b/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.22" />
   </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
   </ItemGroup>

--- a/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
+++ b/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <RepositoryType>Git</RepositoryType>
@@ -22,12 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.22" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
   </ItemGroup>

--- a/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
+++ b/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.22" />
   </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
   </ItemGroup>

--- a/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
+++ b/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.22" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">

--- a/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
+++ b/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;netcoreapp3.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <RepositoryType>Git</RepositoryType>
@@ -19,9 +19,16 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.22" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
   </ItemGroup>
 
@@ -29,7 +36,7 @@
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[1.4.0,2.0.0)" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="IdentityModel" Version="4.4.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.8.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.10.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
+++ b/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[1.4.0,2.0.0)" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="IdentityModel" Version="4.4.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.10.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.8.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.WebApi.Security/Authentication/JwtBearer/Extensions/AuthenticationBuilderExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/JwtBearer/Extensions/AuthenticationBuilderExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using GuardNet;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Options;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extensions on the <see cref="AuthenticationBuilder"/> to add JWT Bearer specific functionality.
+    /// </summary>
+    public static class AuthenticationBuilderExtensions
+    {
+        /// <summary>
+        /// Enables JWT-bearer authentication using the default scheme <see cref="JwtBearerDefaults.AuthenticationScheme"/>/
+        /// JWT bearer authentication performs authentication by extracting and validating a JWT token from the Authorization request header.
+        /// </summary>
+        /// <param name="builder">The builder instance to add the JWT bearer authentication to.</param>
+        /// <param name="configureOptions">The function to configure the JWT bearer options that affects the authentication process.</param>
+        /// <returns>A reference to builder after the operation has completed.</returns>
+        public static AuthenticationBuilder AddJwtBearer(this AuthenticationBuilder builder, Action<JwtBearerOptions, IServiceProvider> configureOptions)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires an authentication builder instance to add the JWT Bearer authentication");
+
+            if (configureOptions != null)
+            {
+                builder.Services.AddOptions();
+                builder.Services.AddSingleton<IConfigureOptions<JwtBearerOptions>>(serviceProvider =>
+                {
+                    return new ConfigureNamedOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options => configureOptions(options, serviceProvider));
+                });
+            }
+
+            return builder.AddJwtBearer(configureOptions: (Action<JwtBearerOptions>) null);
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
+++ b/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
     <DocumentationFile>Arcus.WebApi.Tests.Integration.Open-Api.xml</DocumentationFile>

--- a/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
+++ b/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
     <DocumentationFile>Arcus.WebApi.Tests.Integration.Open-Api.xml</DocumentationFile>

--- a/src/Arcus.WebApi.Tests.Integration/Fixture/TestApiServer.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Fixture/TestApiServer.cs
@@ -23,10 +23,18 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         private TestApiServer(IHost host, TestApiServerOptions options, ILogger logger)
         {
             Guard.NotNull(host, nameof(host), "Requires a 'IHost' instance to start/stop the test API server");
+
             _host = host;
             _options = options;
             _logger = logger;
+
+            ServiceProvider = host.Services;
         }
+
+        /// <summary>
+        /// Gets the service instance provider to provide instances of the registered services in the test API server.
+        /// </summary>
+        public IServiceProvider ServiceProvider { get; }
         
         /// <summary>
         /// Starts a new instance of the <see cref="TestApiServer"/> using the configurable <paramref name="options"/>.

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authentication/Controllers/AuthorizedController.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authentication/Controllers/AuthorizedController.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Integration.Security.Authentication.Controllers
+{
+    [ApiController]
+    public class AuthorizedController : ControllerBase
+    {
+        public const string GetRoute = "/get-authorized";
+
+        [HttpGet]
+        [Route(GetRoute)]
+        [Authorize]
+        public IActionResult Get()
+        {
+            return Ok();
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authentication/JwtBearerAuthenticationTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authentication/JwtBearerAuthenticationTests.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using Arcus.Security.Core;
+using Arcus.Testing.Logging;
+using Arcus.WebApi.Tests.Integration.Fixture;
+using Arcus.WebApi.Tests.Integration.Security.Authentication.Controllers;
+using Bogus;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.WebApi.Tests.Integration.Security.Authentication
+{
+    [Collection("Integration")]
+    public class JwtBearerAuthenticationTests
+    {
+        private const string IssuerName = "issuer.contoso.com", 
+                             AudienceName = "audience.contoso.com";
+
+        private readonly ILogger _logger;
+
+        private static readonly Faker BogusGenerator = new Faker();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JwtBearerAuthenticationTests" /> class.
+        /// </summary>
+        public JwtBearerAuthenticationTests(ITestOutputHelper outputWriter)
+        {
+            _logger = new XunitTestLogger(outputWriter);
+        }
+
+        [Theory]
+        [InlineData("match-secret-value", "match-secret-value", HttpStatusCode.OK)]
+        [InlineData("match-secret-value", "not-match-secret-value", HttpStatusCode.Unauthorized)]
+        [InlineData("match-secret-value", null, HttpStatusCode.Unauthorized)]
+        public async Task AddJwtBearer_WithCorrectSymmetricKey_Succeeds(string expectedSecretValue, string actualSecretValue, HttpStatusCode expectedStatusCode)
+        {
+            // Arrange
+            const string secretName = "JwtSigningKey";
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services =>
+                {
+                    services.AddSecretStore(stores => stores.AddInMemory(secretName, expectedSecretValue))
+                            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                            .AddJwtBearer((jwt, serviceProvider) =>
+                            {
+                                var secretProvider = serviceProvider.GetRequiredService<ISecretProvider>();
+                                string key = secretProvider.GetRawSecretAsync(secretName).GetAwaiter().GetResult();
+                                jwt.TokenValidationParameters = CreateTokenValidationParametersForSecret(key);
+                            });
+                })
+                .Configure(app => app.UseAuthentication()
+                                     .UseAuthorization());
+
+            string tokenText = CreateBearerTokenFromSecret(actualSecretValue);
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                var request = 
+                    HttpRequestBuilder.Get(AuthorizedController.GetRoute)
+                                      .WithHeader("Authorization", $"Bearer {tokenText}");
+
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(expectedStatusCode, response.StatusCode);
+                    AssertPostConfigureJwtOptions(server.ServiceProvider);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task AddJwtBearer_WithoutBearerScheme_Fails()
+        {
+            // Arrange
+            const string secretName = "JwtSigningKey";
+            string secretValue = BogusGenerator.Random.AlphaNumeric(25);
+
+            var options = new TestApiServerOptions()
+                          .ConfigureServices(services =>
+                          {
+                              services.AddSecretStore(stores => stores.AddInMemory(secretName, secretValue))
+                                      .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                                      .AddJwtBearer((jwt, serviceProvider) =>
+                                      {
+                                          var secretProvider = serviceProvider.GetRequiredService<ISecretProvider>();
+                                          string key = secretProvider.GetRawSecretAsync(secretName).GetAwaiter().GetResult();
+                                          jwt.TokenValidationParameters = CreateTokenValidationParametersForSecret(key);
+                                      });
+                          })
+                          .Configure(app => app.UseAuthentication()
+                                               .UseAuthorization());
+
+            string tokenText = CreateBearerTokenFromSecret(secretValue);
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                var request =
+                    HttpRequestBuilder.Get(AuthorizedController.GetRoute)
+                                      .WithHeader("Authorization", tokenText);
+
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+                    AssertPostConfigureJwtOptions(server.ServiceProvider);
+                }
+            }
+        }
+
+        private static TokenValidationParameters CreateTokenValidationParametersForSecret(string key)
+        {
+            return new TokenValidationParameters
+            {
+                ValidIssuer = IssuerName,
+                ValidAudience = AudienceName,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key))
+            };
+        }
+
+
+        private static string CreateBearerTokenFromSecret(string secretValue)
+        {
+            if (secretValue is null)
+            {
+                return null;
+            }
+
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secretValue));
+            var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+            var token = new JwtSecurityToken(
+                issuer: IssuerName,
+                audience: AudienceName,
+                claims: new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, "Bob")
+                },
+                expires: DateTime.Now.AddMinutes(30),
+                signingCredentials: credentials);
+            
+            string tokenText = new JwtSecurityTokenHandler().WriteToken(token);
+            return tokenText;
+        }
+
+        private static void AssertPostConfigureJwtOptions(IServiceProvider provider)
+        {
+            var jwtOptions = provider.GetRequiredService<IOptions<JwtBearerOptions>>();
+            Assert.Equal(jwtOptions.Value.Audience, jwtOptions.Value.TokenValidationParameters.ValidAudience);
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authentication/JwtBearerAuthenticationTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authentication/JwtBearerAuthenticationTests.cs
@@ -129,7 +129,6 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
             };
         }
 
-
         private static string CreateBearerTokenFromSecret(string secretValue)
         {
             if (secretValue is null)


### PR DESCRIPTION
Add updated `.AddJwtBearer` extension to have access to the `IServiceProvider` and the Arcus secret store.

Closes #271 