### PR TITLE
feat: change jwt target type

### DIFF
--- a/docs/preview/features/security/auth/jwt.md
+++ b/docs/preview/features/security/auth/jwt.md
@@ -47,9 +47,9 @@ builder.Services.AddControllers(mvcOptions =>
 {
     // Default configuration:
     // By default, the JWT authorization filter will use the Microsoft 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration' OpenID endpoint to request the configuration.
-    mvcOptions.Filters.AddJwtTokenAuthorization();
+    mvcOptions.AddJwtTokenAuthorizationFilter();
 
-    mvcOptions.Filters.AddJwtTokenAuthorization(options =>
+    mvcOptions.AddJwtTokenAuthorizationFilter(options =>
     {
         // Default configuration with validation parameters:
         // One can still use the default Microsoft OpenID endpoint and provide additional validation parameters to manipulate how the JWT token should be validated.
@@ -93,7 +93,7 @@ builder.Services.AddControllers(mvcOptions =>
     {
         {"aud", Issuer}
     };
-    mvcOptions.Filters.AddJwtTokenAuthorization(claimCheck);
+    mvcOptions.AddJwtTokenAuthorizationFilter(claimCheck);
 
      // Custom OpenID endpoint:
     // You can use your own custom OpenID endpoint by providing another the endpoint in the options; additionally with custom validation parameters and custom claims to manipulate how the JWT token should be validated.
@@ -102,7 +102,7 @@ builder.Services.AddControllers(mvcOptions =>
         {"aud", Issuer},
         {"oid", "fa323e12-e4b8-4e22-bb2a-b18cb4b76301"}
     };
-    mvcOptions.Filters.AddJwtTokenAuthorization(claimCheck);
+    mvcOptions.AddJwtTokenAuthorizationFilter(claimCheck);
 
     // Default configuration with validation parameters:
     // One can still use the default Microsoft OpenID endpoint and provide additional validation parameters and custom claims to manipulate how the JWT token should be validated.
@@ -113,7 +113,7 @@ builder.Services.AddControllers(mvcOptions =>
         {"oid", "fa323e12-e4b8-4e22-bb2a-b18cb4b76301"}
     };
 
-    mvcOptions.Filters.AddJwtTokenAuthorization(claimCheck);
+    mvcOptions.AddJwtTokenAuthorizationFilter(claimCheck);
 }});
 ```
 

--- a/src/Arcus.WebApi.Security/Authorization/Extensions/FilterCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authorization/Extensions/FilterCollectionExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Arcus.WebApi.Security.Authorization;
 using GuardNet;
+using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.AspNetCore.Mvc.Filters
@@ -17,6 +18,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         /// </summary>
         /// <param name="filters">All filters that are being applied to the request pipeline</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
+        [Obsolete("Use the " + nameof(MvcOptionsExtensions.AddJwtTokenAuthorizationFilter) + " instead via the services.AddControllers(options => options." + nameof(MvcOptionsExtensions.AddJwtTokenAuthorizationFilter) + "())")]
         public static FilterCollection AddJwtTokenAuthorization(this FilterCollection filters)
         {
             Guard.NotNull(filters, nameof(filters), "Requires a filter collection to add the JWT token authorization filter");
@@ -30,6 +32,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         /// <param name="filters">All filters that are being applied to the request pipeline</param>
         /// <param name="configureOptions">Configuration options for using JWT token authorization</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
+        [Obsolete("Use the " + nameof(MvcOptionsExtensions.AddJwtTokenAuthorizationFilter) + " instead via the services.AddControllers(options => options." + nameof(MvcOptionsExtensions.AddJwtTokenAuthorizationFilter) + "(...))")]
         public static FilterCollection AddJwtTokenAuthorization(
             this FilterCollection filters, 
             Action<JwtTokenAuthorizationOptions> configureOptions)
@@ -49,6 +52,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         /// <param name="claimCheck">Custom claims key-value pair to validate against</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="claimCheck"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="claimCheck"/> doesn't have any entries or one of the entries has blank key/value inputs.</exception>
+        [Obsolete("Use the " + nameof(MvcOptionsExtensions.AddJwtTokenAuthorizationFilter) + " instead via the services.AddControllers(options => options." + nameof(MvcOptionsExtensions.AddJwtTokenAuthorizationFilter) + "(...))")]
         public static FilterCollection AddJwtTokenAuthorization(
             this FilterCollection filters,
             IDictionary<string, string> claimCheck)
@@ -72,6 +76,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
         /// <param name="claimCheck">Custom claims key-value pair to validate against</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="claimCheck"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="claimCheck"/> doesn't have any entries or one of the entries has blank key/value inputs.</exception>
+        [Obsolete("Use the " + nameof(MvcOptionsExtensions.AddJwtTokenAuthorizationFilter) + " instead via the services.AddControllers(options => options." + nameof(MvcOptionsExtensions.AddJwtTokenAuthorizationFilter) + "(...))")]
         public static FilterCollection AddJwtTokenAuthorization(
             this FilterCollection filters,
             Action<JwtTokenAuthorizationOptions> configureOptions, IDictionary<string, string> claimCheck)

--- a/src/Arcus.WebApi.Security/Authorization/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authorization/Extensions/MvcOptionsExtensions.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Arcus.WebApi.Security.Authorization;
+using GuardNet;
+using Microsoft.AspNetCore.Mvc;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extensions on the <see cref="MvcOptions"/> related to authorization.
+    /// </summary>
+    public static partial class MvcOptionsExtensions
+    {
+        /// <summary>
+        /// Adds JWT token authorization.
+        /// </summary>
+        /// <param name="options">The options that are being applied to the request pipeline.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        public static MvcOptions AddJwtTokenAuthorizationFilter(this MvcOptions options)
+        {
+            Guard.NotNull(options, nameof(options), "Requires a filter collection to add the JWT token authorization filter");
+
+            return AddJwtTokenAuthorizationFilter(options, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Adds JWT token authorization.
+        /// </summary>
+        /// <param name="options">The options that are being applied to the request pipeline/</param>
+        /// <param name="configureOptions">The configuration options for using JWT token authorization.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        public static MvcOptions AddJwtTokenAuthorizationFilter(
+            this MvcOptions options, 
+            Action<JwtTokenAuthorizationOptions> configureOptions)
+        {
+            Guard.NotNull(options, nameof(options), "Requires a filter collection to add the JWT token authorization filter");
+
+            var authOptions= new JwtTokenAuthorizationOptions();
+            configureOptions?.Invoke(authOptions);
+            options.Filters.Add(new JwtTokenAuthorizationFilter(authOptions));
+
+            return options;
+        }
+        /// <summary>
+        /// Adds JWT token authorization.
+        /// </summary>
+        /// <param name="options">The options that are being applied to the request pipeline.</param>
+        /// <param name="claimCheck">The custom claims key-value pair to validate against.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="claimCheck"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="claimCheck"/> doesn't have any entries or one of the entries has blank key/value inputs.</exception>
+        public static MvcOptions AddJwtTokenAuthorizationFilter(
+            this MvcOptions options,
+            IDictionary<string, string> claimCheck)
+        {
+            Guard.NotNull(options, nameof(options), "Requires a filter collection to add the JWT token authorization filter");
+            Guard.NotNull(claimCheck, nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
+            Guard.NotAny(claimCheck, nameof(claimCheck), "Requires at least one entry in the set of claim checks to verify the claims in the request JWT");
+            Guard.For<ArgumentException>(() => claimCheck.Any(item => string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value)), 
+                "Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT");
+
+            return AddJwtTokenAuthorizationFilter(options, configureOptions: null, claimCheck: claimCheck);
+        }
+
+        /// <summary>
+        /// Adds JWT token authorization.
+        /// </summary>
+        /// <param name="options">The options that are being applied to the request pipeline.</param>
+        /// <param name="configureOptions">The configuration options for using JWT token authorization.</param>
+        /// <param name="claimCheck">The custom claims key-value pair to validate against.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="claimCheck"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="claimCheck"/> doesn't have any entries or one of the entries has blank key/value inputs.</exception>
+        public static MvcOptions AddJwtTokenAuthorizationFilter(
+            this MvcOptions options,
+            Action<JwtTokenAuthorizationOptions> configureOptions, 
+            IDictionary<string, string> claimCheck)
+        {
+            Guard.NotNull(options, nameof(options), "Requires a filter collection to add the JWT token authorization filter");
+            Guard.NotNull(claimCheck, nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
+            Guard.NotAny(claimCheck, nameof(claimCheck), "Requires at least one entry in the set of claim checks to verify the claims in the request JWT");
+            Guard.For<ArgumentException>(() => claimCheck.Any(item => string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value)), 
+                "Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT");
+
+            var authOptions = new JwtTokenAuthorizationOptions(claimCheck);
+            configureOptions?.Invoke(authOptions);
+            options.Filters.Add(new JwtTokenAuthorizationFilter(authOptions));
+
+            return options;
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authorization/JwtTokenAuthorizationFilterTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authorization/JwtTokenAuthorizationFilterTests.cs
@@ -604,7 +604,6 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authorization
             }
         }
 
-        
         [Theory]
         [InlineData(BypassOnMethodController.JwtRoute)]
         [InlineData(BypassJwtTokenAuthorizationController.BypassOverAuthorizationRoute)]

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authorization/FilterCollectionExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authorization/FilterCollectionExtensionsTests.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Xunit;
 
+// Ignore obsolete warnings.
+#pragma warning disable CS0618
+
 namespace Arcus.WebApi.Tests.Unit.Security.Authorization
 {
     public class FilterCollectionExtensionsTests

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authorization/MvcOptionsExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authorization/MvcOptionsExtensionsTests.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Security.Authorization
+{
+    public class MvcOptionsExtensionsTests
+    {
+        [Fact]
+        public void AddJwtTokenAuthorizationFilter_WithOptionsWithoutClaimCheck_Fails()
+        {
+            // Arrange
+            var options = new MvcOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddJwtTokenAuthorizationFilter(claimCheck: null, configureOptions: opt => { }));
+        }
+
+        [Fact]
+        public void AddJwtTokenAuthorizationFilter_WithOptionsWithEmptyClaimCheck_Fails()
+        {
+            // Arrange
+            var options = new MvcOptions();
+            var claimCheck = new Dictionary<string, string>();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddJwtTokenAuthorizationFilter(claimCheck: claimCheck, configureOptions: opt => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJwtTokenAuthorizationFilter_WithOptionsWithBlankKeyInClaimCheck_Fails(string key)
+        {
+            // Arrange
+            var options = new MvcOptions();
+            var claimCheck = new Dictionary<string, string> { [key ?? ""] = "some value" };
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddJwtTokenAuthorizationFilter(claimCheck: claimCheck, configureOptions: opt => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJwtTokenAuthorizationFilter_WithOptionsWithBlankValueInClaimCheck_Fails(string value)
+        {
+            // Arrange
+            var options = new MvcOptions();
+            var claimCheck = new Dictionary<string, string> { ["some key"] = value };
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddJwtTokenAuthorizationFilter(claimCheck: claimCheck, configureOptions: opt => { }));
+        }
+
+        [Fact]
+        public void AddJwtTokenAuthorizationFilter_WithoutClaimCheck_Fails()
+        {
+            // Arrange
+            var options = new MvcOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddJwtTokenAuthorizationFilter(claimCheck: null));
+        }
+
+        [Fact]
+        public void AddJwtTokenAuthorizationFilter_WithEmptyClaimCheck_Fails()
+        {
+            // Arrange
+            var options = new MvcOptions();
+            var claimCheck = new Dictionary<string, string>();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddJwtTokenAuthorizationFilter(claimCheck));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJwtTokenAuthorizationFilter_WithBlankKeyInClaimCheck_Fails(string key)
+        {
+            // Arrange
+            var options = new MvcOptions();
+            var claimCheck = new Dictionary<string, string> { [key ?? ""] = "some value" };
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddJwtTokenAuthorizationFilter(claimCheck));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJwtTokenAuthorizationFilter_WithBlankValueInClaimCheck_Fails(string value)
+        {
+            // Arrange
+            var options = new MvcOptions();
+            var claimCheck = new Dictionary<string, string> { ["some key"] = value };
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddJwtTokenAuthorizationFilter(claimCheck));
+        }
+    }
+}


### PR DESCRIPTION
Change target type of JWT authorization filter to the MVC options instead.

Relates to #329