### PR TITLE
fix: use correlation in sub-title io secret store

### DIFF
--- a/docs/versioned_docs/version-v1.1.0/features/correlation.md
+++ b/docs/versioned_docs/version-v1.1.0/features/correlation.md
@@ -127,7 +127,7 @@ public class Startup
 }
 ```
 
-## Using secret store within Azure Functions
+## Using correlation within Azure Functions
 
 ### Installation
 

--- a/docs/versioned_docs/version-v1.2.0/features/correlation.md
+++ b/docs/versioned_docs/version-v1.2.0/features/correlation.md
@@ -127,7 +127,7 @@ public class Startup
 }
 ```
 
-## Using secret store within Azure Functions
+## Using correlation within Azure Functions
 
 ### Installation
 

--- a/docs/versioned_docs/version-v1.3.0/features/correlation.md
+++ b/docs/versioned_docs/version-v1.3.0/features/correlation.md
@@ -127,7 +127,7 @@ public class Startup
 }
 ```
 
-## Using secret store within Azure Functions
+## Using correlation within Azure Functions
 
 ### Installation
 

--- a/docs/versioned_docs/version-v1.4.0/features/correlation.md
+++ b/docs/versioned_docs/version-v1.4.0/features/correlation.md
@@ -137,7 +137,7 @@ public class Startup
 }
 ```
 
-## Using secret store within Azure Functions
+## Using correlation within Azure Functions
 
 ### Installation
 


### PR DESCRIPTION
This was already fixed in the preview docs, but not in the published ones.
I think, due to the fact that it's about a sub-title and not a style 1 header, we can skip the redirects here.

Closes #295