### PR TITLE
feat: add http correlation extension for az func

### DIFF
--- a/src/Arcus.WebApi.Logging.AzureFunctions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Extensions/IServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Arcus.Observability.Correlation;
+using Arcus.WebApi.Logging.Core.Correlation;
 using GuardNet;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 
@@ -18,9 +19,23 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">The functions host builder containing the dependency injection services.</param>
         /// <param name="configureOptions">The function to configure additional options how the correlation works.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        [Obsolete("Use the " + nameof(AddHttpCorrelation) + " method overload with the " + nameof(HttpCorrelationInfoOptions) + " instead")]
         public static IServiceCollection AddHttpCorrelation(this IFunctionsHostBuilder builder, Action<CorrelationInfoOptions> configureOptions = null)
         {
-            Guard.NotNull(builder, nameof(builder));
+            Guard.NotNull(builder, nameof(builder), "Requires a functions host builder instance to add the HTTP correlation services");
+
+            return builder.Services.AddHttpCorrelation(configureOptions);
+        }
+
+        /// <summary>
+        /// Adds operation and transaction correlation to the application.
+        /// </summary>
+        /// <param name="builder">The functions host builder containing the dependency injection services.</param>
+        /// <param name="configureOptions">The function to configure additional options how the correlation works.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        public static IServiceCollection AddHttpCorrelation(this IFunctionsHostBuilder builder, Action<HttpCorrelationInfoOptions> configureOptions)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a function host builder instance to add the HTTP correlation services");
 
             return builder.Services.AddHttpCorrelation(configureOptions);
         }

--- a/src/Arcus.WebApi.Tests.Runtimes.AzureFunction/Startup.cs
+++ b/src/Arcus.WebApi.Tests.Runtimes.AzureFunction/Startup.cs
@@ -1,4 +1,6 @@
-﻿using Arcus.WebApi.Tests.Runtimes.AzureFunction;
+﻿using System;
+using Arcus.WebApi.Logging.Core.Correlation;
+using Arcus.WebApi.Tests.Runtimes.AzureFunction;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -14,7 +16,7 @@ namespace Arcus.WebApi.Tests.Runtimes.AzureFunction
         /// <param name="builder">The instance to build the registered services inside the functions app.</param>
         public override void Configure(IFunctionsHostBuilder builder)
         {
-            builder.AddHttpCorrelation();
+            builder.AddHttpCorrelation(configureOptions: (Action<HttpCorrelationInfoOptions>) null);
         }
     }
 }

--- a/src/Arcus.WebApi.Tests.Unit/Arcus.WebApi.Tests.Unit.csproj
+++ b/src/Arcus.WebApi.Tests.Unit/Arcus.WebApi.Tests.Unit.csproj
@@ -25,12 +25,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Arcus.WebApi.Hosting\Arcus.WebApi.Hosting.csproj" />
+    <ProjectReference Include="..\Arcus.WebApi.Logging.AzureFunctions\Arcus.WebApi.Logging.AzureFunctions.csproj" />
     <ProjectReference Include="..\Arcus.WebApi.Logging\Arcus.WebApi.Logging.csproj" />
     <ProjectReference Include="..\Arcus.WebApi.OpenApi.Extensions\Arcus.WebApi.OpenApi.Extensions.csproj" />
     <ProjectReference Include="..\Arcus.WebApi.Security\Arcus.WebApi.Security.csproj" />
     <ProjectReference Include="..\Arcus.WebApi.Tests.Core\Arcus.WebApi.Tests.Core.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Logging\Fixture\" />
   </ItemGroup>
 </Project>

--- a/src/Arcus.WebApi.Tests.Unit/Logging/IFunctionsHostBuilderTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/IFunctionsHostBuilderTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Arcus.Observability.Correlation;
+using Arcus.WebApi.Logging.Core.Correlation;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Logging
+{
+    // ReSharper disable once InconsistentNaming
+    public class IFunctionsHostBuilderTests
+    {
+        [Fact]
+        public void AddHttpCorrelation_WithoutOptions_RegistersDedicatedCorrelation()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var builder = new Mock<IFunctionsHostBuilder>();
+            builder.Setup(build => build.Services).Returns(services);
+
+            // Act
+            builder.Object.AddHttpCorrelation((Action<HttpCorrelationInfoOptions>) null);
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            Assert.NotNull(provider.GetService<IHttpCorrelationInfoAccessor>());
+            Assert.NotNull(provider.GetService<ICorrelationInfoAccessor<CorrelationInfo>>());
+            Assert.NotNull(provider.GetService<ICorrelationInfoAccessor>());
+        }
+        
+        [Fact]
+        public void AddHttpCorrelation_WithHttpOptions_RegistersDedicatedCorrelation()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var builder = new Mock<IFunctionsHostBuilder>();
+            builder.Setup(build => build.Services).Returns(services);
+
+            // Act
+            builder.Object.AddHttpCorrelation(options => options.UpstreamService.ExtractFromRequest = true);
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            Assert.NotNull(provider.GetService<IHttpCorrelationInfoAccessor>());
+            Assert.NotNull(provider.GetService<ICorrelationInfoAccessor<CorrelationInfo>>());
+            Assert.NotNull(provider.GetService<ICorrelationInfoAccessor>());
+        }
+    }
+}


### PR DESCRIPTION
Adds a dedicated extension for adding HTTP correlation services to an Azure Functions project, using the new `HttpCorrelationInfoOptions` instead.

Closes #298