### PR TITLE
feat: change sharedaccesskey target type

### DIFF
--- a/docs/preview/features/security/auth/shared-access-key.md
+++ b/docs/preview/features/security/auth/shared-access-key.md
@@ -57,17 +57,17 @@ builder.Services.AddControllers(options =>
 {
     // Adds shared access key authentication to the request pipeline where the request query string parameter will be verified 
     // if the query parameter value contain the expected secret value, retrievable with the given secret name.
-    options.Filters.AddSharedAccessAuthenticationOnQuery(
+    options.AddSharedAccessKeyAuthenticationFilterOnQuery(
         queryParameterName: "api-key", 
         secretName: "shared-access-key-name")));
 
     // Adds shared access key authentication to the request pipeline where only the request header will be verified if it contains the expected secret value.
-    options.Filters.AddSharedAccessAuthenticationOnHeader(
+    options.AddSharedAccessKeyAuthenticationFilterOnHeader(
         headerName: "http-request-header-name",
         secretName: "shared-access-key-name"));
 
     // Additional consumer-configurable options to change the behavior of the authentication filter.
-    options.Filters.AddSharedAccessAuthenticationOnHeader(..., configureOptions: opt =>
+    options.AddSharedAccessKeyAuthenticationFilterOnHeader(..., configureOptions: opt =>
     {
         // Adds shared access key authentication with emitting security events during the authentication of the request.
         // (default: `false`)
@@ -122,7 +122,7 @@ Some additional configuration options are available on the attribute.
 ## Behavior in validating shared access key parameter
 The package supports different scenarios for specifying the shared access key parameter and is supported for global or per controller/operation use cases.
 
-- **Use header only** - Only the specified request header will be validated for the shared access key, any supplied query parameter will not be taken into account.
+- **Use header** - Only the specified request header will be validated for the shared access key, any supplied query parameter will not be taken into account.
 
 ```csharp
 using Arcus.Security.Core.Caching.Configuration;
@@ -138,11 +138,11 @@ builder.Services.AddSecretStore(stores =>
 
 builder.Services.AddControllers(options =>
 {
-    options.Filters.AddSharedAccessKeyAuthenticationOnHeader(headerName: "http-request-header-name", secretName: "shared-access-key-name"));
+    options.AddSharedAccessKeyAuthenticationFilterOnHeader(headerName: "http-request-header-name", secretName: "shared-access-key-name"));
 });
 ```
 
-- **Use query parameter only** - Only the specified query parameter  will be validated for the shared access key, any supplied request header will not be taken into account.
+- **Use query parameter** - Only the specified query parameter  will be validated for the shared access key, any supplied request header will not be taken into account.
 
 ```csharp
 using Arcus.Security.Core.Caching.Configuration;
@@ -158,35 +158,9 @@ builder.Services.AddSecretStore(stores =>
 
 builder.Services.AddControllers(options =>
 {
-    options.Filters.AddSharedAccessKeyAuthenticationOnQuery(queryParameterName: "api-key", secretName: "shared-access-key-name"));
+    options.AddSharedAccessKeyAuthenticationFilterOnQuery(queryParameterName: "api-key", secretName: "shared-access-key-name"));
 });
 ```
-
-- **Support both header & query parameter** - Both the specified request header and query parameter  will be validated for the shared access key.
-
-```csharp
-using Arcus.Security.Core.Caching.Configuration;
-using Microsoft.AspNetCore.Builder;
-
-WebApplicationBuilder builder = WebApplication.CreateBuilder();
-
-// See https://security.arcus-azure.net/features/secret-store/ for more information.
-builder.Services.AddSecretStore(stores => 
-{
-    stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default));
-});
-
-builder.Services.AddControllers(options =>
-{
-    options.Filters.AddSharedAccessKeyAuthentication(
-        headerName: "http-request-header-name", 
-        queryParameterName: "api-key", 
-        secretName: "shared-access-key-name");
-});
-```
-
-If both header and query parameter are specified, they must both be valid or an `Unauthorized` will be returned.
-
 
 ## Bypassing authentication
 The package supports a way to bypass the shared access key authentication for certain endpoint.
@@ -211,5 +185,3 @@ public class SystemController : ControllerBase
     }
 }
 ```
-
-[&larr; back](/)

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/FilterCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/FilterCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using Arcus.Security.Core;
 using Arcus.WebApi.Security.Authentication.SharedAccessKey;
 using GuardNet;
+using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.AspNetCore.Mvc.Filters
@@ -19,6 +20,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         /// <param name="secretName">The name of the secret that's being retrieved using the <see cref="ISecretProvider.GetRawSecretAsync"/> call.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="headerName"/> or <paramref name="secretName"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(MvcOptionsExtensions.AddSharedAccessKeyAuthenticationFilterOnHeader) + " instead via services.AddControllers(options => options." + nameof(MvcOptionsExtensions.AddSharedAccessKeyAuthenticationFilterOnHeader) + "(...))")]
         public static FilterCollection AddSharedAccessKeyAuthenticationOnHeader(
             this FilterCollection filters,
             string headerName,
@@ -41,6 +43,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         /// </param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="headerName"/> or <paramref name="secretName"/> is blank.</exception>
+         [Obsolete("Use the " + nameof(MvcOptionsExtensions.AddSharedAccessKeyAuthenticationFilterOnHeader) + "instead via services.AddControllers(options => options." + nameof(MvcOptionsExtensions.AddSharedAccessKeyAuthenticationFilterOnHeader) + "(...))")]
         public static FilterCollection AddSharedAccessKeyAuthenticationOnHeader(
             this FilterCollection filters, 
             string headerName,
@@ -66,6 +69,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         /// <param name="secretName">The name of the secret that's being retrieved using the <see cref="ISecretProvider.GetRawSecretAsync"/> call.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="parameterName"/> or <paramref name="secretName"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(MvcOptionsExtensions.AddSharedAccessKeyAuthenticationFilterOnQuery) + "instead via services.AddControllers(options => options." + nameof(MvcOptionsExtensions.AddSharedAccessKeyAuthenticationFilterOnHeader) + "(...))")]
         public static FilterCollection AddSharedAccessAuthenticationOnQuery(
             this FilterCollection filters,
             string parameterName,
@@ -89,6 +93,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         /// </param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="parameterName"/> or <paramref name="secretName"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(MvcOptionsExtensions.AddSharedAccessKeyAuthenticationFilterOnQuery) + "instead via services.AddControllers(options => options." + nameof(MvcOptionsExtensions.AddSharedAccessKeyAuthenticationFilterOnQuery) + "(...))")]
         public static FilterCollection AddSharedAccessAuthenticationOnQuery(
             this FilterCollection filters, 
             string parameterName,

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/FilterCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/FilterCollectionExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         /// <param name="secretName">The name of the secret that's being retrieved using the <see cref="ISecretProvider.GetRawSecretAsync"/> call.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="parameterName"/> or <paramref name="secretName"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(MvcOptionsExtensions.AddSharedAccessKeyAuthenticationFilterOnQuery) + "instead via services.AddControllers(options => options." + nameof(MvcOptionsExtensions.AddSharedAccessKeyAuthenticationFilterOnHeader) + "(...))")]
+        [Obsolete("Use the " + nameof(MvcOptionsExtensions.AddSharedAccessKeyAuthenticationFilterOnQuery) + "instead via services.AddControllers(options => options." + nameof(MvcOptionsExtensions.AddSharedAccessKeyAuthenticationFilterOnQuery) + "(...))")]
         public static FilterCollection AddSharedAccessAuthenticationOnQuery(
             this FilterCollection filters,
             string parameterName,

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Arcus.Security.Core;
+using Arcus.WebApi.Security.Authentication.SharedAccessKey;
+using GuardNet;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extensions on the <see cref="MvcOptions"/> related to authentication.
+    /// </summary>
+    public static class MvcOptionsExtensions
+    {
+        /// <summary>
+        /// Adds an shared access key authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request on its header.
+        /// </summary>
+        /// <param name="options">The current MVC optiops of the application.</param>
+        /// <param name="headerName">The name of the request header which value must match the stored secret.</param>
+        /// <param name="secretName">The name of the secret that's being retrieved using the <see cref="ISecretProvider.GetRawSecretAsync"/> call.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="headerName"/> or <paramref name="secretName"/> is blank.</exception>
+        public static MvcOptions AddSharedAccessKeyAuthenticationFilterOnHeader(this MvcOptions options, string headerName, string secretName)
+        {
+             Guard.NotNull(options, nameof(options), "Requires an MVC options instance to add the shared access key authenctication filter");
+            Guard.NotNullOrWhitespace(headerName, nameof(headerName), "Requires a non-blank HTTP request header name to match the stored secret during the shared access key authentication");
+
+            return AddSharedAccessKeyAuthenticationFilterOnHeader(options, headerName, secretName, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Adds an shared access key authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request on its header.
+        /// </summary>
+        /// <param name="options">The current MVC optiops of the application.</param>
+        /// <param name="headerName">The name of the request header which value must match the stored secret.</param>
+        /// <param name="secretName">The name of the secret that's being retrieved using the <see cref="ISecretProvider.GetRawSecretAsync"/> call.</param>
+        /// <param name="configureOptions">
+        ///     The optional function to configure the set of additional consumer-configurable options to change the behavior of the shared access authentication.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="headerName"/> or <paramref name="secretName"/> is blank.</exception>
+        public static MvcOptions AddSharedAccessKeyAuthenticationFilterOnHeader(
+            this MvcOptions options, 
+            string headerName, 
+            string secretName, 
+            Action<SharedAccessKeyAuthenticationOptions> configureOptions)
+        {
+            Guard.NotNull(options, nameof(options), "Requires an MVC options instance to add the shared access key authenctication filter");
+            Guard.NotNullOrWhitespace(headerName, nameof(headerName), "Requires a non-blank HTTP request header name to match the stored secret during the shared access key authentication");
+
+            var authOptions = new SharedAccessKeyAuthenticationOptions();
+            configureOptions?.Invoke(authOptions);
+            
+            options.Filters.Add(new SharedAccessKeyAuthenticationFilter(headerName, queryParameterName: null, secretName, authOptions));
+            return options;
+        }
+
+        /// <summary>
+        /// Adds an shared access key authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request on its query.
+        /// </summary>
+        /// <param name="options">The current MVC filters of the application.</param>
+        /// <param name="parameterName">The name of the request query parameter name which value must match the stored secret.</param>
+        /// <param name="secretName">The name of the secret that's being retrieved using the <see cref="ISecretProvider.GetRawSecretAsync"/> call.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="parameterName"/> or <paramref name="secretName"/> is blank.</exception>
+        public static MvcOptions AddSharedAccessKeyAuthenticationFilterOnQuery(
+            this MvcOptions options,
+            string parameterName,
+            string secretName)
+        {
+            Guard.NotNull(options, nameof(options), "Requires a set of MVC options to add the shared access authentication MVC filter");
+            Guard.NotNullOrWhitespace(parameterName, nameof(parameterName), "Requires a non-blank HTTP request query parameter name name to match the stored secret during the shared access key authentication");
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to retrieve the stored access key in the secret store during the shared access key authentication");
+
+            return AddSharedAccessKeyAuthenticationFilterOnQuery(options, parameterName, secretName, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Adds an shared access key authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request on its query.
+        /// </summary>
+        /// <param name="options">The current MVC filters of the application.</param>
+        /// <param name="parameterName">The name of the request query parameter name which value must match the stored secret.</param>
+        /// <param name="secretName">The name of the secret that's being retrieved using the <see cref="ISecretProvider.GetRawSecretAsync"/> call.</param>
+        /// <param name="configureOptions">
+        ///     The optional function to configure the set of additional consumer-configurable options to change the behavior of the shared access authentication.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="parameterName"/> or <paramref name="secretName"/> is blank.</exception>
+        public static MvcOptions AddSharedAccessKeyAuthenticationFilterOnQuery(
+            this MvcOptions options, 
+            string parameterName,
+            string secretName,
+            Action<SharedAccessKeyAuthenticationOptions> configureOptions)
+        {
+            Guard.NotNull(options, nameof(options), "Requires a set of MVC options to add the shared access authentication MVC filter");
+            Guard.NotNullOrWhitespace(parameterName, nameof(parameterName), "Requires a non-blank HTTP request query parameter name name to match the stored secret during the shared access key authentication");
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to retrieve the stored access key in the secret store during the shared access key authentication");
+            
+            var authOptions = new SharedAccessKeyAuthenticationOptions();
+            configureOptions?.Invoke(authOptions);
+            
+            options.Filters.Add(new SharedAccessKeyAuthenticationFilter(headerName: null, queryParameterName: parameterName, secretName, authOptions));
+            return options;
+        }
+    }
+}

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds an shared access key authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request on its header.
         /// </summary>
-        /// <param name="options">The current MVC optiops of the application.</param>
+        /// <param name="options">The current MVC options of the application.</param>
         /// <param name="headerName">The name of the request header which value must match the stored secret.</param>
         /// <param name="secretName">The name of the secret that's being retrieved using the <see cref="ISecretProvider.GetRawSecretAsync"/> call.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds an shared access key authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request on its header.
         /// </summary>
-        /// <param name="options">The current MVC optiops of the application.</param>
+        /// <param name="options">The current MVC options of the application.</param>
         /// <param name="headerName">The name of the request header which value must match the stored secret.</param>
         /// <param name="secretName">The name of the secret that's being retrieved using the <see cref="ISecretProvider.GetRawSecretAsync"/> call.</param>
         /// <param name="configureOptions">
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds an shared access key authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request on its query.
         /// </summary>
-        /// <param name="options">The current MVC filters of the application.</param>
+        /// <param name="options">The current MVC options of the application.</param>
         /// <param name="parameterName">The name of the request query parameter name which value must match the stored secret.</param>
         /// <param name="secretName">The name of the secret that's being retrieved using the <see cref="ISecretProvider.GetRawSecretAsync"/> call.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
@@ -82,7 +82,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds an shared access key authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request on its query.
         /// </summary>
-        /// <param name="options">The current MVC filters of the application.</param>
+        /// <param name="options">The current MVC options of the application.</param>
         /// <param name="parameterName">The name of the request query parameter name which value must match the stored secret.</param>
         /// <param name="secretName">The name of the secret that's being retrieved using the <see cref="ISecretProvider.GetRawSecretAsync"/> call.</param>
         /// <param name="configureOptions">

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
@@ -1,20 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Arcus.Security.Core;
 using Arcus.WebApi.Security.Authentication.SharedAccessKey;
 using GuardNet;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Extensions on the <see cref="MvcOptions"/> related to authentication.
     /// </summary>
-    public static class MvcOptionsExtensions
+    public static partial class MvcOptionsExtensions
     {
         /// <summary>
         /// Adds an shared access key authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request on its header.

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authentication/MvcOptionsExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authentication/MvcOptionsExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Arcus.WebApi.Tests.Unit.Security.Authentication
@@ -75,7 +76,7 @@ namespace Arcus.WebApi.Tests.Unit.Security.Authentication
             
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(() =>
-                options.AddSharedAccessAuthenticationFilterOnQuery(parameterName, "MySecret", options => options.EmitSecurityEvents = true));
+                options.AddSharedAccessKeyAuthenticationFilterOnQuery(parameterName, "MySecret", options => options.EmitSecurityEvents = true));
         }
         
         [Theory]
@@ -87,7 +88,7 @@ namespace Arcus.WebApi.Tests.Unit.Security.Authentication
             
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(() =>
-                options.AddSharedAccessAuthenticationFilterOnQuery("x-api-key", secretName));
+                options.AddSharedAccessKeyAuthenticationFilterOnQuery("x-api-key", secretName));
         }
         
         [Theory]
@@ -99,7 +100,7 @@ namespace Arcus.WebApi.Tests.Unit.Security.Authentication
             
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(() =>
-                options.AddSharedAccessAuthenticationFilterOnQuery("x-api-key", secretName, options => options.EmitSecurityEvents = true));
+                options.AddSharedAccessKeyAuthenticationFilterOnQuery("x-api-key", secretName, options => options.EmitSecurityEvents = true));
         }
     }
 }

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authentication/MvcOptionsExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authentication/MvcOptionsExtensionsTests.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Security.Authentication
+{
+    public class MvcOptionsExtensionsTests
+    {
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddSharedAccessKeyAuthenticationFilterOnHeader_WithoutHeaderName_Fails(string headerName)
+        {
+            // Arrange
+            var options = new MvcOptions();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                options.AddSharedAccessKeyAuthenticationFilterOnHeader(headerName, "MySecret"));
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddSharedAccessKeyAuthenticationFilterOnHeaderWithOptions_WithoutHeaderName_Fails(string headerName)
+        {
+            // Arrange
+            var options = new MvcOptions();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                options.AddSharedAccessKeyAuthenticationFilterOnHeader(headerName, "MySecret", options => options.EmitSecurityEvents = true));
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddSharedAccessKeyAuthenticationFilterOnHeader_WithoutSecretName_Fails(string secretName)
+        {
+            // Arrange
+            var options = new MvcOptions();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                options.AddSharedAccessKeyAuthenticationFilterOnHeader("x-api-key", secretName));
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddSharedAccessKeyAuthenticationFilterOnHeaderWithOptions_WithoutSecretName_Fails(string secretName)
+        {
+            // Arrange
+            var options = new MvcOptions();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                options.AddSharedAccessKeyAuthenticationFilterOnHeader("x-api-key", secretName, options => options.EmitSecurityEvents = true));
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddSharedAccessKeyAuthenticationFilterOnQuery_WithoutParameterName_Fails(string parameterName)
+        {
+            // Arrange
+            var options = new MvcOptions();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                options.AddSharedAccessKeyAuthenticationFilterOnHeader(parameterName, "MySecret"));
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddSharedAccessKeyAuthenticationFilterOnQueryWithOptions_WithoutParameterName_Fails(string parameterName)
+        {
+            // Arrange
+            var options = new MvcOptions();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                options.AddSharedAccessAuthenticationFilterOnQuery(parameterName, "MySecret", options => options.EmitSecurityEvents = true));
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddSharedAccessKeyAuthenticationFilterOnQuery_WithoutSecretName_Fails(string secretName)
+        {
+            // Arrange
+            var options = new MvcOptions();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                options.AddSharedAccessAuthenticationFilterOnQuery("x-api-key", secretName));
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddSharedAccessKeyAuthenticationFilterOnQueryWithOptions_WithoutSecretName_Fails(string secretName)
+        {
+            // Arrange
+            var options = new MvcOptions();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                options.AddSharedAccessAuthenticationFilterOnQuery("x-api-key", secretName, options => options.EmitSecurityEvents = true));
+        }
+    }
+}


### PR DESCRIPTION
Change the target type of the shared access key authentcation from the `FilterCollection` (`mvcOptions.Filters`) to `MvcOptions` (`services.AddControllers(mvcOptions => ...)`).

Relates to #329