### PR TITLE
feat: add http client correlation tracking

### DIFF
--- a/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
+++ b/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Net.Http;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.WebApi.Logging.Core.Correlation
+{
+    /// <summary>
+    /// Represents additional user-configurable options to influence how the HTTP dependency is tracked via either the <see cref="HttpCorrelationMessageHandler"/>
+    /// or via the <see cref="HttpClientExtensions.SendAsync(HttpClient,HttpRequestMessage,IHttpCorrelationInfoAccessor,ILogger)"/>.
+    /// </summary>
+    public class HttpCorrelationClientOptions
+    {
+        private Func<string> _generateDependencyId = () => Guid.NewGuid().ToString();
+        private string _upstreamServiceHeaderName = "Request-Id";
+        private string _transactionIdHeaderName = "X-Transaction-Id";
+
+        /// <summary>
+        /// Gets or sets the function to generate the dependency ID used when tracking HTTP dependencies.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="value"/> is <c>null</c>.</exception>
+        public Func<string> GenerateDependencyId
+        {
+            get => _generateDependencyId;
+            set
+            {
+                Guard.NotNull(value, nameof(value), "Requires a function to generate the dependency ID used when tracking HTTP dependencies");
+                _generateDependencyId = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the HTTP request header name where the dependency ID (generated via <see cref="GenerateDependencyId"/>) should be added when tracking HTTP dependencies.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
+        public string UpstreamServiceHeaderName
+        {
+            get => _upstreamServiceHeaderName;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the HTTP request header where the dependency ID should be added when tracking HTTP dependencies");
+                _upstreamServiceHeaderName = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the HTTP request header name where the transaction ID should be added when tracking HTTP dependencies.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
+        public string TransactionIdHeaderName
+        {
+            get => _transactionIdHeaderName;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the HTTP request header where the transaction ID should be added when tracking HTTP dependencies");
+                _transactionIdHeaderName = value;
+            }
+        }
+    }
+}

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Observability.Correlation;
+using Arcus.Observability.Telemetry.Core;
+using GuardNet;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.WebApi.Logging.Core.Correlation
+{
+    /// <summary>
+    /// Represents an HTTP message handler implementation (<see cref="DelegatingHandler"/>) that enriches the HTTP request with correlation information.
+    /// </summary>
+    public class HttpCorrelationMessageHandler : DelegatingHandler
+    {
+        private readonly IHttpCorrelationInfoAccessor _correlationInfoAccessor;
+        private readonly HttpCorrelationClientOptions _options;
+        private readonly ILogger<HttpCorrelationMessageHandler> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpCorrelationMessageHandler" /> class.
+        /// </summary>
+        /// <param name="correlationInfoAccessor">The accessor of the current HTTP context.</param>
+        /// <param name="options">The additional set of options to influence the HTTP dependency tracking.</param>
+        /// <param name="logger">The logger instance to write the HTTP dependency telemetry.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="correlationInfoAccessor"/>, <paramref name="options"/>, or <paramref name="logger"/> is <c>null</c>.
+        /// </exception>
+        public HttpCorrelationMessageHandler(
+            IHttpCorrelationInfoAccessor correlationInfoAccessor, 
+            HttpCorrelationClientOptions options, 
+            ILogger<HttpCorrelationMessageHandler> logger)
+        {
+            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires a HTTP context accessor to retrieve the current HTTP correlation");
+            Guard.NotNull(options, nameof(options), "Requires a set of additional user-configurable options to influence the HTTP dependency tracking");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write the HTTP dependency telemetry");
+
+            _correlationInfoAccessor = correlationInfoAccessor;
+            _options = options;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Sends an HTTP request to the inner handler to send to the server as an asynchronous operation.
+        /// </summary>
+        /// <param name="request">The HTTP request message to send to the server.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel operation.</param>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="request" /> was <see langword="null" />.</exception>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var statusCode = default(HttpStatusCode);
+            string dependencyId = _options.GenerateDependencyId();
+            request.Headers.Add(_options.UpstreamServiceHeaderName, dependencyId);
+
+            CorrelationInfo correlation = DetermineCorrelationInfo();
+            request.Headers.Add(_options.TransactionIdHeaderName, correlation.TransactionId);
+            
+            using (var measurement = DurationMeasurement.Start())
+            {
+                try
+                {
+                    HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
+                    statusCode = response.StatusCode;
+
+                    return response;
+                }
+                finally
+                {
+                    _logger.LogHttpDependency(request, statusCode, measurement, dependencyId);
+                }
+            }
+        }
+
+        private CorrelationInfo DetermineCorrelationInfo()
+        {
+            CorrelationInfo correlation = _correlationInfoAccessor.GetCorrelationInfo();
+            if (correlation is null)
+            {
+                throw new InvalidOperationException(
+                    "Cannot enrich the HTTP request with HTTP correlation because no HTTP correlation was registered in the application, " +
+                    "make sure that you register the HTTP correlation services with 'services.WithHttpCorrelationTracking()' " +
+                    "and that you use the HTTP correlation middleware 'app.UseHttpCorrelation()' in API scenario's");
+            }
+
+            return correlation;
+        }
+    }
+}

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationProperties.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationProperties.cs
@@ -1,0 +1,18 @@
+﻿namespace Arcus.WebApi.Logging.Core.Correlation
+{
+    /// <summary>
+    /// Represents constant properties within HTTP correlation scenarios.
+    /// </summary>
+    public static class HttpCorrelationProperties
+    {
+        /// <summary>
+        /// Gets the default HTTP request header name used to set the transaction ID in HTTP correlation scenarios.
+        /// </summary>
+        public const string TransactionIdHeaderName = "X-Transaction-ID";
+
+        /// <summary>
+        /// Gets the default HTTP request header name used to set the upstream service ID in HTTP correlation scenarios.
+        /// </summary>
+        public const string UpstreamServiceHeaderName = "Request-Id";
+    }
+}

--- a/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
@@ -1,0 +1,138 @@
+﻿using System.Threading.Tasks;
+using Arcus.Observability.Correlation;
+using Arcus.Observability.Telemetry.Core;
+using Arcus.WebApi.Logging.Core.Correlation;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace System.Net.Http
+{
+    /// <summary>
+    /// Extensions on the <see cref="HttpClient"/> to track HTTP correlation while sending HTTP requests.
+    /// </summary>
+    public static class HttpClientExtensions
+    {
+        /// <summary>
+        /// Sends an HTTP request as an asynchronous operation while tracking the HTTP correlation.
+        /// </summary>
+        /// <param name="client">The client to send the <paramref name="request"/>.</param>
+        /// <param name="request">The HTTP request message to send.</param>
+        /// <param name="correlationAccessor">The HTTP correlation accessor to retrieve the current correlation available to track with the <paramref name="request"/>.</param>
+        /// <param name="logger">The logger instance to write the HTTP dependency while tracking the <paramref name="request"/>.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="client"/>, <paramref name="request"/>, <paramref name="correlationAccessor"/>, <paramref name="logger"/> is <c>null</c>.
+        /// </exception>
+        public static async Task<HttpResponseMessage> SendAsync(
+            this HttpClient client,
+            HttpRequestMessage request,
+            IHttpCorrelationInfoAccessor correlationAccessor,
+            ILogger logger)
+        {
+            Guard.NotNull(client, nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
+            Guard.NotNull(correlationAccessor, nameof(correlationAccessor), "Requires a HTTP correlation accessor instance to retrieve the current correlation to include in the HTTP request");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+
+            return await SendAsync(client, request, correlationAccessor, logger, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Sends an HTTP request as an asynchronous operation while tracking the HTTP correlation.
+        /// </summary>
+        /// <param name="client">The client to send the <paramref name="request"/>.</param>
+        /// <param name="request">The HTTP request message to send.</param>
+        /// <param name="correlationAccessor">The HTTP correlation accessor to retrieve the current correlation available to track with the <paramref name="request"/>.</param>
+        /// <param name="logger">The logger instance to write the HTTP dependency while tracking the <paramref name="request"/>.</param>
+        /// <param name="configureOptions">The additional options to configure how the <paramref name="request"/> must be tracked.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="client"/>, <paramref name="request"/>, <paramref name="correlationAccessor"/>, <paramref name="logger"/> is <c>null</c>.
+        /// </exception>
+        public static async Task<HttpResponseMessage> SendAsync(
+            this HttpClient client,
+            HttpRequestMessage request,
+            IHttpCorrelationInfoAccessor correlationAccessor,
+            ILogger logger,
+            Action<HttpCorrelationClientOptions> configureOptions)
+        {
+            Guard.NotNull(client, nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
+            Guard.NotNull(correlationAccessor, nameof(correlationAccessor), "Requires a HTTP correlation accessor instance to retrieve the current correlation to include in the HTTP request");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+
+            CorrelationInfo correlation = correlationAccessor.GetCorrelationInfo();
+            return await SendAsync(client, request, correlation, logger, configureOptions);
+        }
+
+        /// <summary>
+        /// Sends an HTTP request as an asynchronous operation while tracking the HTTP correlation.
+        /// </summary>
+        /// <param name="client">The client to send the <paramref name="request"/>.</param>
+        /// <param name="request">The HTTP request message to send.</param>
+        /// <param name="correlationInfo">The current HTTP correlation available to track with the <paramref name="request"/>.</param>
+        /// <param name="logger">The logger instance to write the HTTP dependency while tracking the <paramref name="request"/>.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="client"/>, <paramref name="request"/>, <paramref name="correlationInfo"/>, <paramref name="logger"/> is <c>null</c>.
+        /// </exception>
+        public static async Task<HttpResponseMessage> SendAsync(
+            this HttpClient client,
+            HttpRequestMessage request,
+            CorrelationInfo correlationInfo,
+            ILogger logger)
+        {
+            Guard.NotNull(client, nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
+            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a HTTP correlation instance to include in the HTTP request");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+
+            return await SendAsync(client, request, correlationInfo, logger, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Sends an HTTP request as an asynchronous operation while tracking the HTTP correlation.
+        /// </summary>
+        /// <param name="client">The client to send the <paramref name="request"/>.</param>
+        /// <param name="request">The HTTP request message to send.</param>
+        /// <param name="correlationInfo">The current HTTP correlation available to track with the <paramref name="request"/>.</param>
+        /// <param name="logger">The logger instance to write the HTTP dependency while tracking the <paramref name="request"/>.</param>
+        /// <param name="configureOptions">The additional options to configure how the <paramref name="request"/> must be tracked.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="client"/>, <paramref name="request"/>, <paramref name="correlationInfo"/>, <paramref name="logger"/> is <c>null</c>.
+        /// </exception>
+        public static async Task<HttpResponseMessage> SendAsync(
+            this HttpClient client, 
+            HttpRequestMessage request, 
+            CorrelationInfo correlationInfo, 
+            ILogger logger,
+            Action<HttpCorrelationClientOptions> configureOptions)
+        {
+            Guard.NotNull(client, nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
+            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a HTTP correlation instance to include in the HTTP request");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+
+            var options = new HttpCorrelationClientOptions();
+            configureOptions?.Invoke(options);
+            string dependencyId = options.GenerateDependencyId();
+            var statusCode = default(HttpStatusCode);
+
+            request.Headers.Add(options.UpstreamServiceHeaderName, dependencyId);
+            request.Headers.Add(options.TransactionIdHeaderName, correlationInfo.TransactionId);
+
+            using (var measurement = DurationMeasurement.Start())
+            {
+                try
+                {
+                    HttpResponseMessage response = await client.SendAsync(request);
+                    statusCode = response.StatusCode;
+
+                    return response;
+                }
+                finally
+                {
+                    logger.LogHttpDependency(request, statusCode, measurement, dependencyId);
+                } 
+            }
+        }
+    }
+}

--- a/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
@@ -3,6 +3,7 @@ using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.WebApi.Logging.Core.Correlation;
 using GuardNet;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
@@ -16,6 +17,12 @@ namespace System.Net.Http
         /// <summary>
         /// Sends an HTTP request as an asynchronous operation while tracking the HTTP correlation.
         /// </summary>
+        /// <remarks>
+        ///     This way of sending correlated HTTP requests is not needed if you used
+        ///     <see cref="IHttpClientBuilderExtensions.WithHttpCorrelationTracking(IHttpClientBuilder)"/> to register <see cref="HttpClient"/> instances.
+        ///     This extension is only needed when the <see cref="HttpClient"/> used here is created by yourself,
+        ///     otherwise use the regular <see cref="HttpClient.SendAsync(HttpRequestMessage)"/> to send the HTTP request and the request will be correlated automatically.
+        /// </remarks>
         /// <param name="client">The client to send the <paramref name="request"/>.</param>
         /// <param name="request">The HTTP request message to send.</param>
         /// <param name="correlationAccessor">The HTTP correlation accessor to retrieve the current correlation available to track with the <paramref name="request"/>.</param>
@@ -40,6 +47,12 @@ namespace System.Net.Http
         /// <summary>
         /// Sends an HTTP request as an asynchronous operation while tracking the HTTP correlation.
         /// </summary>
+        /// <remarks>
+        ///     This way of sending correlated HTTP requests is not needed if you used
+        ///     <see cref="IHttpClientBuilderExtensions.WithHttpCorrelationTracking(IHttpClientBuilder)"/> to register <see cref="HttpClient"/> instances.
+        ///     This extension is only needed when the <see cref="HttpClient"/> used here is created by yourself,
+        ///     otherwise use the regular <see cref="HttpClient.SendAsync(HttpRequestMessage)"/> to send the HTTP request and the request will be correlated automatically.
+        /// </remarks>
         /// <param name="client">The client to send the <paramref name="request"/>.</param>
         /// <param name="request">The HTTP request message to send.</param>
         /// <param name="correlationAccessor">The HTTP correlation accessor to retrieve the current correlation available to track with the <paramref name="request"/>.</param>
@@ -67,6 +80,12 @@ namespace System.Net.Http
         /// <summary>
         /// Sends an HTTP request as an asynchronous operation while tracking the HTTP correlation.
         /// </summary>
+        /// <remarks>
+        ///     This way of sending correlated HTTP requests is not needed if you used
+        ///     <see cref="IHttpClientBuilderExtensions.WithHttpCorrelationTracking(IHttpClientBuilder)"/> to register <see cref="HttpClient"/> instances.
+        ///     This extension is only needed when the <see cref="HttpClient"/> used here is created by yourself,
+        ///     otherwise use the regular <see cref="HttpClient.SendAsync(HttpRequestMessage)"/> to send the HTTP request and the request will be correlated automatically.
+        /// </remarks>
         /// <param name="client">The client to send the <paramref name="request"/>.</param>
         /// <param name="request">The HTTP request message to send.</param>
         /// <param name="correlationInfo">The current HTTP correlation available to track with the <paramref name="request"/>.</param>
@@ -91,6 +110,12 @@ namespace System.Net.Http
         /// <summary>
         /// Sends an HTTP request as an asynchronous operation while tracking the HTTP correlation.
         /// </summary>
+        /// <remarks>
+        ///     This way of sending correlated HTTP requests is not needed if you used
+        ///     <see cref="IHttpClientBuilderExtensions.WithHttpCorrelationTracking(IHttpClientBuilder)"/> to register <see cref="HttpClient"/> instances.
+        ///     This extension is only needed when the <see cref="HttpClient"/> used here is created by yourself,
+        ///     otherwise use the regular <see cref="HttpClient.SendAsync(HttpRequestMessage)"/> to send the HTTP request and the request will be correlated automatically.
+        /// </remarks>
         /// <param name="client">The client to send the <paramref name="request"/>.</param>
         /// <param name="request">The HTTP request message to send.</param>
         /// <param name="correlationInfo">The current HTTP correlation available to track with the <paramref name="request"/>.</param>

--- a/src/Arcus.WebApi.Logging.Core/Extensions/IHttpClientBuilderExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/IHttpClientBuilderExtensions.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Arcus.WebApi.Logging.Core.Correlation;
+using GuardNet;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extensions on the <see cref="IHttpClientBuilder"/> for more easily HTTP correlation additions.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class IHttpClientBuilderExtensions
+    {
+        /// <summary>
+        /// Adds an additional HTTP message handler that will enrich the send HTTP request with HTTP correlation.
+        /// </summary>
+        /// <param name="builder">The builder instance to add the HTTP message handler.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the no <see cref="IHttpContextAccessor"/> was found in the dependency injection container.</exception>
+        public static IHttpClientBuilder WithHttpCorrelationTracking(this IHttpClientBuilder builder)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a HTTP client builder instance to add the HTTP correlation message handler");
+            return WithHttpCorrelationTracking(builder, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Adds an additional HTTP message handler that will enrich the send HTTP request with HTTP correlation.
+        /// </summary>
+        /// <param name="builder">The builder instance to add the HTTP message handler.</param>
+        /// <param name="configureOptions">The function to configure additional options that influence how the HTTP correlation will be added and tracked.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the no <see cref="IHttpContextAccessor"/> was found in the dependency injection container.</exception>
+        public static IHttpClientBuilder WithHttpCorrelationTracking(this IHttpClientBuilder builder, Action<HttpCorrelationClientOptions> configureOptions)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a HTTP client builder instance to add the HTTP correlation message handler");
+
+            return builder.AddHttpMessageHandler(serviceProvider =>
+            {
+                var correlationAccessor = serviceProvider.GetService<IHttpCorrelationInfoAccessor>();
+                if (correlationAccessor is null)
+                {
+                    throw new InvalidOperationException(
+                        );
+                }
+
+                var options = new HttpCorrelationClientOptions();
+                configureOptions?.Invoke(options);
+
+                var logger = serviceProvider.GetRequiredService<ILogger<HttpCorrelationMessageHandler>>();
+                return new HttpCorrelationMessageHandler(correlationAccessor, options, logger);
+            });
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Controllers/CorrelationController.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Controllers/CorrelationController.cs
@@ -1,4 +1,5 @@
-﻿using Arcus.Observability.Correlation;
+﻿using System;
+using Arcus.Observability.Correlation;
 using Arcus.WebApi.Logging.Core.Correlation;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
@@ -9,6 +10,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Controllers
     public class CorrelationController : ControllerBase
     {
         public const string GetRoute = "correlation",
+                            PostRoute = "correlation",
                             SetCorrelationRoute = "correlation/set";
 
         private readonly IHttpCorrelationInfoAccessor _correlationInfoAccessor;
@@ -37,6 +39,18 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Controllers
             [FromHeader(Name = "Request-Id")] string operationParentId)
         {
             _correlationInfoAccessor.SetCorrelationInfo(new CorrelationInfo(operationId, transactionId, operationParentId));
+
+            string json = JsonConvert.SerializeObject(_correlationInfoAccessor.GetCorrelationInfo());
+            return Ok(json);
+        }
+
+        [HttpPost]
+        [Route(GetRoute)]
+        public IActionResult Post(
+            [FromHeader(Name = "RequestId")] string operationParentId, 
+            [FromHeader(Name = "X-Transaction-ID")] string transactionId)
+        {
+            _correlationInfoAccessor.SetCorrelationInfo(new CorrelationInfo($"operation-{Guid.NewGuid()}", transactionId, operationParentId));
 
             string json = JsonConvert.SerializeObject(_correlationInfoAccessor.GetCorrelationInfo());
             return Ok(json);

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Controllers/ServiceAController.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Controllers/ServiceAController.cs
@@ -20,7 +20,6 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Controllers
                             TransactionIdHeaderNameParameter = "TransactionId_HeaderName",
                             DependencyIdGenerationParameter = "DependencyId_Generation";
 
-
         private readonly HttpClient _client;
         private readonly HttpAssert _assertion;
         private readonly ILogger<ServiceAController> _logger;

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Controllers/ServiceAController.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Controllers/ServiceAController.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Arcus.Observability.Correlation;
+using Arcus.WebApi.Logging.Core.Correlation;
+using Arcus.WebApi.Tests.Integration.Logging.Fixture;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.WebApi.Tests.Integration.Logging.Controllers
+{
+    [ApiController]
+    public class ServiceAController : ControllerBase
+    {
+        public const string RouteWithMessageHandler = "service-a-message-handler",
+                            RouteWithExtension = "service-a-extension",
+                            ServiceBUrlParameterName = "ServiceB_Url",
+                            DependencyIdHeaderNameParameter = "DependencyId_HeaderName",
+                            TransactionIdHeaderNameParameter = "TransactionId_HeaderName",
+                            DependencyIdGenerationParameter = "DependencyId_Generation";
+
+
+        private readonly HttpClient _client;
+        private readonly HttpAssert _assertion;
+        private readonly ILogger<ServiceAController> _logger;
+
+        private static readonly HttpClient DefaultHttpClient = new HttpClient();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceAController" /> class.
+        /// </summary>
+        public ServiceAController(IHttpClientFactory factory, HttpAssertProvider provider, ILogger<ServiceAController> logger)
+        {
+            _logger = logger;
+            _client = factory.CreateClient("from-service-a-to-service-b");
+            _assertion = provider.GetAssertion("service-a");
+        }
+
+        [HttpGet]
+        [Route(RouteWithMessageHandler)]
+        public async Task<IActionResult> GetWithMessageHandler([FromHeader(Name = ServiceBUrlParameterName)] string url)
+        {
+            _assertion.Assert(HttpContext);
+
+            using (HttpResponseMessage response = await _client.GetAsync(url))
+            {
+                return StatusCode((int) response.StatusCode);
+            }
+        }
+
+        [HttpGet]
+        [Route(RouteWithExtension)]
+        public async Task<IActionResult> GetWithExtension(
+            [FromHeader(Name = ServiceBUrlParameterName)] string url,
+            [FromHeader(Name = DependencyIdGenerationParameter)] string dependencyIdGeneration,
+            [FromHeader(Name = DependencyIdHeaderNameParameter)] string dependencyIdHeaderName = HttpCorrelationProperties.UpstreamServiceHeaderName,
+            [FromHeader(Name = TransactionIdHeaderNameParameter)] string transactionIdHeaderName = HttpCorrelationProperties.TransactionIdHeaderName)
+        {
+            _assertion.Assert(HttpContext);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            var correlationAccessor = HttpContext.RequestServices.GetRequiredService<IHttpCorrelationInfoAccessor>();
+            CorrelationInfo correlation = correlationAccessor.GetCorrelationInfo();
+
+            using (HttpResponseMessage response = 
+                   await DefaultHttpClient.SendAsync(request, correlation, _logger, options =>
+                   {
+                       options.GenerateDependencyId = () => dependencyIdGeneration ?? Guid.NewGuid().ToString();
+                       options.UpstreamServiceHeaderName = dependencyIdHeaderName;
+                       options.TransactionIdHeaderName = transactionIdHeaderName;
+                   }))
+            {
+                return StatusCode((int) response.StatusCode);
+            }
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Controllers/ServiceBController.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Controllers/ServiceBController.cs
@@ -1,0 +1,28 @@
+﻿using Arcus.WebApi.Tests.Integration.Logging.Fixture;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.WebApi.Tests.Integration.Logging.Controllers
+{
+    [ApiController]
+    public class ServiceBController : ControllerBase
+    {
+        private readonly HttpAssert _assertion;
+        public const string Route = "service-b";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceBController" /> class.
+        /// </summary>
+        public ServiceBController(HttpAssertProvider provider)
+        {
+            _assertion = provider.GetAssertion("service-b");
+        }
+
+        [HttpGet]
+        [Route(Route)]
+        public IActionResult Get()
+        {
+            _assertion.Assert(HttpContext);
+           return Ok();
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssert.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssert.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using GuardNet;
+using Microsoft.AspNetCore.Http;
+
+namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
+{
+    /// <summary>
+    /// Represents an assertion function on the <see cref="HttpContext"/>.
+    /// </summary>
+    public class HttpAssert
+    {
+        private readonly Action<HttpContext> _assertion;
+
+        private HttpAssert(Action<HttpContext> assertion)
+        {
+            Guard.NotNull(assertion, nameof(assertion), "Requires an assertion function to verify a HTTP context");
+            _assertion = assertion;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="HttpAssert"/> model that asserts on a given <see cref="HttpContext"/>.
+        /// </summary>
+        /// <param name="assertion">The assertion to run against the <see cref="HttpContext"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="assertion"/> is <c>null</c>.</exception>
+        public static HttpAssert Create(Action<HttpContext> assertion)
+        {
+            Guard.NotNull(assertion, nameof(assertion), "Requires an assertion function to verify a HTTP context");
+            return new HttpAssert(assertion);
+        }
+
+        /// <summary>
+        /// Asserts on a HTTP <paramref name="context"/>.
+        /// </summary>
+        /// <param name="context">The currently available HTTP context that needs to be asserted.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="context"/> is <c>null</c>.</exception>
+        public void Assert(HttpContext context)
+        {
+            Guard.NotNull(context, nameof(context), "Requires a HTTP context to run an assertion function on it");
+            _assertion(context);
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertProvider.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertProvider.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
+{
+    /// <summary>
+    /// Represents an instance that provides <see cref="HttpAssert"/> instances based on a registered name.
+    /// </summary>
+    public class HttpAssertProvider
+    {
+        private readonly Tuple<string, HttpAssert>[] _namedAssertions;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpAssertProvider" /> class.
+        /// </summary>
+        /// <param name="namedAssertions">The registered series of <see cref="HttpAssert"/> that can be retrieved by name.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="namedAssertions"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="namedAssertions"/> contains <c>null</c> elements or has duplicate names.</exception>
+        public HttpAssertProvider(IEnumerable<Tuple<string, HttpAssert>> namedAssertions)
+        {
+            Guard.NotNull(namedAssertions, nameof(namedAssertions), "Requires a series of named HTTP assertions to setup the HTTP assertion provider");
+            Guard.For(() => namedAssertions.Any(item => item is null), 
+                new ArgumentException("Requires a series of named HTTP assertions without any 'null' elements to setup the HTTP assertion provider", nameof(namedAssertions)));
+            Guard.For(() => namedAssertions.GroupBy(item => item.Item1).All(group => group.Count() != 1),
+                new ArgumentException("Requires a series of named HTTP assertions with unique names to setup the HTTP assertion provider", nameof(namedAssertions)));
+
+            _namedAssertions = namedAssertions.ToArray();
+        }
+
+        /// <summary>
+        /// Get an <see cref="HttpAssert"/> instance registered under the given <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">The name under which the <see cref="HttpAssert"/> was registered.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
+        /// <exception cref="SingleException">Thrown when more than one <see cref="HttpAssert"/> was registered under the given <paramref name="name"/>.</exception>
+        public HttpAssert GetAssertion(string name)
+        {
+            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to retrieve the HTTP assertion");
+            return Assert.Single(_namedAssertions, item => item.Item1 == name).Item2;
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertServiceCollectionExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using GuardNet;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
+{
+    /// <summary>
+    /// Extensions on the <see cref="IServiceCollection"/> to register more easily <see cref="HttpAssert"/> instances.
+    /// </summary>
+    public static class HttpAssertServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds an <see cref="HttpAssert"/> instance with an unique <paramref name="name"/>
+        /// which can be run as a 'backdoor' assertion on any of the Web API application components.
+        /// </summary>
+        /// <param name="services">The application services to add the HTTP assertion to.</param>
+        /// <param name="name">The unique name to register the HTTP assertion under.</param>
+        /// <param name="assertion">The assertion function to verify the current available HTTP context.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="assertion"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
+        public static IServiceCollection AddHttpAssert(this IServiceCollection services, string name, Action<HttpContext> assertion)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a set of services to add the HTTP assertion to");
+            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to register the HTTP assertion");
+            Guard.NotNull(assertion, nameof(assertion), "Requires an assertion function to verify the currently available HTTP context");
+
+            services.TryAddSingleton<HttpAssertProvider>();
+            return services.AddSingleton(Tuple.Create(name, HttpAssert.Create(assertion)));
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Logging/HttpCorrelationMessageHandlerTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/HttpCorrelationMessageHandlerTests.cs
@@ -1,0 +1,320 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Arcus.Observability.Correlation;
+using Arcus.Testing.Logging;
+using Arcus.WebApi.Logging.Core.Correlation;
+using Arcus.WebApi.Tests.Integration.Fixture;
+using Arcus.WebApi.Tests.Integration.Logging.Controllers;
+using Arcus.WebApi.Tests.Integration.Logging.Fixture;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+using Serilog.Events;
+using Xunit;
+using Xunit.Abstractions;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace Arcus.WebApi.Tests.Integration.Logging
+{
+    [Collection("Integration")]
+    public class HttpCorrelationMessageHandlerTests
+    {
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpCorrelationMessageHandlerTests" /> class.
+        /// </summary>
+        public HttpCorrelationMessageHandlerTests(ITestOutputHelper outputWriter)
+        {
+            _logger = new XunitTestLogger(outputWriter);
+        }
+
+        [Theory]
+        [InlineData(ServiceAController.RouteWithMessageHandler)]
+        [InlineData(ServiceAController.RouteWithExtension)]
+        public async Task WithHtpCorrelationTracking_WithinHttpContext_Succeeds(string routeToServiceA)
+        {
+            // Arrange
+            string dependencyIdAtServiceB = null;
+            string generatedTransactionId = null;
+            var spySink = new InMemorySink();
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services =>
+                {
+                    services.AddHttpAssert("service-a", context =>
+                    {
+                        CorrelationInfo correlation = AssertCorrelationServiceA(context);
+                        generatedTransactionId = correlation.TransactionId;
+                    });
+                    services.AddHttpAssert("service-b", context =>
+                    {
+                        dependencyIdAtServiceB = AssertUpstreamServiceHeader(context);
+                        AssertHeaderValue(context, HttpCorrelationProperties.TransactionIdHeaderName, generatedTransactionId);
+                    });
+                    services.AddHttpCorrelation()
+                            .AddHttpClient("from-service-a-to-service-b")
+                            .WithHttpCorrelationTracking();
+                })
+                .Configure(app => app.UseHttpCorrelation())
+                .ConfigureHost(host => host.UseSerilog((context, config) => config.WriteTo.Sink(spySink)));
+
+            HttpRequestBuilder request = CreateHttpRequestToServiceA(routeToServiceA, options);
+
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    
+                    string dependencyIdInTelemetry = GetDependencyIdFromTrackedDependencyTelemetry(spySink);
+                    Assert.Equal(dependencyIdInTelemetry, dependencyIdAtServiceB);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(ServiceAController.RouteWithMessageHandler)]
+        [InlineData(ServiceAController.RouteWithExtension)]
+        public async Task WithHtpCorrelationTrackingWithCustomDependencyId_WithinHttpContext_Succeeds(string routeToServiceA)
+        {
+            // Arrange
+            string dependencyIdAtServiceB = null;
+            string transactionId = null;
+            var spySink = new InMemorySink();
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services =>
+                {
+                    services.AddHttpAssert("service-a", context =>
+                    {
+                        CorrelationInfo correlation = AssertCorrelationServiceA(context);
+                        transactionId = correlation.TransactionId;
+                    });
+                    services.AddHttpAssert("service-b", context =>
+                    {
+                        dependencyIdAtServiceB = AssertUpstreamServiceHeader(context);
+                        AssertHeaderValue(context, HttpCorrelationProperties.TransactionIdHeaderName, transactionId);
+                    });
+                    services.AddHttpCorrelation()
+                            .AddHttpClient("from-service-a-to-service-b")
+                            .WithHttpCorrelationTracking();
+                })
+                .Configure(app => app.UseHttpCorrelation())
+                .ConfigureHost(host => host.UseSerilog((context, config) => config.WriteTo.Sink(spySink)));
+
+            HttpRequestBuilder request = CreateHttpRequestToServiceA(routeToServiceA, options);
+
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    
+                    string dependencyIdInTelemetry = GetDependencyIdFromTrackedDependencyTelemetry(spySink);
+                    Assert.Equal(dependencyIdInTelemetry, dependencyIdAtServiceB);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(HttpCorrelationProperties.TransactionIdHeaderName, HttpCorrelationProperties.UpstreamServiceHeaderName)]
+        [InlineData("X-MyTransaction-Id", HttpCorrelationProperties.UpstreamServiceHeaderName)]
+        [InlineData(HttpCorrelationProperties.TransactionIdHeaderName, "My-Request-Id")]
+        [InlineData("X-MyTransaction-Id", "X-MyRequest-Id")]
+        public async Task WithHttpCorrelationTrackingWithCustomHeaders_WithinHttpContext_Succeeds(
+            string transactionIdHeaderName, 
+            string dependencyIdHeaderName)
+        {
+            // Arrange
+            var expectedDependencyId = Guid.NewGuid().ToString();
+            var expectedTransactionId = Guid.NewGuid().ToString();
+
+            var spySink = new InMemorySink();
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services =>
+                {
+                    services.AddHttpAssert("service-a", context =>
+                    {
+                        CorrelationInfo correlation = AssertCorrelationServiceA(context);
+                        Assert.Equal(expectedTransactionId, correlation.TransactionId);
+                    });
+                    services.AddHttpAssert("service-b", context =>
+                    {
+                        AssertHeaderValue(context, dependencyIdHeaderName, expectedDependencyId);
+                        AssertHeaderValue(context, transactionIdHeaderName, expectedTransactionId);
+                        AssertCorrelationServiceB(context, expectedDependencyId, expectedTransactionId);
+                    });
+                    services.AddHttpCorrelation(options =>
+                            {
+                                options.Transaction.HeaderName = transactionIdHeaderName;
+                                options.UpstreamService.HeaderName = dependencyIdHeaderName;
+                            })
+                            .AddHttpClient("from-service-a-to-service-b")
+                            .WithHttpCorrelationTracking(options =>
+                            {
+                                options.GenerateDependencyId = () => expectedDependencyId;
+                                options.TransactionIdHeaderName = transactionIdHeaderName;
+                                options.UpstreamServiceHeaderName = dependencyIdHeaderName;
+                            });
+                })
+                .Configure(app => app.UseHttpCorrelation())
+                .ConfigureHost(host => host.UseSerilog((context, config) => config.WriteTo.Sink(spySink)));
+
+            HttpRequestBuilder request =
+                CreateHttpRequestToServiceA(ServiceAController.RouteWithMessageHandler, options)
+                    .WithHeader(transactionIdHeaderName, expectedTransactionId);
+
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                    string actualDependencyId = GetDependencyIdFromTrackedDependencyTelemetry(spySink);
+                    Assert.Equal(expectedDependencyId, actualDependencyId);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(HttpCorrelationProperties.TransactionIdHeaderName, HttpCorrelationProperties.UpstreamServiceHeaderName)]
+        [InlineData("X-MyTransaction-Id", HttpCorrelationProperties.UpstreamServiceHeaderName)]
+        [InlineData(HttpCorrelationProperties.TransactionIdHeaderName, "My-Request-Id")]
+        [InlineData("X-MyTransaction-Id", "X-MyRequest-Id")]
+        public async Task WithHttpCorrelationTrackingViaExtensionWithCustomHeaders_WithinHttpContext_Succeeds(
+            string transactionIdHeaderName, 
+            string dependencyIdHeaderName)
+        {
+            // Arrange
+            var expectedDependencyId = Guid.NewGuid().ToString();
+            var expectedTransactionId = Guid.NewGuid().ToString();
+
+            var spySink = new InMemorySink();
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services =>
+                {
+                    services.AddHttpAssert("service-a", context =>
+                    {
+                        CorrelationInfo correlation = AssertCorrelationServiceA(context);
+                        Assert.Equal(expectedTransactionId, correlation.TransactionId);
+                    });
+                    services.AddHttpAssert("service-b", context =>
+                    {
+                        AssertHeaderValue(context, dependencyIdHeaderName, expectedDependencyId);
+                        AssertHeaderValue(context, transactionIdHeaderName, expectedTransactionId);
+                        AssertCorrelationServiceB(context, expectedDependencyId, expectedTransactionId);
+                    });
+                    services.AddHttpClient("from-service-a-to-service-b");
+                    services.AddHttpCorrelation(options =>
+                    {
+                        options.Transaction.HeaderName = transactionIdHeaderName;
+                        options.UpstreamService.HeaderName = dependencyIdHeaderName;
+                    });
+                })
+                .Configure(app => app.UseHttpCorrelation())
+                .ConfigureHost(host => host.UseSerilog((context, config) => config.WriteTo.Sink(spySink)));
+
+            HttpRequestBuilder request = 
+                CreateHttpRequestToServiceA(ServiceAController.RouteWithExtension, options)
+                    .WithHeader(transactionIdHeaderName, expectedTransactionId)
+                    .WithHeader(ServiceAController.DependencyIdGenerationParameter, expectedDependencyId)
+                    .WithHeader(ServiceAController.DependencyIdHeaderNameParameter, dependencyIdHeaderName)
+                    .WithHeader(ServiceAController.TransactionIdHeaderNameParameter, transactionIdHeaderName);
+
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                    string actualDependencyId = GetDependencyIdFromTrackedDependencyTelemetry(spySink);
+                    Assert.Equal(expectedDependencyId, actualDependencyId);
+                }
+            }
+        }
+
+        private static HttpRequestBuilder CreateHttpRequestToServiceA(string routeToServiceA, TestApiServerOptions options)
+        {
+            var request = HttpRequestBuilder
+                .Get(routeToServiceA)
+                .WithHeader(ServiceAController.ServiceBUrlParameterName, options.Url + ServiceBController.Route);
+            
+            return request;
+        }
+
+        private static CorrelationInfo AssertCorrelationServiceA(HttpContext context)
+        {
+            var correlation = context.Features.Get<CorrelationInfo>();
+            Assert.NotNull(correlation);
+            Assert.True(correlation.OperationParentId is null, "Operation parent ID at service A should be blank");
+            Assert.False(string.IsNullOrWhiteSpace(correlation.TransactionId), "Transaction ID at service A should not be blank");
+            Assert.False(string.IsNullOrWhiteSpace(correlation.OperationId), "Operation ID at service A should not be blank");
+
+            return correlation;
+        }
+
+        private static void AssertCorrelationServiceB(HttpContext context, string operationParentId, string transactionId)
+        {
+            var correlation = context.Features.Get<CorrelationInfo>();
+            Assert.NotNull(correlation);
+            Assert.False(string.IsNullOrWhiteSpace(correlation.OperationParentId), "Operation parent ID at service B should not be blank");
+            Assert.False(string.IsNullOrWhiteSpace(correlation.TransactionId), "Transaction ID at service B should not be blank");
+            Assert.False(string.IsNullOrWhiteSpace(correlation.OperationId), "Operation ID at service B should not be blank");
+
+            Assert.Equal(operationParentId, correlation.OperationParentId);
+            Assert.Equal(transactionId, correlation.TransactionId);
+        }
+
+        private static string AssertUpstreamServiceHeader(HttpContext context)
+        {
+            return AssertHeaderAvailable(context, HttpCorrelationProperties.UpstreamServiceHeaderName);
+        }
+
+        private static void AssertHeaderValue(
+            HttpContext context,
+            string headerName,
+            string expected)
+        {
+            string actual = AssertHeaderAvailable(context, headerName);
+            Assert.Equal(expected, actual);
+        }
+
+        private static string AssertHeaderAvailable(HttpContext context, string headerName)
+        {
+            string headerValue = context.Request.Headers[headerName];
+            Assert.NotNull(headerValue);
+            Assert.NotEmpty(headerValue);
+
+            return headerValue;
+        }
+
+        private static string GetDependencyIdFromTrackedDependencyTelemetry(InMemorySink spySink)
+        {
+            LogEvent[] logEvents = spySink.DequeueLogEvents().ToArray();
+            Assert.NotEmpty(logEvents);
+
+            LogEvent dependencyLogEvent = Assert.Single(logEvents, ev => ev.MessageTemplate.Text == "{@Dependency}");
+
+            LogEventPropertyValue dependencyProperty = Assert.Contains("Dependency", dependencyLogEvent.Properties);
+            var dependency = Assert.IsType<StructureValue>(dependencyProperty);
+            Assert.Contains(dependency.Properties, prop => prop.Name == "DependencyName" && prop.Value.ToStringValue() == "GET /service-b");
+            string actualDependencyId = Assert.Single(dependency.Properties, prop => prop.Name == "DependencyId").Value.ToStringValue();
+            
+            Assert.NotNull(actualDependencyId);
+            Assert.NotEmpty(actualDependencyId);
+
+            return actualDependencyId;
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Arcus.WebApi.Tests.Unit.csproj
+++ b/src/Arcus.WebApi.Tests.Unit/Arcus.WebApi.Tests.Unit.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Arcus.Testing.Logging" Version="0.1.0" />
+    <PackageReference Include="Arcus.Testing.Logging" Version="0.4.0" />
     <PackageReference Include="Bogus" Version="29.0.2" />
     <PackageReference Include="BouncyCastle.NetCoreSdk" Version="1.9.0.1" />
     <PackageReference Include="IdentityServer4" Version="4.1.1" />

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Fixture/AssertHttpMessageHandler.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Fixture/AssertHttpMessageHandler.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Arcus.WebApi.Tests.Unit.Logging.Fixture
+{
+    /// <summary>
+    /// Represents an <see cref="HttpMessageHandler"/> that asserts on a send request.
+    /// </summary>
+    public class AssertHttpMessageHandler : DelegatingHandler
+    {
+        private readonly HttpStatusCode? _statusCode;
+        private readonly Action<HttpRequestMessage> _assertion;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertHttpMessageHandler" /> class.
+        /// </summary>
+        public AssertHttpMessageHandler(HttpStatusCode statusCode, Action<HttpRequestMessage> assertion)
+        {
+            _statusCode = statusCode;
+            _assertion = assertion;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertHttpMessageHandler" /> class.
+        /// </summary>
+        public AssertHttpMessageHandler(Action<HttpRequestMessage> assertion)
+        {
+            _assertion = assertion;
+        }
+
+        /// <summary>
+        /// Sends an HTTP request to the inner handler to send to the server as an asynchronous operation.
+        /// </summary>
+        /// <param name="request">The HTTP request message to send to the server.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel operation.</param>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="request" /> was <see langword="null" />.</exception>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            _assertion(request);
+
+            if (_statusCode is null)
+            {
+                return base.SendAsync(request, cancellationToken);
+            }
+
+            return Task.FromResult(new HttpResponseMessage(_statusCode.Value));
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Fixture/DefaultHttpMessageHandlerBuilder.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Fixture/DefaultHttpMessageHandlerBuilder.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using GuardNet;
+using Microsoft.Extensions.Http;
+
+namespace Arcus.WebApi.Tests.Unit.Logging.Fixture
+{
+    /// <summary>
+    /// Represents a builder instance that combines many <see cref="HttpMessageHandler"/> instances.
+    /// </summary>
+    public class DefaultHttpMessageHandlerBuilder : HttpMessageHandlerBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultHttpMessageHandlerBuilder" /> class.
+        /// </summary>
+        /// <param name="provider">The application services available for the application.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="provider"/> is <c>null</c>.</exception>
+        public DefaultHttpMessageHandlerBuilder(IServiceProvider provider)
+        {
+            Guard.NotNull(provider, nameof(provider), "Requires a service provider to retrieve the available application services when registering HTTP message handlers");
+            Services = provider;
+        }
+
+        /// <summary>
+        /// Gets an <see cref="T:System.IServiceProvider" /> which can be used to resolve services
+        /// from the dependency injection container.
+        /// </summary>
+        /// <remarks>
+        /// This property is sensitive to the value of
+        /// <see cref="P:Microsoft.Extensions.Http.HttpClientFactoryOptions.SuppressHandlerScope" />. If <c>true</c> this
+        /// property will be a reference to the application's root service provider. If <c>false</c>
+        /// (default) this will be a reference to a scoped service provider that has the same
+        /// lifetime as the handler being created.
+        /// </remarks>
+        public override IServiceProvider Services { get; }
+
+        /// <summary>
+        /// Creates an <see cref="T:System.Net.Http.HttpMessageHandler" />.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="T:System.Net.Http.HttpMessageHandler" /> built from the <see cref="P:Microsoft.Extensions.Http.HttpMessageHandlerBuilder.PrimaryHandler" /> and
+        /// <see cref="P:Microsoft.Extensions.Http.HttpMessageHandlerBuilder.AdditionalHandlers" />.
+        /// </returns>
+        public override HttpMessageHandler Build()
+        {
+            return CreateHandlerPipeline(PrimaryHandler, AdditionalHandlers);
+        }
+
+        /// <summary>
+        /// Gets a list of additional <see cref="T:System.Net.Http.DelegatingHandler" /> instances used to configure an
+        /// <see cref="T:System.Net.Http.HttpClient" /> pipeline.
+        /// </summary>
+        public override IList<DelegatingHandler> AdditionalHandlers { get; } = new List<DelegatingHandler>();
+
+        /// <summary>
+        /// Gets or sets the name of the <see cref="T:System.Net.Http.HttpClient" /> being created.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="P:Microsoft.Extensions.Http.HttpMessageHandlerBuilder.Name" /> is set by the <see cref="T:System.Net.Http.IHttpClientFactory" /> infrastructure
+        /// and is public for unit testing purposes only. Setting the <see cref="P:Microsoft.Extensions.Http.HttpMessageHandlerBuilder.Name" /> outside of
+        /// testing scenarios may have unpredictable results.
+        /// </remarks>
+        public override string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the primary <see cref="T:System.Net.Http.HttpMessageHandler" />.
+        /// </summary>
+        public override HttpMessageHandler PrimaryHandler { get; set; }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Fixture/StubHttpCorrelationInfoAccessor.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Fixture/StubHttpCorrelationInfoAccessor.cs
@@ -1,0 +1,32 @@
+﻿using Arcus.Observability.Correlation;
+using Arcus.WebApi.Logging.Core.Correlation;
+
+namespace Arcus.WebApi.Tests.Unit.Logging.Fixture
+{
+    /// <summary>
+    /// Represents an <see cref="IHttpCorrelationInfoAccessor"/> that retrieves the HTTP correlation internally.
+    /// </summary>
+    public class StubHttpCorrelationInfoAccessor : IHttpCorrelationInfoAccessor
+    {
+        private CorrelationInfo _correlation;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StubHttpCorrelationInfoAccessor" /> class.
+        /// </summary>
+        /// <param name="correlation">The currently available HTTP correlation instance.</param>
+        public StubHttpCorrelationInfoAccessor(CorrelationInfo correlation)
+        {
+            _correlation = correlation;
+        }
+
+        public CorrelationInfo GetCorrelationInfo()
+        {
+            return _correlation;
+        }
+
+        public void SetCorrelationInfo(CorrelationInfo correlationInfo)
+        {
+            _correlation = correlationInfo;
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Fixture/StubHttpMessageHandler.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Fixture/StubHttpMessageHandler.cs
@@ -1,0 +1,25 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Arcus.WebApi.Tests.Unit.Logging.Fixture
+{
+    public class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StubHttpMessageHandler" /> class.
+        /// </summary>
+        public StubHttpMessageHandler(HttpStatusCode statusCode)
+        {
+            _statusCode = statusCode;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(_statusCode));
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpClientExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpClientExtensionsTests.cs
@@ -1,0 +1,361 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Arcus.Observability.Correlation;
+using Arcus.Testing.Logging;
+using Arcus.WebApi.Logging.Core.Correlation;
+using Arcus.WebApi.Tests.Unit.Logging.Fixture;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Logging
+{
+    public class HttpClientExtensionsTests : HttpCorrelationTrackingTests
+    {
+        private static readonly HttpClient DefaultHttpClient = new HttpClient();
+
+        [Fact]
+        public async Task SendWithAccessor_Default_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var accessor = new StubHttpCorrelationInfoAccessor(correlation);
+            var logger = new InMemoryLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var assertion = new AssertHttpMessageHandler(statusCode, req =>
+            {
+                // Assert
+                AssertHeaderValue(req, HttpCorrelationProperties.TransactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderAvailable(req, HttpCorrelationProperties.UpstreamServiceHeaderName);
+            });
+
+            var client = new HttpClient(assertion);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+
+            // Act
+            await client.SendAsync(request, accessor, logger);
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, statusCode);
+        }
+
+        [Fact]
+        public async Task SendWithAccessor_WithCustomTransactionIdHeaderName_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var accessor = new StubHttpCorrelationInfoAccessor(correlation);
+            var logger = new InMemoryLogger();
+            string transactionIdHeaderName = BogusGenerator.Random.AlphaNumeric(10);
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var assertion = new AssertHttpMessageHandler(statusCode, req =>
+            {
+                // Assert
+                AssertHeaderValue(req, transactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderAvailable(req, HttpCorrelationProperties.UpstreamServiceHeaderName);
+            });
+
+            var client = new HttpClient(assertion);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+
+            // Act
+            await client.SendAsync(request, accessor, logger, options => options.TransactionIdHeaderName = transactionIdHeaderName);
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, statusCode);
+        }
+
+        [Fact]
+        public async Task SendWithAccessor_WithCustomUpstreamServiceHeaderName_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var accessor = new StubHttpCorrelationInfoAccessor(correlation);
+            var logger = new InMemoryLogger();
+            string upstreamServiceHeaderName = BogusGenerator.Random.AlphaNumeric(10);
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var assertion = new AssertHttpMessageHandler(statusCode, req =>
+            {
+                // Assert
+                AssertHeaderValue(req, HttpCorrelationProperties.TransactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderAvailable(req, upstreamServiceHeaderName);
+            });
+
+            var client = new HttpClient(assertion);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+
+            // Act
+            await client.SendAsync(request, accessor, logger, options => options.UpstreamServiceHeaderName = upstreamServiceHeaderName);
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, statusCode);
+        }
+
+        [Fact]
+        public async Task SendWithAccessor_WithCustomDependencyId_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var accessor = new StubHttpCorrelationInfoAccessor(correlation);
+            var logger = new InMemoryLogger();
+            string dependencyId = BogusGenerator.Random.AlphaNumeric(10);
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var assertion = new AssertHttpMessageHandler(statusCode, req =>
+            {
+                // Assert
+                AssertHeaderValue(req, HttpCorrelationProperties.TransactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderValue(req, HttpCorrelationProperties.UpstreamServiceHeaderName, dependencyId);
+            });
+
+            var client = new HttpClient(assertion);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+
+            // Act
+            await client.SendAsync(request, accessor, logger, options => options.GenerateDependencyId = () => dependencyId);
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, dependencyId, statusCode);
+        }
+
+        [Fact]
+        public async Task SendWithCorrelation_Default_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var logger = new InMemoryLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var assertion = new AssertHttpMessageHandler(statusCode, req =>
+            {
+                // Assert
+                AssertHeaderValue(req, HttpCorrelationProperties.TransactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderAvailable(req, HttpCorrelationProperties.UpstreamServiceHeaderName);
+            });
+
+            var client = new HttpClient(assertion);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+
+            // Act
+            await client.SendAsync(request, correlation, logger);
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, statusCode);
+        }
+
+        [Fact]
+        public async Task SendWithCorrelation_WithCustomTransactionIdHeaderName_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var logger = new InMemoryLogger();
+            string transactionIdHeaderName = BogusGenerator.Random.AlphaNumeric(10);
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var assertion = new AssertHttpMessageHandler(statusCode, req =>
+            {
+                // Assert
+                AssertHeaderValue(req, transactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderAvailable(req, HttpCorrelationProperties.UpstreamServiceHeaderName);
+            });
+
+            var client = new HttpClient(assertion);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+
+            // Act
+            await client.SendAsync(request, correlation, logger, options => options.TransactionIdHeaderName = transactionIdHeaderName);
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, statusCode);
+        }
+
+        [Fact]
+        public async Task SendWithCorrelation_WithCustomUpstreamServiceHeaderName_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var logger = new InMemoryLogger();
+            string upstreamServiceHeaderName = BogusGenerator.Random.AlphaNumeric(10);
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var assertion = new AssertHttpMessageHandler(statusCode, req =>
+            {
+                // Assert
+                AssertHeaderValue(req, HttpCorrelationProperties.TransactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderAvailable(req, upstreamServiceHeaderName);
+            });
+
+            var client = new HttpClient(assertion);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+
+            // Act
+            await client.SendAsync(request, correlation, logger, options => options.UpstreamServiceHeaderName = upstreamServiceHeaderName);
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, statusCode);
+        }
+
+        [Fact]
+        public async Task SendWithCorrelation_WithCustomDependencyId_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var logger = new InMemoryLogger();
+            string dependencyId = BogusGenerator.Random.AlphaNumeric(10);
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var assertion = new AssertHttpMessageHandler(statusCode, req =>
+            {
+                // Assert
+                AssertHeaderValue(req, HttpCorrelationProperties.TransactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderValue(req, HttpCorrelationProperties.UpstreamServiceHeaderName, dependencyId);
+            });
+
+            var client = new HttpClient(assertion);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+
+            // Act
+            await client.SendAsync(request, correlation, logger, options => options.GenerateDependencyId = () => dependencyId);
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, dependencyId, statusCode);
+        }
+
+        [Fact]
+        public void SendWithAccessorWithoutOptions_WithoutRequest_Fails()
+        {
+            // Arrange
+            var accessor = Mock.Of<IHttpCorrelationInfoAccessor>();
+            var logger = NullLogger.Instance;
+
+            // Act / Assert
+            Assert.ThrowsAnyAsync<ArgumentException>(() => DefaultHttpClient.SendAsync(request: null, accessor, logger));
+        }
+
+        [Fact]
+        public void SendWithAccessorWithoutOptions_WithoutAccessor_Fails()
+        {
+            // Arrange
+            var request = new HttpRequestMessage();
+            var logger = NullLogger.Instance;
+
+            // Act / Assert
+            Assert.ThrowsAnyAsync<ArgumentException>(() => DefaultHttpClient.SendAsync(request, correlationAccessor: null, logger));
+        }
+
+        [Fact]
+        public void SendWithAccessorWithoutOptions_WithoutLogger_Fails()
+        {
+            // Arrange
+            var request = new HttpRequestMessage();
+            var accessor = Mock.Of<IHttpCorrelationInfoAccessor>();
+
+            // Act / Assert
+            Assert.ThrowsAnyAsync<ArgumentException>(() => DefaultHttpClient.SendAsync(request, accessor, logger: null));
+        }
+
+        [Fact]
+        public void SendWithAccessorWithOptions_WithoutRequest_Fails()
+        {
+            // Arrange
+            var accessor = Mock.Of<IHttpCorrelationInfoAccessor>();
+            var logger = NullLogger.Instance;
+
+            // Act / Assert
+            Assert.ThrowsAnyAsync<ArgumentException>(() => DefaultHttpClient.SendAsync(request: null, accessor, logger, configureOptions: options => { }));
+        }
+
+        [Fact]
+        public void SendWithAccessorWithOptions_WithoutAccessor_Fails()
+        {
+            // Arrange
+            var request = new HttpRequestMessage();
+            var logger = NullLogger.Instance;
+
+            // Act / Assert
+            Assert.ThrowsAnyAsync<ArgumentException>(() => DefaultHttpClient.SendAsync(request, correlationAccessor: null, logger, configureOptions: options => { }));
+        }
+
+        [Fact]
+        public void SendWithAccessorWithOptions_WithoutLogger_Fails()
+        {
+            // Arrange
+            var request = new HttpRequestMessage();
+            var accessor = Mock.Of<IHttpCorrelationInfoAccessor>();
+
+            // Act / Assert
+            Assert.ThrowsAnyAsync<ArgumentException>(() => DefaultHttpClient.SendAsync(request, accessor, logger: null, configureOptions: options => { }));
+        }
+
+        [Fact]
+        public void SendWithCorrelationWithoutOptions_WithoutRequest_Fails()
+        {
+            // Arrange
+            var correlation = new CorrelationInfo("operation-id", "transaction-id");
+            var logger = NullLogger.Instance;
+
+            // Act / Assert
+            Assert.ThrowsAnyAsync<ArgumentException>(() => DefaultHttpClient.SendAsync(request: null, correlation, logger));
+        }
+
+        [Fact]
+        public void SendWithCorrelationWithoutOptions_WithoutAccessor_Fails()
+        {
+            // Arrange
+            var request = new HttpRequestMessage();
+            var logger = NullLogger.Instance;
+
+            // Act / Assert
+            Assert.ThrowsAnyAsync<ArgumentException>(() => DefaultHttpClient.SendAsync(request, correlationInfo: null, logger));
+        }
+
+        [Fact]
+        public void SendWithCorrelationWithoutOptions_WithoutLogger_Fails()
+        {
+            // Arrange
+            var request = new HttpRequestMessage();
+            var correlation = new CorrelationInfo("operation-id", "transaction-id");
+
+            // Act / Assert
+            Assert.ThrowsAnyAsync<ArgumentException>(() => DefaultHttpClient.SendAsync(request, correlation, logger: null));
+        }
+
+        [Fact]
+        public void SendWithCorrelationWithOptions_WithoutRequest_Fails()
+        {
+            // Arrange
+            var correlation = new CorrelationInfo("operation-id", "transaction-id");
+            var logger = NullLogger.Instance;
+
+            // Act / Assert
+            Assert.ThrowsAnyAsync<ArgumentException>(() => DefaultHttpClient.SendAsync(request: null, correlation, logger, configureOptions: options => { }));
+        }
+
+        [Fact]
+        public void SendWithCorrelationWithOptions_WithoutAccessor_Fails()
+        {
+            // Arrange
+            var request = new HttpRequestMessage();
+            var logger = NullLogger.Instance;
+
+            // Act / Assert
+            Assert.ThrowsAnyAsync<ArgumentException>(() => DefaultHttpClient.SendAsync(request, correlationInfo: null, logger, configureOptions: options => { }));
+        }
+
+        [Fact]
+        public void SendWithCorrelationWithOptions_WithoutLogger_Fails()
+        {
+            // Arrange
+            var request = new HttpRequestMessage();
+            var correlation = new CorrelationInfo("operation-id", "transaction-id");
+
+            // Act / Assert
+            Assert.ThrowsAnyAsync<ArgumentException>(() => DefaultHttpClient.SendAsync(request, correlation, logger: null, configureOptions: options => { }));
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationTrackingTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationTrackingTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using Arcus.Observability.Correlation;
+using Bogus;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Logging
+{
+    public abstract class HttpCorrelationTrackingTests
+    {
+        private static readonly Regex DependencyIdRegex = new Regex(@"ID [a-z0-9]{8}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{12}", RegexOptions.Compiled);
+        protected static readonly Faker BogusGenerator = new Faker();
+
+        protected static CorrelationInfo GenerateCorrelationInfo()
+        {
+            return new CorrelationInfo(
+                $"operation-{Guid.NewGuid()}",
+                $"transaction-{Guid.NewGuid()}",
+                $"parent-{Guid.NewGuid()}");
+        }
+
+        protected static HttpRequestMessage GenerateHttpRequestMessage()
+        {
+            HttpMethod method = GenerateHttpMethod();
+            var uri = new Uri(BogusGenerator.Internet.UrlWithPath());
+            var request = new HttpRequestMessage(method, uri);
+            
+            return request;
+        }
+
+        protected static HttpMethod GenerateHttpMethod()
+        {
+            return BogusGenerator.PickRandom(
+                HttpMethod.Get,
+                HttpMethod.Delete,
+                HttpMethod.Head,
+                HttpMethod.Options,
+                HttpMethod.Patch,
+                HttpMethod.Post,
+                HttpMethod.Put,
+                HttpMethod.Trace);
+        }
+
+        protected static void AssertHeaderValue(HttpRequestMessage request, string headerName, string headerValue)
+        {
+            string actual = Assert.Single(request.Headers.GetValues(headerName));
+            Assert.Equal(headerValue, actual);
+        }
+
+        protected static void AssertLoggedHttpDependency(string message, HttpRequestMessage request, HttpStatusCode statusCode)
+        {
+            string path = request.RequestUri?.AbsolutePath;
+            Assert.False(string.IsNullOrWhiteSpace(path), "HTTP request path should not be blank when asserting on the tracked HTTP dependency");
+
+            Assert.StartsWith($"Http {request.Method} {path}", message);
+            Assert.Matches(DependencyIdRegex, message);
+            Assert.Contains($"ResultCode: {(int)statusCode}", message);
+        }
+
+        protected static void AssertLoggedHttpDependency(string message, HttpRequestMessage request, string dependencyId, HttpStatusCode statusCode)
+        {
+            string path = request.RequestUri?.AbsolutePath;
+            Assert.False(string.IsNullOrWhiteSpace(path), "HTTP request path should not be blank when asserting on the tracked HTTP dependency");
+
+            Assert.StartsWith($"Http {request.Method} {path}", message);
+            Assert.Contains($"ID {dependencyId}", message);
+            Assert.Contains($"ResultCode: {(int)statusCode}", message);
+        }
+
+        protected static void AssertHeaderAvailable(HttpRequestMessage request, string headerName)
+        {
+            string actual = Assert.Single(request.Headers.GetValues(headerName));
+            Assert.False(string.IsNullOrWhiteSpace(actual), $"HTTP request message should have header with name '{headerName}'");
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpMessageHandlerTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpMessageHandlerTests.cs
@@ -1,0 +1,217 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Arcus.Observability.Correlation;
+using Arcus.Testing.Logging;
+using Arcus.WebApi.Logging.Core.Correlation;
+using Arcus.WebApi.Tests.Unit.Logging.Fixture;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Logging
+{
+    public class HttpMessageHandlerTests : HttpCorrelationTrackingTests
+    {
+        [Fact]
+        public async Task Send_Default_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var accessor = new StubHttpCorrelationInfoAccessor(correlation);
+            var logger = new InMemoryLogger<HttpCorrelationMessageHandler>();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var assertion = new AssertHttpMessageHandler(req =>
+            {
+                // Assert
+                AssertHeaderValue(req, HttpCorrelationProperties.TransactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderAvailable(req, HttpCorrelationProperties.UpstreamServiceHeaderName);
+            });
+
+            var services = new ServiceCollection();
+            var defaultHttpClientName = string.Empty;
+            services.AddSingleton<IHttpCorrelationInfoAccessor>(provider => accessor)
+                    .AddSingleton<ILogger<HttpCorrelationMessageHandler>>(provider => logger)
+                    .AddHttpClient(defaultHttpClientName)
+                    .WithHttpCorrelationTracking()
+                    .AddHttpMessageHandler(() => assertion);
+
+            IServiceProvider provider = services.BuildServiceProvider();
+            HttpClient client = CreateHttpClient(provider, statusCode);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+
+            // Act
+            await client.SendAsync(request);
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, statusCode);
+        }
+
+        [Fact]
+        public async Task Send_WithCustomTransactionIdHeader_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var accessor = new StubHttpCorrelationInfoAccessor(correlation);
+            var logger = new InMemoryLogger<HttpCorrelationMessageHandler>();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            string transactionIdHeaderName = "X-MyTransaction-Id";
+            var assertion = new AssertHttpMessageHandler(req =>
+            {
+                // Assert
+                AssertHeaderValue(req, transactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderAvailable(req, HttpCorrelationProperties.UpstreamServiceHeaderName);
+            });
+
+            var services = new ServiceCollection();
+            var defaultHttpClientName = string.Empty;
+            services.AddSingleton<IHttpCorrelationInfoAccessor>(provider => accessor)
+                    .AddSingleton<ILogger<HttpCorrelationMessageHandler>>(provider => logger)
+                    .AddHttpClient(defaultHttpClientName)
+                    .WithHttpCorrelationTracking(options => options.TransactionIdHeaderName = transactionIdHeaderName)
+                    .AddHttpMessageHandler(() => assertion);
+
+            IServiceProvider provider = services.BuildServiceProvider();
+            HttpClient client = CreateHttpClient(provider, statusCode);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+            
+            // Act
+            await client.SendAsync(request);
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, statusCode);
+        }
+
+        [Fact]
+        public async Task Send_WithCustomUpstreamServiceHeader_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var accessor = new StubHttpCorrelationInfoAccessor(correlation);
+            var logger = new InMemoryLogger<HttpCorrelationMessageHandler>();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            string upstreamServiceHeaderName = "X-MyRequest-Id";
+            var assertion = new AssertHttpMessageHandler(req =>
+            {
+                // Assert
+                AssertHeaderValue(req, HttpCorrelationProperties.TransactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderAvailable(req, upstreamServiceHeaderName);
+            });
+
+            var services = new ServiceCollection();
+            var defaultHttpClientName = string.Empty;
+            services.AddSingleton<IHttpCorrelationInfoAccessor>(provider => accessor)
+                    .AddSingleton<ILogger<HttpCorrelationMessageHandler>>(provider => logger)
+                    .AddHttpClient(defaultHttpClientName)
+                    .WithHttpCorrelationTracking(options => options.UpstreamServiceHeaderName= upstreamServiceHeaderName)
+                    .AddHttpMessageHandler(() => assertion);
+
+            IServiceProvider provider = services.BuildServiceProvider();
+            HttpClient client = CreateHttpClient(provider, statusCode);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+            
+            // Act
+            await client.SendAsync(request);
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, statusCode);
+        }
+
+        [Fact]
+        public async Task Send_WithCustomDependencyId_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var accessor = new StubHttpCorrelationInfoAccessor(correlation);
+            var logger = new InMemoryLogger<HttpCorrelationMessageHandler>();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var dependencyId = $"parent-{Guid.NewGuid()}";
+            var assertion = new AssertHttpMessageHandler(req =>
+            {
+                // Assert
+                AssertHeaderValue(req, HttpCorrelationProperties.TransactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderValue(req, HttpCorrelationProperties.UpstreamServiceHeaderName, dependencyId);
+            });
+
+            var services = new ServiceCollection();
+            var defaultHttpClientName = string.Empty;
+            services.AddSingleton<IHttpCorrelationInfoAccessor>(provider => accessor)
+                    .AddSingleton<ILogger<HttpCorrelationMessageHandler>>(provider => logger)
+                    .AddHttpClient(defaultHttpClientName)
+                    .WithHttpCorrelationTracking(options => options.GenerateDependencyId= () => dependencyId)
+                    .AddHttpMessageHandler(() => assertion);
+
+            IServiceProvider provider = services.BuildServiceProvider();
+            HttpClient client = CreateHttpClient(provider, statusCode);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+            
+            // Act
+            await client.SendAsync(request);
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, dependencyId, statusCode);
+        }
+
+        private static HttpClient CreateHttpClient(IServiceProvider provider, HttpStatusCode statusCode)
+        {
+            var options = provider.GetService<IOptions<HttpClientFactoryOptions>>();
+            Assert.NotNull(options);
+
+            var builder = new DefaultHttpMessageHandlerBuilder(provider)
+            {
+                PrimaryHandler = new StubHttpMessageHandler(statusCode)
+            };
+            Assert.All(options.Value.HttpMessageHandlerBuilderActions, action => action(builder));
+
+            HttpMessageHandler handler = builder.Build();
+            var client = new HttpClient(handler);
+            
+            return client;
+        }
+
+        [Fact]
+        public void Create_WithoutHttpContextAccessor_Fails()
+        {
+            // Arrange
+            var options = new HttpCorrelationClientOptions();
+            var logger = NullLogger<HttpCorrelationMessageHandler>.Instance;
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                new HttpCorrelationMessageHandler(correlationInfoAccessor: null, options, logger));
+        }
+
+        [Fact]
+        public void Create_WithoutOptions_Fails()
+        {
+            // Arrange
+            var accessor = Mock.Of<IHttpCorrelationInfoAccessor>();
+            var logger = NullLogger<HttpCorrelationMessageHandler>.Instance;
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                new HttpCorrelationMessageHandler(accessor, options: null, logger));
+        }
+
+        [Fact]
+        public void Create_WithoutLogger_Fails()
+        {
+            // Arrange
+            var accessor = Mock.Of<IHttpCorrelationInfoAccessor>();
+            var options = new HttpCorrelationClientOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                new HttpCorrelationMessageHandler(accessor, options, logger: null));
+        }
+    }
+}


### PR DESCRIPTION
Adds HTTP correlation tracking to sending side:
- as a `HttpMessageHandler` that can be added to the registered `IHttpClientFactory`
- as an extension on the `HttpClient` for existings instances

Closes #257
Closes #258