### PR TITLE
test: circumvent non-ascii chars in json formatting tests

### DIFF
--- a/src/Arcus.WebApi.Tests.Integration/Hosting/Formatting/MvcOptionsExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Hosting/Formatting/MvcOptionsExtensionsTests.cs
@@ -41,7 +41,7 @@ namespace Arcus.WebApi.Tests.Integration.Hosting.Formatting
                     opt.InputFormatters.Add(new PlainTextInputFormatter());
                 }));
 
-            string sentence = BogusGenerator.Lorem.Sentence();
+            string sentence = string.Join(" ", BogusGenerator.Lorem.Words());
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
             {
                 var request = HttpRequestBuilder
@@ -71,7 +71,7 @@ namespace Arcus.WebApi.Tests.Integration.Hosting.Formatting
                     opt.OnlyAllowJsonFormatting();
                 }));
 
-            string sentence = BogusGenerator.Lorem.Sentence();
+            string sentence = string.Join(" ", BogusGenerator.Lorem.Words());
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
             {
                 var request = HttpRequestBuilder


### PR DESCRIPTION
Circumvent non-ASCII characters in the JSON formatting integration tests so that we don't fail on equalization assertion failures due to the fact that the non-ASCII characters were escaped in the returned string but not in the original string.

Closes #352