### PR TITLE
feat: change certificate auth target type

### DIFF
--- a/docs/preview/features/security/auth/certificate.md
+++ b/docs/preview/features/security/auth/certificate.md
@@ -74,10 +74,10 @@ builder.Services.AddSingleton(certificateValidator);
 builder.Services.AddControllers(mvcOptions => 
 {
     // Adds certificate authentication to the request pipeline.
-    mvcOptions.Filters.AddCertificateAuthentication();
+    mvcOptions.AddCertificateAuthenticationFilter();
    
     // Additional consumer-configurable options to change the behavior of the authentication filter.
-    mvcOptions.Filters.AddCertificateAuthentication(configureOptions: options =>
+    mvcOptions.AddCertificateAuthenticationFilter(configureOptions: options =>
     {
         // Adds certificate authentication to the request pipeline with emitting security events during the authorization of the request.
         // (default: `false`)
@@ -174,6 +174,3 @@ public class SystemController : ControllerBase
     }
 }
 ```
-
-
-[&larr; back](/)

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationConfigBuilder.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationConfigBuilder.cs
@@ -137,6 +137,13 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// </summary>
         public CertificateAuthenticationConfig Build()
         {
+            if (_locationAndKeyByRequirement.Count <= 0)
+            {
+                throw new InvalidOperationException(
+                    "Cannot build up the certificate authentication validation because there's nothing configured to be validated on the client certificate, "
+                    + $"please configure the certificate validation requirements with methods like {nameof(WithThumbprint)}, {nameof(WithIssuer)}");
+            }
+
             return new CertificateAuthenticationConfig(_locationAndKeyByRequirement);
         }
     }

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/FilterCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/FilterCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Arcus.WebApi.Security.Authentication.Certificates;
 using GuardNet;
+using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.AspNetCore.Mvc.Filters
@@ -16,13 +17,14 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         /// <param name="filters">The current MVC filters of the application.</param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
+        [Obsolete("Use the " + nameof(MvcOptionsExtensions.AddCertificateAuthenticationFilter) + " instead via the services.AddControllers(options => options." + nameof(MvcOptionsExtensions.AddCertificateAuthenticationFilter) + "())")]
         public static FilterCollection AddCertificateAuthentication(this FilterCollection filters)
         {
             Guard.NotNull(filters, nameof(filters), "Requires a set of MVC filters to add the certificate authentication MVC filter");
 
             return AddCertificateAuthentication(filters, configureOptions: null);
         }
-        
+
         /// <summary>
         /// Adds an certificate authentication MVC filter to the given <paramref name="filters"/> that authenticates the incoming HTTP request.
         /// </summary>
@@ -32,6 +34,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         /// </param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
+        [Obsolete("Use the " + nameof(MvcOptionsExtensions.AddCertificateAuthenticationFilter) + " instead via the services.AddControllers(options => options." + nameof(MvcOptionsExtensions.AddCertificateAuthenticationFilter) + "(...))")]
         public static FilterCollection AddCertificateAuthentication(
             this FilterCollection filters,
             Action<CertificateAuthenticationOptions> configureOptions)

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/MvcOptionsExtensions.cs
@@ -3,12 +3,13 @@ using Arcus.WebApi.Security.Authentication.Certificates;
 using GuardNet;
 using Microsoft.AspNetCore.Mvc;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Extensions on the <see cref="MvcOptions"/> related to authentication.
     /// </summary>
-    public static class MvcOptionsExtensions
+    public static partial class MvcOptionsExtensions
     {
          /// <summary>
         /// Adds an certificate authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request.

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/MvcOptionsExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Arcus.WebApi.Security.Authentication.Certificates;
+using GuardNet;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extensions on the <see cref="MvcOptions"/> related to authentication.
+    /// </summary>
+    public static class MvcOptionsExtensions
+    {
+         /// <summary>
+        /// Adds an certificate authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request.
+        /// </summary>
+        /// <param name="options">The current MVC options of the application.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        public static MvcOptions AddCertificateAuthenticationFilter(this MvcOptions options)
+        {
+            Guard.NotNull(options, nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
+
+            return AddCertificateAuthenticationFilter(options, configureOptions: null);
+        }
+        
+        /// <summary>
+        /// Adds an certificate authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request.
+        /// </summary>
+        /// <param name="options">The current MVC options of the application.</param>
+        /// <param name="configureOptions">
+        ///     The optional function to configure the set of additional consumer-configurable options to change the behavior of the certificate authentication.
+        /// </param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        public static MvcOptions AddCertificateAuthenticationFilter(
+            this MvcOptions options,
+            Action<CertificateAuthenticationOptions> configureOptions)
+        {
+            Guard.NotNull(options, nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
+
+            var authOptions = new CertificateAuthenticationOptions();
+            configureOptions?.Invoke(authOptions);
+
+            options.Filters.Add(new CertificateAuthenticationFilter(authOptions));
+            return options;
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authentication/CertificateAuthenticationFilterTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authentication/CertificateAuthenticationFilterTests.cs
@@ -850,7 +850,6 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
             }
         }
 
-        
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authentication/CertificateAuthenticationFilterTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authentication/CertificateAuthenticationFilterTests.cs
@@ -96,7 +96,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                         services.AddSecretStore(stores => stores.AddInMemory(subjectKey, subjectValue))
                                 .AddSingleton(certificateValidator)
                                 .AddClientCertificate(clientCertificate)
-                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                                .AddControllers(opt => opt.AddCertificateAuthenticationFilter());
                     });
 
                 await using (var server = await TestApiServer.StartNewAsync(options, _logger))
@@ -180,7 +180,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                         services.AddSecretStore(stores => stores.AddInMemory(thumbprintKey, clientCertificate.Thumbprint + thumbprintNoise))
                                 .AddSingleton(certificateValidator)
                                 .AddClientCertificate(clientCertificate)
-                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                                .AddControllers(opt => opt.AddCertificateAuthenticationFilter());
                     });
                 
                 await using (var server = await TestApiServer.StartNewAsync(options, _logger))
@@ -280,7 +280,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                                     [subjectKey] = "CN=known-subject",
                                     [issuerKey] = "CN=known-issuername"
                                 }))
-                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                                .AddControllers(opt => opt.AddCertificateAuthenticationFilter());
                     });
                 
                 await using (var server = await TestApiServer.StartNewAsync(options, _logger))
@@ -380,7 +380,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
 
                         services.AddSingleton(certificateValidator)
                                 .AddClientCertificate(clientCertificate)
-                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                                .AddControllers(opt => opt.AddCertificateAuthenticationFilter());
                     });
 
                 await using (var server = await TestApiServer.StartNewAsync(options, _logger))
@@ -480,7 +480,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                         services.AddSecretStore(stores => stores.AddInMemory(issuerKey, "CN=known-issuername"))
                                 .AddClientCertificate(clientCertificate)
                                 .AddSingleton(certificateValidator)
-                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                                .AddControllers(opt => opt.AddCertificateAuthenticationFilter());
                     });
 
                 await using (var server = await TestApiServer.StartNewAsync(options, _logger))
@@ -545,7 +545,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                                 .Build());
 
                     services.AddSingleton(certificateValidator)
-                            .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                            .AddControllers(opt => opt.AddCertificateAuthenticationFilter());
                 });
 
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
@@ -629,7 +629,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                         
                         services.AddSecretStore(stores => stores.AddInMemory(issuerKey, "CN=known-issuername"))
                                 .AddSingleton(certificateValidator)
-                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                                .AddControllers(opt => opt.AddCertificateAuthenticationFilter());
                     });
                 
                 await using (var server = await TestApiServer.StartNewAsync(options, _logger))
@@ -710,7 +710,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                         services.AddSecretStore(stores => stores.AddInMemory(issuerKey, "CN=issuer"))
                                 .AddClientCertificate(clientCertificate)
                                 .AddSingleton(certificateValidator)
-                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                                .AddControllers(opt => opt.AddCertificateAuthenticationFilter());
                     });
 
                 await using (var server = await TestApiServer.StartNewAsync(options, _logger))
@@ -784,7 +784,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
 
                     services.AddSecretStore(stores => stores.AddInMemory(issuerKey, "CN=issuer"))
                             .AddSingleton(certificateValidator)
-                            .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                            .AddControllers(opt => opt.AddCertificateAuthenticationFilter());
                 })
                 .ConfigureHost(host => host.UseSerilog((context, config) => config.WriteTo.Sink(spySink)));
 
@@ -871,7 +871,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
 
                     services.AddSecretStore(stores => stores.AddInMemory(issuerKey, "CN=issuer"))
                             .AddSingleton(certificateValidator)
-                            .AddMvc(opt => opt.AddCertificateAuthenticationFilter(authOptions =>
+                            .AddControllers(opt => opt.AddCertificateAuthenticationFilter(authOptions =>
                             {
                                 authOptions.EmitSecurityEvents = emitsSecurityEvents;
                             }));

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authentication/CertificateAuthenticationFilterTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authentication/CertificateAuthenticationFilterTests.cs
@@ -23,7 +23,8 @@ using Xunit;
 using Xunit.Abstractions;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
-// ReSharper disable AccessToDisposedClosure
+// Ignore obsolete warnings.
+#pragma warning disable CS0618
 
 namespace Arcus.WebApi.Tests.Integration.Security.Authentication
 {
@@ -41,7 +42,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
         }
 
         [Fact]
-        public async Task AuthorizedRoute_WithCertificateAuthentication_ShouldFailWithUnauthorized_WhenClientCertificateSubjectNameDoesntMatch()
+        public async Task AuthorizedRoute_WithCertificateAuthenticationOnFilters_ShouldFailWithUnauthorized_WhenClientCertificateSubjectNameDoesntMatch()
         {
             // Arrange
             string subjectKey = "subject", subjectValue = $"subject-{Guid.NewGuid()}";
@@ -76,7 +77,86 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
             }
         }
 
+         [Fact]
+        public async Task AuthorizedRoute_WithCertificateAuthentication_ShouldFailWithUnauthorized_WhenClientCertificateSubjectNameDoesntMatch()
+        {
+            // Arrange
+            string subjectKey = "subject", subjectValue = $"subject-{Guid.NewGuid()}";
+            using (X509Certificate2 clientCertificate = SelfSignedCertificate.CreateWithSubject("unrecognized-subject-name"))
+            {
+                var options = new TestApiServerOptions()
+                    .ConfigureServices(services =>
+                    {
+                        var certificateValidator = 
+                            new CertificateAuthenticationValidator(
+                                new CertificateAuthenticationConfigBuilder()
+                                    .WithSubject(X509ValidationLocation.SecretProvider, subjectKey)
+                                    .Build());
+
+                        services.AddSecretStore(stores => stores.AddInMemory(subjectKey, subjectValue))
+                                .AddSingleton(certificateValidator)
+                                .AddClientCertificate(clientCertificate)
+                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                    });
+
+                await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+                {
+                    var request = HttpRequestBuilder.Get(NoneAuthenticationController.GetRoute);
+
+                    // Act
+                    using (HttpResponseMessage response = await server.SendAsync(request))
+                    {
+                        // Assert
+                        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+                    }
+                }
+            }
+        }
+
         [Theory]
+        [InlineData("", false)]
+        [InlineData("thumbprint-noise", true)]
+        public async Task AuthorizedRoute_WithCertificateAuthenticationOnFilters_ShouldFailWithUnauthorized_WhenClientCertificateThumbprintDoesntMatch(
+            string thumbprintNoise,
+            bool expected)
+        {
+            // Arrange
+            using (X509Certificate2 clientCertificate = SelfSignedCertificate.Create())
+            {
+                const string thumbprintKey = "thumbprint";
+                
+                var options = new TestApiServerOptions()
+                    .ConfigureServices(services =>
+                    {
+                        var certificateValidator =
+                            new CertificateAuthenticationValidator(
+                                new CertificateAuthenticationConfigBuilder()
+                                    .WithThumbprint(X509ValidationLocation.SecretProvider, thumbprintKey)
+                                    .Build());
+                        
+                        services.AddSecretStore(stores => stores.AddInMemory(thumbprintKey, clientCertificate.Thumbprint + thumbprintNoise))
+                                .AddSingleton(certificateValidator)
+                                .AddClientCertificate(clientCertificate)
+                                .AddMvc(opt => opt.Filters.AddCertificateAuthentication());
+                    });
+                
+                await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+                {
+                    var request = HttpRequestBuilder.Get(NoneAuthenticationController.GetRoute);
+
+                    // Act
+                    using (HttpResponseMessage response = await server.SendAsync(request))
+                    {
+                        // Assert
+                        Assert.True(
+                            (HttpStatusCode.Unauthorized == response.StatusCode) == expected,
+                            $"Response HTTP status code {(expected ? "should" : "shouldn't")} be 'Unauthorized' but was '{response.StatusCode}'");
+                    }
+                }
+            }
+        }
+
+         [Theory]
         [InlineData("", false)]
         [InlineData("thumbprint-noise", true)]
         public async Task AuthorizedRoute_WithCertificateAuthentication_ShouldFailWithUnauthorized_WhenClientCertificateThumbprintDoesntMatch(
@@ -100,6 +180,56 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                         services.AddSecretStore(stores => stores.AddInMemory(thumbprintKey, clientCertificate.Thumbprint + thumbprintNoise))
                                 .AddSingleton(certificateValidator)
                                 .AddClientCertificate(clientCertificate)
+                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                    });
+                
+                await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+                {
+                    var request = HttpRequestBuilder.Get(NoneAuthenticationController.GetRoute);
+
+                    // Act
+                    using (HttpResponseMessage response = await server.SendAsync(request))
+                    {
+                        // Assert
+                        Assert.True(
+                            (HttpStatusCode.Unauthorized == response.StatusCode) == expected,
+                            $"Response HTTP status code {(expected ? "should" : "shouldn't")} be 'Unauthorized' but was '{response.StatusCode}'");
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("known-subject", "known-issuername", false)]
+        [InlineData("unrecognizedSubjectName", "known-issuername", true)]
+        [InlineData("known-subject", "unrecognizedIssuerName", true)]
+        [InlineData("unrecognizedSubjectName", "unrecognizedIssuerName", true)]
+        public async Task AuthorizedRoute_WithCertificateAuthenticationViaSecretProviderOnFilters_ShouldFailWithUnauthorized_WhenAnyClientCertificateValidationDoesntSucceeds(
+            string subjectValue,
+            string issuerValue,
+            bool expected)
+        {
+            // Arrange
+            const string subjectKey = "subject", issuerKey = "issuer";
+            using (X509Certificate2 clientCertificate = SelfSignedCertificate.CreateWithIssuerAndSubjectName(issuerValue, subjectValue))
+            {
+                var options = new TestApiServerOptions()
+                    .ConfigureServices(services =>
+                    {
+                        var certificateValidator =
+                            new CertificateAuthenticationValidator(
+                                new CertificateAuthenticationConfigBuilder()
+                                    .WithSubject(X509ValidationLocation.SecretProvider, subjectKey)
+                                    .WithIssuer(X509ValidationLocation.SecretProvider, issuerKey)
+                                    .Build());
+
+                        services.AddClientCertificate(clientCertificate)
+                                .AddSingleton(certificateValidator)
+                                .AddSecretStore(stores => stores.AddInMemory(new Dictionary<string, string>
+                                {
+                                    [subjectKey] = "CN=known-subject",
+                                    [issuerKey] = "CN=known-issuername"
+                                }))
                                 .AddMvc(opt => opt.Filters.AddCertificateAuthentication());
                     });
                 
@@ -150,7 +280,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                                     [subjectKey] = "CN=known-subject",
                                     [issuerKey] = "CN=known-issuername"
                                 }))
-                                .AddMvc(opt => opt.Filters.AddCertificateAuthentication());
+                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
                     });
                 
                 await using (var server = await TestApiServer.StartNewAsync(options, _logger))
@@ -170,6 +300,56 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
         }
 
         [Theory]
+        [InlineData("known-subject", "known-issuername", false)]
+        [InlineData("unrecognizedSubjectName", "known-issuername", true)]
+        [InlineData("known-subject", "unrecognizedIssuerName", true)]
+        [InlineData("unrecognizedSubjectName", "unrecognizedIssuerName", true)]
+        public async Task AuthorizedRoute_WithCertificateAuthenticationViaConfigurationOnFilters_ShouldFailWithUnauthorized_WhenAnyClientCertificateValidationDoesntSucceeds(
+            string subjectValue,
+            string issuerValue,
+            bool expected)
+        {
+            // Arrange
+            const string subjectKey = "subject", issuerKey = "issuer";
+            using (X509Certificate2 clientCertificate = SelfSignedCertificate.CreateWithIssuerAndSubjectName(issuerValue, subjectValue))
+            {
+                var options = new TestApiServerOptions()
+                    .ConfigureAppConfiguration(config => config.AddInMemoryCollection(new []
+                    {
+                        new KeyValuePair<string, string>(subjectKey, "CN=known-subject"),
+                        new KeyValuePair<string, string>(issuerKey, "CN=known-issuername")
+                    }))
+                    .ConfigureServices(services =>
+                    {
+                        var certificateValidator =
+                            new CertificateAuthenticationValidator(
+                                new CertificateAuthenticationConfigBuilder()
+                                    .WithSubject(X509ValidationLocation.Configuration, subjectKey)
+                                    .WithIssuer(X509ValidationLocation.Configuration, issuerKey)
+                                    .Build());
+
+                        services.AddSingleton(certificateValidator)
+                                .AddClientCertificate(clientCertificate)
+                                .AddMvc(opt => opt.Filters.AddCertificateAuthentication());
+                    });
+
+                await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+                {
+                    var request = HttpRequestBuilder.Get(NoneAuthenticationController.GetRoute);
+
+                    // Act
+                    using (HttpResponseMessage response = await server.SendAsync(request))
+                    {
+                        // Assert
+                        Assert.True(
+                            (HttpStatusCode.Unauthorized == response.StatusCode) == expected,
+                            $"Response HTTP status code {(expected ? "should" : "shouldn't")} be 'Unauthorized' but was '{response.StatusCode}'");
+                    }
+                }
+            }
+        }
+
+         [Theory]
         [InlineData("known-subject", "known-issuername", false)]
         [InlineData("unrecognizedSubjectName", "known-issuername", true)]
         [InlineData("known-subject", "unrecognizedIssuerName", true)]
@@ -200,6 +380,56 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
 
                         services.AddSingleton(certificateValidator)
                                 .AddClientCertificate(clientCertificate)
+                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                    });
+
+                await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+                {
+                    var request = HttpRequestBuilder.Get(NoneAuthenticationController.GetRoute);
+
+                    // Act
+                    using (HttpResponseMessage response = await server.SendAsync(request))
+                    {
+                        // Assert
+                        Assert.True(
+                            (HttpStatusCode.Unauthorized == response.StatusCode) == expected,
+                            $"Response HTTP status code {(expected ? "should" : "shouldn't")} be 'Unauthorized' but was '{response.StatusCode}'");
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("known-subject", "known-issuername", false)]
+        [InlineData("unrecognizedSubjectName", "known-issuername", true)]
+        [InlineData("known-subject", "unrecognizedIssuerName", true)]
+        [InlineData("unrecognizedSubjectName", "unrecognizedIssuerName", true)]
+        public async Task AuthorizedRoute_WithCertificateAuthenticationViaConfigurationAndSecretProviderOnFilters_ShouldFailWithUnauthorized_WhenAnyClientCertificateValidationDoesntSucceeds(
+            string subjectValue,
+            string issuerValue,
+            bool expected)
+        {
+            // Arrange
+            const string subjectKey = "subject", issuerKey = "issuer";
+            using (X509Certificate2 clientCertificate = SelfSignedCertificate.CreateWithIssuerAndSubjectName(issuerValue, subjectValue))
+            {
+                var options = new TestApiServerOptions()
+                    .ConfigureAppConfiguration(config => config.AddInMemoryCollection(new []
+                    {
+                        new KeyValuePair<string, string>(subjectKey, "CN=known-subject")
+                    }))
+                    .ConfigureServices(services =>
+                    {
+                        var certificateValidator =
+                            new CertificateAuthenticationValidator(
+                                new CertificateAuthenticationConfigBuilder()
+                                    .WithSubject(X509ValidationLocation.Configuration, subjectKey)
+                                    .WithIssuer(X509ValidationLocation.SecretProvider, issuerKey)
+                                    .Build());
+
+                        services.AddSecretStore(stores => stores.AddInMemory(issuerKey, "CN=known-issuername"))
+                                .AddClientCertificate(clientCertificate)
+                                .AddSingleton(certificateValidator)
                                 .AddMvc(opt => opt.Filters.AddCertificateAuthentication());
                     });
 
@@ -250,7 +480,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                         services.AddSecretStore(stores => stores.AddInMemory(issuerKey, "CN=known-issuername"))
                                 .AddClientCertificate(clientCertificate)
                                 .AddSingleton(certificateValidator)
-                                .AddMvc(opt => opt.Filters.AddCertificateAuthentication());
+                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
                     });
 
                 await using (var server = await TestApiServer.StartNewAsync(options, _logger))
@@ -270,7 +500,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
         }
 
         [Fact]
-        public async Task AuthorizedRoute_WithCertificateAuthentication_ShouldFailOnInvalidBase64Format()
+        public async Task AuthorizedRoute_WithCertificateAuthenticationOnFilters_ShouldFailOnInvalidBase64Format()
         {
             // Arrange
             var options = new TestApiServerOptions()
@@ -300,8 +530,39 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
             }
         }
 
+         [Fact]
+        public async Task AuthorizedRoute_WithCertificateAuthentication_ShouldFailOnInvalidBase64Format()
+        {
+            // Arrange
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services =>
+                {
+                    var certificateValidator =
+                        new CertificateAuthenticationValidator(
+                            new CertificateAuthenticationConfigBuilder()
+                                .Build());
+
+                    services.AddSingleton(certificateValidator)
+                            .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                });
+
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                var request = HttpRequestBuilder
+                    .Get(NoneAuthenticationController.GetRoute)
+                    .WithHeader("X-ARR-ClientCert", "something not even close to an client certificate export");
+
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+                }
+            }
+        }
+
         [Fact]
-        public async Task AuthorizedRoute_WithCertificateAuthenticationInHeader_ShouldSucceed()
+        public async Task AuthorizedRoute_WithCertificateAuthenticationInHeaderOnFilters_ShouldSucceed()
         {
             // Arrange
             const string subjectKey = "subject", issuerKey = "issuer";
@@ -342,12 +603,55 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                 }
             }
         }
+
+         [Fact]
+        public async Task AuthorizedRoute_WithCertificateAuthenticationInHeader_ShouldSucceed()
+        {
+            // Arrange
+            const string subjectKey = "subject", issuerKey = "issuer";
+            using (X509Certificate2 clientCertificate = SelfSignedCertificate.CreateWithIssuerAndSubjectName("known-issuername", "known-subject"))
+            {
+                var options = new TestApiServerOptions()
+                    .ConfigureAppConfiguration(config => config.AddInMemoryCollection(new []
+                    {
+                        new KeyValuePair<string, string>(subjectKey, "CN=known-subject")
+                    }))
+                    .ConfigureServices(services =>
+                    {
+                        var certificateValidator =
+                            new CertificateAuthenticationValidator(
+                                new CertificateAuthenticationConfigBuilder()
+                                    .WithSubject(X509ValidationLocation.Configuration, subjectKey)
+                                    .WithIssuer(X509ValidationLocation.SecretProvider, issuerKey)
+                                    .Build());
+                        
+                        services.AddSecretStore(stores => stores.AddInMemory(issuerKey, "CN=known-issuername"))
+                                .AddSingleton(certificateValidator)
+                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                    });
+                
+                await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+                {
+                    string base64String = Convert.ToBase64String(clientCertificate.Export(X509ContentType.Pkcs12), Base64FormattingOptions.None);
+                    var request = HttpRequestBuilder
+                        .Get(NoneAuthenticationController.GetRoute)
+                        .WithHeader("X-ARR-ClientCert", base64String);
+
+                    // Act
+                    using (HttpResponseMessage response = await server.SendAsync(request))
+                    {
+                        // Assert
+                        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+                    }
+                }
+            }
+        }
         
         [Theory]
         [InlineData(BypassOnMethodController.CertificateRoute)]
         [InlineData(BypassCertificateController.BypassOverAuthenticationRoute)]
         [InlineData(AllowAnonymousCertificateController.Route)]
-        public async Task CertificateAuthorizedRoute_WithBypassAttribute_SkipsAuthentication(string route)
+        public async Task CertificateAuthorizedRoute_WithBypassAttributeOnFilters_SkipsAuthentication(string route)
         {
             // Arrange
             const string issuerKey = "issuer";
@@ -381,9 +685,48 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                 }
             }
         }
+
+         [Theory]
+        [InlineData(BypassOnMethodController.CertificateRoute)]
+        [InlineData(BypassCertificateController.BypassOverAuthenticationRoute)]
+        [InlineData(AllowAnonymousCertificateController.Route)]
+        public async Task CertificateAuthorizedRoute_WithBypassAttribute_SkipsAuthentication(string route)
+        {
+            // Arrange
+            const string issuerKey = "issuer";
+            using (X509Certificate2 clientCertificate = SelfSignedCertificate.CreateWithIssuerAndSubjectName("issuer", "subject"))
+            {
+                var options = new TestApiServerOptions()
+                    .ConfigureServices(services =>
+                    {
+                        var certificateValidator =
+                            new CertificateAuthenticationValidator(
+                                new CertificateAuthenticationConfigBuilder()
+                                    .WithIssuer(X509ValidationLocation.SecretProvider, issuerKey)
+                                    .Build());
+
+                        services.AddSecretStore(stores => stores.AddInMemory(issuerKey, "CN=issuer"))
+                                .AddClientCertificate(clientCertificate)
+                                .AddSingleton(certificateValidator)
+                                .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                    });
+
+                await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+                {
+                    var request = HttpRequestBuilder.Get(route);
+                    
+                    // Act
+                    using (HttpResponseMessage response = await server.SendAsync(request))
+                    {
+                        // Assert
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    }
+                }
+            }
+        }
         
         [Fact]
-        public async Task SharedAccessKeyAuthorizedRoute_DoesntEmitSecurityEventsByDefault_RunsAuthentication()
+        public async Task SharedAccessKeyAuthorizedRoute_DoesntEmitSecurityEventsByDefaultOnFilters_RunsAuthentication()
         {
             // Arrange
             const string issuerKey = "issuer";
@@ -422,6 +765,92 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
             }
         }
 
+         [Fact]
+        public async Task SharedAccessKeyAuthorizedRoute_DoesntEmitSecurityEventsByDefault_RunsAuthentication()
+        {
+            // Arrange
+            const string issuerKey = "issuer";
+            var spySink = new InMemorySink();
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services =>
+                {
+                    var certificateValidator =
+                        new CertificateAuthenticationValidator(
+                            new CertificateAuthenticationConfigBuilder()
+                                .WithIssuer(X509ValidationLocation.SecretProvider, issuerKey)
+                                .Build());
+
+                    services.AddSecretStore(stores => stores.AddInMemory(issuerKey, "CN=issuer"))
+                            .AddSingleton(certificateValidator)
+                            .AddMvc(opt => opt.AddCertificateAuthenticationFilter());
+                })
+                .ConfigureHost(host => host.UseSerilog((context, config) => config.WriteTo.Sink(spySink)));
+
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                var request = HttpRequestBuilder.Get(NoneAuthenticationController.GetRoute);
+                
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+                    IEnumerable<LogEvent> logEvents = spySink.DequeueLogEvents();
+                    Assert.DoesNotContain(logEvents, logEvent =>
+                    {
+                        string message = logEvent.RenderMessage();
+                        return message.Contains("EventType") && message.Contains("Security");
+                    });
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SharedAccessKeyAuthorizedRoute_EmitsSecurityEventsWhenRequestedOnFilters_RunsAuthentication(bool emitsSecurityEvents)
+        {
+            // Arrange
+            const string issuerKey = "issuer";
+            var spySink = new InMemorySink();
+            var options = new TestApiServerOptions()
+                .ConfigureServices(services =>
+                {
+                    var certificateValidator =
+                        new CertificateAuthenticationValidator(
+                            new CertificateAuthenticationConfigBuilder()
+                                .WithIssuer(X509ValidationLocation.SecretProvider, issuerKey)
+                                .Build());
+
+                    services.AddSecretStore(stores => stores.AddInMemory(issuerKey, "CN=issuer"))
+                            .AddSingleton(certificateValidator)
+                            .AddMvc(opt => opt.Filters.AddCertificateAuthentication(authOptions =>
+                            {
+                                authOptions.EmitSecurityEvents = emitsSecurityEvents;
+                            }));
+                })
+                .ConfigureHost(host => host.UseSerilog((context, config) => config.WriteTo.Sink(spySink)));
+
+            await using (var server = await TestApiServer.StartNewAsync(options, _logger))
+            {
+                var request = HttpRequestBuilder.Get(NoneAuthenticationController.GetRoute);
+                
+                // Act
+                using (HttpResponseMessage response = await server.SendAsync(request))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+                    IEnumerable<LogEvent> logEvents = spySink.DequeueLogEvents();
+                    Assert.True(emitsSecurityEvents == logEvents.Any(logEvent =>
+                    {
+                        string message = logEvent.RenderMessage();
+                        return message.Contains("EventType") && message.Contains("Security");
+                    }));
+                }
+            }
+        }
+
+        
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -441,7 +870,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
 
                     services.AddSecretStore(stores => stores.AddInMemory(issuerKey, "CN=issuer"))
                             .AddSingleton(certificateValidator)
-                            .AddMvc(opt => opt.Filters.AddCertificateAuthentication(authOptions =>
+                            .AddMvc(opt => opt.AddCertificateAuthenticationFilter(authOptions =>
                             {
                                 authOptions.EmitSecurityEvents = emitsSecurityEvents;
                             }));

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authentication/CertificateAuthenticationFilterTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authentication/CertificateAuthenticationFilterTests.cs
@@ -509,6 +509,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                     var certificateValidator =
                         new CertificateAuthenticationValidator(
                             new CertificateAuthenticationConfigBuilder()
+                                .WithSubject(X509ValidationLocation.Configuration, "ignored-subject")
                                 .Build());
 
                     services.AddSingleton(certificateValidator)
@@ -540,6 +541,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                     var certificateValidator =
                         new CertificateAuthenticationValidator(
                             new CertificateAuthenticationConfigBuilder()
+                                .WithSubject(X509ValidationLocation.Configuration, "ignored-subject")
                                 .Build());
 
                     services.AddSingleton(certificateValidator)

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authentication/CertificateAuthenticationConfigBuilderTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authentication/CertificateAuthenticationConfigBuilderTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Arcus.WebApi.Security.Authentication.Certificates;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Security.Authentication
+{
+    public class CertificateAuthenticationConfigBuilderTests
+    {
+        [Fact]
+        public void Build_WithoutAnything_Fails()
+        {
+            // Arrange
+            var builder = new CertificateAuthenticationConfigBuilder();
+
+            // Act / Assert
+            Assert.Throws<InvalidOperationException>(() => builder.Build());
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authentication/CertificateAuthenticationFilterTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authentication/CertificateAuthenticationFilterTests.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Arcus.WebApi.Security.Authentication.Certificates;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Security.Authentication
+{
+    public class CertificateAuthenticationFilterTests
+    {
+        [Fact]
+        public void Create_WithoutCertificateAuthenticationOptions_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => new CertificateAuthenticationFilter(options: null));
+        }
+    }
+}


### PR DESCRIPTION
Change target type of the certificate authentication to the MVC options itself.

Relates to #329