### PR TITLE
fix: correct default transaction id header name

### DIFF
--- a/docs/preview/features/correlation.md
+++ b/docs/preview/features/correlation.md
@@ -7,21 +7,6 @@ layout: default
 
 The `Arcus.WebApi.Correlation` library provides a way to add correlation between HTTP requests. 
 
-- [Correlation Between HTTP Requests](#correlation-between-http-requests)
-  - [How This Works](#how-this-works)
-  - [Installation](#installation)
-  - [Usage](#usage)
-    - [Sending side](#sending-side)
-    - [Receiving side](#receiving-side)
-  - [Configuration](#configuration)
-    - [Configuring HTTP correlation services](#configuring-http-correlation-services)
-    - [Configuring HTTP correlation client tracking](#configuring-http-correlation-client-tracking)
-  - [Dependency injection](#dependency-injection)
-  - [Logging](#logging)
-  - [Using correlation within Azure Functions](#using-correlation-within-azure-functions)
-    - [Installation](#installation-1)
-    - [Usage](#usage-1)
-
 ## How This Works
 
 This diagram shows an example of a user interacting with service A that calls another service B.

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
@@ -13,7 +13,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
     {
         private Func<string> _generateDependencyId = () => Guid.NewGuid().ToString();
         private string _upstreamServiceHeaderName = "Request-Id";
-        private string _transactionIdHeaderName = "X-Transaction-Id";
+        private string _transactionIdHeaderName = "X-Transaction-ID";
 
         /// <summary>
         /// Gets or sets the function to generate the dependency ID used when tracking HTTP dependencies.

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationOptionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationOptionsTests.cs
@@ -1,0 +1,20 @@
+﻿using Arcus.WebApi.Logging.Core.Correlation;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Logging
+{
+    public class HttpCorrelationOptionsTests
+    {
+        [Fact]
+        public void SendOptions_AndReceiveOptions_AreSame()
+        {
+            // Arrange
+            var sendOptions = new HttpCorrelationClientOptions();
+            var receiveOptions = new HttpCorrelationInfoOptions();
+
+            // Act
+            Assert.Equal(sendOptions.TransactionIdHeaderName, receiveOptions.Transaction.HeaderName);
+            Assert.Equal(sendOptions.UpstreamServiceHeaderName, receiveOptions.UpstreamService.HeaderName);
+        }
+    }
+}


### PR DESCRIPTION
Correct default transaction ID for both sending and receiving options.