### PR TITLE
feat: add custom healthreport json dto

### DIFF
--- a/docs/preview/features/openapi/health-checks.md
+++ b/docs/preview/features/openapi/health-checks.md
@@ -1,0 +1,58 @@
+﻿---
+title: "Using health checks report in OpenAPI documentation"
+layout: default
+---
+
+# Using health checks report in OpenAPI documentation
+
+Microsoft has a way of providing the health status of an application by running over a series of 'health checks' that eventually generate a health checks report. 
+For more information on application health, see [Microsoft's documentation](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks).
+
+The problem is that the health checks report model called `HealthReport` cannot be safely used as a JSON serializable type, as it could contain exception details (and therefore assembly information).
+Arcus provides a dedicated JSON data-trasfer object (DTO) to expose the health status of the application in a reliable and safe manner.
+
+## Installation
+
+This feature requires to install our NuGet package
+
+```shell
+PM > Install-Package Arcus.WebApi.OpenApi.Extensions
+```
+
+## Usage
+
+The Arcus-provided health checks status model is called `HealthReportJson` and has the same information as Microsoft's model but without any exception details.
+The Arcus model and Microsoft's model are perfectly exchangable. They can be converted between each other, but keep in mind that the exception details are not part of this conversion.
+
+Here's an example of an API controller that uses the Microsoft's health checks service to generate the health report, but uses Arcus' model to expose this information.
+Notice that the `[ProduceResponseType]` attribute uses Arcus' model so that the OpenAPI document uses this model during its generation.
+
+```csharp
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+[ApiController]
+[Route("api/v1/health")]
+public class HealthController : ControllerBase
+{
+    private readonly HealthCheckService _healthService;
+
+    public HealthController(HealthCheckService healthService)
+    {
+        _healthService = healthService;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(HealthReportJson), 200)]
+    public async Task<IActionResult> Get()
+    {
+        HealthReport report = await _healthService.CheckHealthAsync();
+
+        var json = HealthReportJson.FromHealthReport(report);
+        return Ok(json);
+    }
+}
+```
+
+> 💡 The `HealthReportJson` has implicit operators that does the conversion between Microsoft's and Arcus health checks report for you, so you can use `HealthReportJson json = await _healthService.CheckHealthAsync()` and the conversion happens behind the screens.

--- a/src/Arcus.WebApi.OpenApi.Extensions/Arcus.WebApi.OpenApi.Extensions.csproj
+++ b/src/Arcus.WebApi.OpenApi.Extensions/Arcus.WebApi.OpenApi.Extensions.csproj
@@ -31,6 +31,10 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" Condition="'$(TargetFramework)' != 'netstandard2.1'" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.24" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Arcus.WebApi.Security\Arcus.WebApi.Security.csproj" />
   </ItemGroup>

--- a/src/Arcus.WebApi.OpenApi.Extensions/Health/HealthReportEntryJson.cs
+++ b/src/Arcus.WebApi.OpenApi.Extensions/Health/HealthReportEntryJson.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Diagnostics.HealthChecks
+{
+    /// <summary>
+    /// Represents an entry in a <see cref="HealthReportJson"/>.
+    /// Corresponds to the result of a single <see cref="IHealthCheck"/>.
+    /// </summary>
+    public struct HealthReportEntryJson
+    {
+        /// <summary>
+        /// Gets additional key-value pairs describing the health of the component.
+        /// </summary>
+        public IDictionary<string, object> Data { get; set; }
+
+        /// <summary>
+        /// Gets a human-readable description of the status of the component that was checked.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets the health check execution duration.
+        /// </summary>
+        public TimeSpan Duration { get; set; }
+
+        /// <summary>
+        /// Gets the health status of the component that was checked.
+        /// </summary>
+        public HealthStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets the tags associated with the health check.
+        /// </summary>
+        public IEnumerable<string> Tags { get; set; }
+
+        /// <summary>
+        /// Implicit operation to work seamlessly with the <see cref="HealthReportEntry"/> once the health report is being finalized and needs to be sent.
+        /// </summary>
+        /// <param name="entry">The entry of the created health report, representing a single <see cref="IHealthCheck"/> with exception details.</param>
+        public static implicit operator HealthReportEntryJson(HealthReportEntry entry)
+        {
+            return new HealthReportEntryJson
+            {
+                Data = entry.Data.ToDictionary(item => item.Key, item => item.Value),
+                Description = entry.Description,
+                Duration = entry.Duration,
+                Status = entry.Status,
+                Tags = entry.Tags
+            };
+        }
+
+        /// <summary>
+        /// Implicit operation to work seamlessly with the Microsoft <see cref="HealthReportEntry"/> once the serialization is complete.
+        /// </summary>
+        /// <param name="entry">The JSON data-transfer object, representing a single <see cref="IHealthCheck"/> without the exception details.</param>
+        public static implicit operator HealthReportEntry(HealthReportEntryJson entry)
+        {
+            return new HealthReportEntry(
+                entry.Status,
+                entry.Description,
+                entry.Duration,
+                exception: null,
+                new ReadOnlyDictionary<string, object>(entry.Data),
+                entry.Tags);
+        }
+    }
+}

--- a/src/Arcus.WebApi.OpenApi.Extensions/Health/HealthReportJson.cs
+++ b/src/Arcus.WebApi.OpenApi.Extensions/Health/HealthReportJson.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Diagnostics.HealthChecks
+{
+    /// <summary>
+    /// Represents an alternative <see cref="HealthReport"/> model without the exception details so it can be exposed safely with OpenAPI.
+    /// </summary>
+    /// <remarks>
+    ///     This model should not be used within the domain and is just available for the serialization between trust boundaries.
+    ///     Use the <see cref="FromHealthReport"/> and <see cref="ToHealthReport"/> to switch between the two.
+    /// </remarks>
+    public class HealthReportJson
+    {
+        /// <summary>
+        /// Gets a dictionary containing the results from each health check.
+        /// </summary>
+        public IDictionary<string, HealthReportEntryJson> Entries { get; set; }
+
+        /// <summary>
+        /// Gets a <see cref="HealthStatus"/> representing the aggregate status of all the health checks.
+        /// The value of <see cref="Status"/> will be the most severe status reported by a health check.
+        /// If no checks were executed, the value is always <see cref="HealthStatus.Healthy"/>.
+        /// </summary>
+        public HealthStatus Status { get; set; } = HealthStatus.Healthy;
+
+        /// <summary>
+        /// Gets the time the health check service took to execute.
+        /// </summary>
+        public TimeSpan TotalDuration { get; set; }
+
+        /// <summary>
+        /// Creates a JSON data-transfer object from the given <paramref name="report"/>.
+        /// </summary>
+        /// <param name="report">The finalized health report.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="report"/> is <c>null</c>.</exception>
+        public static HealthReportJson FromHealthReport(HealthReport report)
+        {
+            Guard.NotNull(report, nameof(report), "Requires a Microsoft HealthReport instance to convert to a JSON instance without the exception details");
+
+            return new HealthReportJson
+            {
+                Entries = report.Entries.ToDictionary(item => item.Key, item => (HealthReportEntryJson) item.Value),
+                Status = report.Status,
+                TotalDuration = report.TotalDuration
+            };
+        }
+
+        /// <summary>
+        /// Creates a JSON data-transfer object from the given <paramref name="report"/>.
+        /// </summary>
+        /// <param name="report">The finalized health report.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="report"/> is <c>null</c>.</exception>
+        public static HealthReport ToHealthReport(HealthReportJson report)
+        {
+            Guard.NotNull(report, nameof(report), "Requires a Microsoft HealthReport instance to convert to a JSON instance without the exception details");
+
+            IDictionary<string, HealthReportEntry> entries =
+                report.Entries.ToDictionary(item => item.Key, item => (HealthReportEntry) item.Value);
+
+            return new HealthReport(
+                new ReadOnlyDictionary<string, HealthReportEntry>(entries),
+                report.TotalDuration);
+        }
+
+        /// <summary>
+        /// Implicit operation to work seamlessly with the Microsoft <see cref="HealthReport"/> once the health report is finalized.
+        /// </summary>
+        /// <param name="report">The finalized health report.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="report"/> is <c>null</c>.</exception>
+        public static implicit operator HealthReportJson(HealthReport report)
+        {
+            Guard.NotNull(report, nameof(report), "Requires a Microsoft HealthReport instance to convert to a JSON instance without the exception details");
+            return FromHealthReport(report);
+        }
+
+        /// <summary>
+        /// Implicit operation to work seamlessly with the Microsoft <see cref="HealthReport"/> once the serialization is complete.
+        /// </summary>
+        /// <param name="report">The JSON data-transfer object that needs to be converted back to the Microsoft instance.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="report"/> is <c>null</c>.</exception>
+        public static implicit operator HealthReport(HealthReportJson report)
+        {
+            Guard.NotNull(report, nameof(report), "Requires a JSON HealthReport instance to convert to a Microsoft instance with the exception details");
+            return ToHealthReport(report);
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
+++ b/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
@@ -14,6 +14,14 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.25" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Arcus.Testing.Logging" Version="0.2.0-preview-2" />
     <PackageReference Include="Arcus.Testing.Security" Version="0.2.0-preview-2" />

--- a/src/Arcus.WebApi.Tests.Integration/Controllers/DefaultController.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Controllers/DefaultController.cs
@@ -4,9 +4,9 @@ namespace Arcus.WebApi.Tests.Integration.Controllers
 {
     [ApiController]
     [Route(GetRoute)]
-    public class HealthController : ControllerBase
+    public class DefaultController : ControllerBase
     {
-        public const string GetRoute = "api/v1/health";
+        public const string GetRoute = "api/v1/default";
 
         [HttpGet]
         public IActionResult Get()

--- a/src/Arcus.WebApi.Tests.Integration/Logging/RequestTrackingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/RequestTrackingMiddlewareTests.cs
@@ -67,7 +67,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
             {
                 var request = HttpRequestBuilder
-                    .Get(HealthController.GetRoute)
+                    .Get(DefaultController.GetRoute)
                     .WithHeader(headerName, headerValue);
 
                 using (HttpResponseMessage response = await server.SendAsync(request))
@@ -650,7 +650,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
         }
 
         [Theory]
-        [InlineData(HealthController.GetRoute)]
+        [InlineData(DefaultController.GetRoute)]
         [InlineData("/api/v1")]
         [InlineData("/api")]
         [InlineData("api")]
@@ -664,7 +664,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
 
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
             {
-                var request = HttpRequestBuilder.Get(HealthController.GetRoute);
+                var request = HttpRequestBuilder.Get(DefaultController.GetRoute);
                 
                 // Act
                 using (HttpResponseMessage response = await server.SendAsync(request))
@@ -725,7 +725,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
             {
                 var request = HttpRequestBuilder
-                    .Get(HealthController.GetRoute)
+                    .Get(DefaultController.GetRoute)
                     .WithHeader(headerName, headerValue);
 
                 using (HttpResponseMessage response = await server.SendAsync(request))

--- a/src/Arcus.WebApi.Tests.Integration/Logging/VersionTrackingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/VersionTrackingMiddlewareTests.cs
@@ -41,7 +41,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
 
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
             {
-                var request = HttpRequestBuilder.Get(HealthController.GetRoute);
+                var request = HttpRequestBuilder.Get(DefaultController.GetRoute);
                 
                 // Act
                 using (HttpResponseMessage response = await server.SendAsync(request))
@@ -66,7 +66,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
 
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
             {
-                var request = HttpRequestBuilder.Get(HealthController.GetRoute);
+                var request = HttpRequestBuilder.Get(DefaultController.GetRoute);
                 using (HttpResponseMessage response = await server.SendAsync(request))
                 {
                     // Assert
@@ -91,7 +91,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
 
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
             {
-                var request = HttpRequestBuilder.Get(HealthController.GetRoute);
+                var request = HttpRequestBuilder.Get(DefaultController.GetRoute);
                 using (HttpResponseMessage response = await server.SendAsync(request))
                 {
                     // Assert

--- a/src/Arcus.WebApi.Tests.Integration/OpenApi/Controllers/HealthController.cs
+++ b/src/Arcus.WebApi.Tests.Integration/OpenApi/Controllers/HealthController.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Arcus.WebApi.Tests.Integration.OpenApi.Controllers
+{
+    [ApiController]
+    [Route(GetRoute)]
+    public class HealthController : ControllerBase
+    {
+        public const string GetRoute = "api/v1/health";
+
+        private readonly HealthCheckService _healthService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HealthController" /> class.
+        /// </summary>
+        public HealthController(HealthCheckService healthService)
+        {
+            _healthService = healthService;
+        }
+
+        [HttpGet]
+        [ProducesResponseType(typeof(HealthReportJson), 200)]
+        public async Task<IActionResult> Get()
+        {
+            HealthReportJson report = await _healthService.CheckHealthAsync();
+
+            return Ok(report);
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/OpenApi/HealthReportJsonOpenApiTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/OpenApi/HealthReportJsonOpenApiTests.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Arcus.Testing.Logging;
+using Arcus.WebApi.Tests.Integration.Controllers;
+using Arcus.WebApi.Tests.Integration.Fixture;
+using Arcus.WebApi.Tests.Integration.OpenApi.Controllers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.WebApi.Tests.Integration.OpenApi
+{
+    [Collection("Integration")]
+    public class HealthReportJsonOpenApiTests
+    {
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HealthReportJsonOpenApiTests" /> class.
+        /// </summary>
+        public HealthReportJsonOpenApiTests(ITestOutputHelper outputWriter)
+        {
+            _logger = new XunitTestLogger(outputWriter);
+        }
+
+        [Fact]
+        public async Task Route_WithHealthReportJsonResponse_ShouldCorrectlySerializeReport()
+        {
+            string assemblyName = typeof(AuthenticationOperationFilterTests).Assembly.GetName().Name;
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services =>
+                {
+                    services.AddMvc()
+                            .AddNewtonsoftJson();
+
+                    services.AddHealthChecks()
+                            .AddCheck("sample", () => HealthCheckResult.Unhealthy("sample description", new InvalidOperationException("Something happened!")));
+
+                    var openApiInformation = new OpenApiInfo { Title = assemblyName, Version = "v1" };
+                    services.AddSwaggerGen(swagger =>
+                    {
+                        swagger.SwaggerDoc("v1", openApiInformation);
+                        swagger.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, assemblyName + ".Open-Api.xml"));
+                    });
+                })
+                .Configure(app =>
+                {
+                    app.UseSwagger();
+                    app.UseSwaggerUI(swagger =>
+                    {
+                        swagger.SwaggerEndpoint("v1/swagger.json", assemblyName);
+                        swagger.DocumentTitle = assemblyName;
+                    });
+                });
+
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                // Assert
+                await AssertHealthReportSerializationAsync(server);
+                await AssertSwaggerDocumentContainsHealthReportJsonAsync(server);
+            }
+        }
+
+        private static async Task AssertHealthReportSerializationAsync(TestApiServer server)
+        {
+            var request = HttpRequestBuilder.Get(HealthController.GetRoute);
+            using (HttpResponseMessage response = await server.SendAsync(request))
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                string json = await response.Content.ReadAsStringAsync();
+
+                HealthReport report = JsonConvert.DeserializeObject<HealthReportJson>(json);
+                Assert.NotNull(report);
+                Assert.Equal(HealthStatus.Unhealthy, report.Status);
+                (string entryName, HealthReportEntry entry) = Assert.Single(report.Entries);
+                Assert.NotEmpty(entryName);
+                Assert.True(entry.Duration > TimeSpan.Zero, "entry.Duration > Zero");
+                Assert.NotNull(entry.Description);
+                Assert.Null(entry.Exception);
+            }
+        }
+
+        private async Task AssertSwaggerDocumentContainsHealthReportJsonAsync(TestApiServer server)
+        {
+            var request = HttpRequestBuilder.Get("/swagger/v1/swagger.json");
+            using (HttpResponseMessage response = await server.SendAsync(request))
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                OpenApiDocument swagger = await ReadSwaggerOpenAPiDocumentAsync(response);
+                Assert.True(swagger.Paths.TryGetValue("/" + HealthController.GetRoute, out OpenApiPathItem path),
+                    $"Cannot find /{DefaultController.GetRoute} path in Open API spec file");
+
+                (OperationType _, OpenApiOperation value) = Assert.Single(path.Operations);
+                (string _, OpenApiResponse resp) = Assert.Single(value.Responses);
+                (string _, OpenApiMediaType applicationJsonType) =
+                    Assert.Single(resp.Content, content => content.Key == "application/json");
+
+                Assert.Equal(nameof(HealthReportJson), applicationJsonType.Schema.Reference.Id);
+                Assert.Contains(swagger.Components.Schemas, schema => schema.Key == nameof(HealthReportJson));
+            }
+        }
+
+        private async Task<OpenApiDocument> ReadSwaggerOpenAPiDocumentAsync(HttpResponseMessage response)
+        {
+            var reader = new OpenApiStreamReader();
+            using (var responseStream = await response.Content.ReadAsStreamAsync())
+            {
+                OpenApiDocument swagger = reader.Read(responseStream, out OpenApiDiagnostic diagnostic);
+                _logger.LogTrace(diagnostic.Errors.Count == 0
+                    ? String.Empty
+                    : String.Join(", ", diagnostic.Errors.Select(e => e.Message + ": " + e.Pointer)));
+
+                return swagger;
+            }
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authentication/SharedAccessKeyAuthenticationFilterTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authentication/SharedAccessKeyAuthenticationFilterTests.cs
@@ -74,7 +74,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
 
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
             {
-                var request = HttpRequestBuilder.Get(HealthController.GetRoute);
+                var request = HttpRequestBuilder.Get(DefaultController.GetRoute);
                 
                 // Act
                 using (HttpResponseMessage response = await server.SendAsync(request))
@@ -112,7 +112,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
 
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
             {
-                var request = HttpRequestBuilder.Get(HealthController.GetRoute);
+                var request = HttpRequestBuilder.Get(DefaultController.GetRoute);
                 
                 // Act
                 using (HttpResponseMessage response = await server.SendAsync(request))

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authorization/JwtTokenAuthorizationFilterTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authorization/JwtTokenAuthorizationFilterTests.cs
@@ -63,7 +63,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authorization
                 {
                     string accessToken = testOpenIdServer.RequestSecretToken(issuer, authority, privateKey, daysValid: 7);
                     var request = HttpRequestBuilder
-                        .Get(HealthController.GetRoute)
+                        .Get(DefaultController.GetRoute)
                         .WithHeader(JwtTokenAuthorizationOptions.DefaultHeaderName, accessToken);
 
                     // Act
@@ -91,7 +91,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authorization
 
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
             {
-                var request = HttpRequestBuilder.Get(HealthController.GetRoute);
+                var request = HttpRequestBuilder.Get(DefaultController.GetRoute);
                 
                 // Act
                 using (HttpResponseMessage response = await server.SendAsync(request))
@@ -127,7 +127,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authorization
                 {
                     string accessToken = testOpenIdServer.RequestSecretToken(issuer, authority, privateKey, daysValid: 7);
                     var request = HttpRequestBuilder
-                        .Get(HealthController.GetRoute)
+                        .Get(DefaultController.GetRoute)
                         .WithHeader(JwtTokenAuthorizationOptions.DefaultHeaderName, accessToken);
 
                     // Act
@@ -157,7 +157,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authorization
             {
                 var accessToken = $"Bearer {_bogusGenerator.Random.AlphaNumeric(10)}.{_bogusGenerator.Random.AlphaNumeric(50)}.{_bogusGenerator.Random.AlphaNumeric(40)}";
                 var request = HttpRequestBuilder
-                    .Get(HealthController.GetRoute)
+                    .Get(DefaultController.GetRoute)
                     .WithHeader(JwtTokenAuthorizationOptions.DefaultHeaderName, accessToken);
 
                 // Act
@@ -195,7 +195,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authorization
                 {
                     var accessToken = $"Bearer {_bogusGenerator.Random.AlphaNumeric(10)}.{_bogusGenerator.Random.AlphaNumeric(50)}.{_bogusGenerator.Random.AlphaNumeric(40)}";
                     var request = HttpRequestBuilder
-                        .Get(HealthController.GetRoute)
+                        .Get(DefaultController.GetRoute)
                         .WithHeader(JwtTokenAuthorizationOptions.DefaultHeaderName, accessToken);
 
                     // Act
@@ -219,7 +219,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authorization
             {
                 string accessToken = $"Bearer {_bogusGenerator.Random.AlphaNumeric(10)}.{_bogusGenerator.Random.AlphaNumeric(50)}";
                 var request = HttpRequestBuilder
-                    .Get(HealthController.GetRoute)
+                    .Get(DefaultController.GetRoute)
                     .WithHeader(JwtTokenAuthorizationOptions.DefaultHeaderName, accessToken);
 
                 // Act
@@ -260,7 +260,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authorization
                 {
                     string accessToken = testOpenIdServer.RequestSecretToken(issuer, authority, privateKey, daysValid: 7);
                     var request = HttpRequestBuilder
-                        .Get(HealthController.GetRoute)
+                        .Get(DefaultController.GetRoute)
                         .WithHeader(JwtTokenAuthorizationOptions.DefaultHeaderName, accessToken);
 
                     // Act
@@ -299,7 +299,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authorization
 
                 await using (var testApiServer = await TestApiServer.StartNewAsync(options, _logger))
                 {
-                    var request = HttpRequestBuilder.Get(HealthController.GetRoute);
+                    var request = HttpRequestBuilder.Get(DefaultController.GetRoute);
 
                     // Act
                     using (HttpResponseMessage response = await testApiServer.SendAsync(request))
@@ -347,7 +347,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authorization
             {
                 string accessToken = $"Bearer {_bogusGenerator.Random.AlphaNumeric(10)}.{_bogusGenerator.Random.AlphaNumeric(50)}";
                 var request = HttpRequestBuilder
-                    .Get(HealthController.GetRoute)
+                    .Get(DefaultController.GetRoute)
                     .WithHeader(JwtTokenAuthorizationOptions.DefaultHeaderName, accessToken);
 
                 // Act
@@ -383,7 +383,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authorization
             {
                 string accessToken = $"Bearer {_bogusGenerator.Random.AlphaNumeric(10)}.{_bogusGenerator.Random.AlphaNumeric(50)}";
                 var request = HttpRequestBuilder
-                    .Get(HealthController.GetRoute)
+                    .Get(DefaultController.GetRoute)
                     .WithHeader(JwtTokenAuthorizationOptions.DefaultHeaderName, accessToken);
 
                 // Act

--- a/src/Arcus.WebApi.Tests.Unit/OpenApi/HealthReportJsonTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/OpenApi/HealthReportJsonTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Bogus;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.OpenApi
+{
+    public class HealthReportJsonTests
+    {
+        private static readonly Faker BogusGenerator = new Faker();
+
+        [Fact]
+        public void MicrosoftReport_ToJsonReport_RemovesException()
+        {
+            // Arrange
+            IDictionary<string, object> data = 
+                BogusGenerator.Lorem.Words()
+                    .Select(word => new KeyValuePair<string, object>(word, BogusGenerator.Lorem.Word()))
+                    .ToDictionary(item => item.Key, item => item.Value);
+
+            var entry = new HealthReportEntry(
+                BogusGenerator.PickRandom<HealthStatus>(), 
+                BogusGenerator.Lorem.Sentence(), 
+                duration: BogusGenerator.Date.Timespan(), 
+                BogusGenerator.System.Exception(), 
+                new ReadOnlyDictionary<string, object>(data));
+
+            var entries = new Dictionary<string, HealthReportEntry> { ["sample"] = entry };
+            var report = new HealthReport(
+                new ReadOnlyDictionary<string, HealthReportEntry>(entries),
+                totalDuration: BogusGenerator.Date.Timespan());
+
+            // Act
+            HealthReportJson json = HealthReportJson.FromHealthReport(report);
+
+            // Assert
+            HealthReport actual = HealthReportJson.ToHealthReport(json);
+            HealthReportEntry actualEntry = Assert.Single(actual.Entries.Values);
+            Assert.NotEqual(entry, actualEntry);
+            Assert.Equal(entry.Status, actualEntry.Status);
+            Assert.Equal(entry.Data, actualEntry.Data);
+            Assert.Equal(entry.Description, actualEntry.Description);
+            Assert.Equal(entry.Duration, actualEntry.Duration);
+            Assert.Null(actualEntry.Exception);
+            Assert.Equal(report.Status, actual.Status);
+            Assert.Equal(report.TotalDuration, actual.TotalDuration);
+        }
+
+        [Fact]
+        public void ToMicrosoftReport_WithoutInstance_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(() => HealthReportJson.ToHealthReport(report: null));
+        }
+
+        [Fact]
+        public void FromMicrosoftReport_WithoutInstance_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(() => HealthReportJson.FromHealthReport(report: null));
+        }
+    }
+}


### PR DESCRIPTION
Creates a dedicated `HealthReportJson` without any exception details as alternative for Microsoft's `HealthReport` so it can be safely used within OpenAPI documents and serialization.

Closes #277 