### PR TITLE
chore: improve http client correlation tracking exception message

### DIFF
--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
@@ -81,9 +81,9 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             if (correlation is null)
             {
                 throw new InvalidOperationException(
-                    "Cannot enrich the HTTP request with HTTP correlation because no HTTP correlation was registered in the application, " +
-                    "make sure that you register the HTTP correlation services with 'services.WithHttpCorrelationTracking()' " +
-                    "and that you use the HTTP correlation middleware 'app.UseHttpCorrelation()' in API scenario's");
+                    "Cannot enrich the HTTP request with HTTP correlation because no HTTP correlation was registered in the application, " 
+                    + "make sure that you register the HTTP correlation services with 'services.AddHttpCorrelation()' " 
+                    + "and that you use the HTTP correlation middleware 'app.UseHttpCorrelation()' in API scenario's");
             }
 
             return correlation;

--- a/src/Arcus.WebApi.Logging.Core/Extensions/IHttpClientBuilderExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/IHttpClientBuilderExtensions.cs
@@ -42,7 +42,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 if (correlationAccessor is null)
                 {
                     throw new InvalidOperationException(
-                        );
+                        "Cannot enrich the HTTP request with HTTP correlation because no HTTP correlation was registered in the application, " 
+                        + "make sure that you register the HTTP correlation services with 'services.AddHttpCorrelation()' " 
+                        + "and that you use the HTTP correlation middleware 'app.UseHttpCorrelation()' in API scenario's");
                 }
 
                 var options = new HttpCorrelationClientOptions();

--- a/src/Arcus.WebApi.Tests.Unit/Logging/IHttpClientBuilderExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/IHttpClientBuilderExtensionsTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Logging
+{
+    // ReSharper disable once InconsistentNaming
+    public class IHttpClientBuilderExtensionsTests
+    {
+        [Fact]
+        public void Add_WithHttpCorrelationInfoAccessor_Succeeds()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddHttpCorrelation();
+            IHttpClientBuilder builder = services.AddHttpClient("service-a");
+
+            // Act
+            builder.WithHttpCorrelationTracking();
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IHttpClientFactory>();
+            Assert.NotNull(factory.CreateClient("service-a"));
+        }
+
+        [Fact]
+        public void Add_WithoutHttpCorrelationInfoAccessor_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            IHttpClientBuilder builder = services.AddHttpClient("service-a");
+
+            // Act
+            builder.WithHttpCorrelationTracking();
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IHttpClientFactory>();
+            Assert.Throws<InvalidOperationException>(() => factory.CreateClient("service-a"));
+        }
+    }
+}


### PR DESCRIPTION
Improve exception message when registering the HTTP client with HTTP correlation tracking.

Follow-up #346