### PR TITLE
chore: add dev-friendly msg for missed http ctx accessor

### DIFF
--- a/src/Arcus.WebApi.Logging/Extensions/HttpCorrelationEnricherExtensions.cs
+++ b/src/Arcus.WebApi.Logging/Extensions/HttpCorrelationEnricherExtensions.cs
@@ -33,7 +33,7 @@ namespace Serilog.Configuration
             if (httpContextAccessor is null)
             {
                 throw new InvalidOperationException(
-                    $"Cannot register the HTTP correlation as an Serilog enrichment because no {nameof(IHttpContextAccessor)} was available in the registered services," 
+                    $"Cannot register the HTTP correlation as a Serilog enrichment because no {nameof(IHttpContextAccessor)} was available in the registered services," 
                     + "please make sure to call 'services.AddHttpCorrelation()' when configuring the services. " 
                     + "For more information on HTTP correlation, see the official documentation: https://webapi.arcus-azure.net/features/correlation");
             }

--- a/src/Arcus.WebApi.Logging/Extensions/HttpCorrelationEnricherExtensions.cs
+++ b/src/Arcus.WebApi.Logging/Extensions/HttpCorrelationEnricherExtensions.cs
@@ -26,7 +26,7 @@ namespace Serilog.Configuration
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> or <paramref name="serviceProvider"/> is <c>null</c>.</exception>
         public static LoggerConfiguration WithHttpCorrelationInfo(this LoggerEnrichmentConfiguration enrichmentConfiguration, IServiceProvider serviceProvider)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an Serilog logger enrichment configuration to register the HTTP correlation as enrichment");
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires a Serilog logger enrichment configuration to register the HTTP correlation as enrichment");
             Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider to retrieve the HTTP correlation from the registered services when enriching the Serilog with the HTTP correlation");
 
             var httpContextAccessor = serviceProvider.GetService<IHttpContextAccessor>();


### PR DESCRIPTION
Adds a more dev-friendly exception message when the `IHttpContextAccessor` is missing from the registered services.

Closes #285