### PR TITLE
(❗) feat: add telemetry context to http client correlation options

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/docs/preview/features/correlation.md
+++ b/docs/preview/features/correlation.md
@@ -180,6 +180,12 @@ builder.Services.AddHttpClient("from-service-a-to-service-b")
                     // The function to generate the dependency ID for the called service. 
                     // (service A tracks dependency with this ID, service B tracks request with this ID).
                     options.GenerateDependencyId = () => $"my-request-id-{Guid.NewGuid()}";
+
+                    // The dictionary containing any additional contextual inforamtion that will be used when tracking the HTTP dependency (Default: empty dictionary).
+                    options.AddTelemetryContext(new Dictionary<string, object>
+                    {
+                        ["My-HTTP-custom-key"] = "Any additional information"
+                    });
                 });
 ```
 

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
@@ -61,7 +61,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         /// <summary>
         /// Gets the telemetry context used during HTTP dependency tracking.
         /// </summary>
-        internal Dictionary<string, object> TelemetryContext { get; private set; } = new Dictionary<string, object>();
+        internal Dictionary<string, object> TelemetryContext { get; } = new Dictionary<string, object>();
 
         /// <summary>
         /// Adds a telemetry context while tracking the HTTP dependency.

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
@@ -73,7 +73,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             Guard.NotNull(telemetryContext, nameof(telemetryContext), "Requires a telemetry context dictionary to add to the HTTP dependency tracking");
             foreach (KeyValuePair<string, object> item in telemetryContext)
             {
-                TelemetryContext.Add(item.Key, item.Value);
+                TelemetryContext[item.Key] = item.Value;
             }
         }
     }

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using GuardNet;
 using Microsoft.Extensions.Logging;
@@ -55,6 +56,22 @@ namespace Arcus.WebApi.Logging.Core.Correlation
                 Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the HTTP request header where the transaction ID should be added when tracking HTTP dependencies");
                 _transactionIdHeaderName = value;
             }
+        }
+
+        /// <summary>
+        /// Gets the telemetry context used during HTTP dependency tracking.
+        /// </summary>
+        internal Dictionary<string, object> TelemetryContext { get; private set; } = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Adds a telemetry context while tracking the HTTP dependency.
+        /// </summary>
+        /// <param name="telemetryContext">The dictionary with contextual information about the dependency telemetry.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="telemetryContext"/> is <c>null</c>.</exception>
+        public void AddTelemetryContext(Dictionary<string, object> telemetryContext)
+        {
+            Guard.NotNull(telemetryContext, nameof(telemetryContext), "Requires a telemetry context dictionary to add to the HTTP dependency tracking");
+            TelemetryContext = telemetryContext;
         }
     }
 }

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
@@ -71,7 +71,10 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         public void AddTelemetryContext(Dictionary<string, object> telemetryContext)
         {
             Guard.NotNull(telemetryContext, nameof(telemetryContext), "Requires a telemetry context dictionary to add to the HTTP dependency tracking");
-            TelemetryContext = telemetryContext;
+            foreach (KeyValuePair<string, object> item in telemetryContext)
+            {
+                TelemetryContext.Add(item.Key, item.Value);
+            }
         }
     }
 }

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
@@ -70,7 +70,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
                 }
                 finally
                 {
-                    _logger.LogHttpDependency(request, statusCode, measurement, dependencyId);
+                    _logger.LogHttpDependency(request, statusCode, measurement, dependencyId, _options.TelemetryContext);
                 }
             }
         }

--- a/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
@@ -155,7 +155,7 @@ namespace System.Net.Http
                 }
                 finally
                 {
-                    logger.LogHttpDependency(request, statusCode, measurement, dependencyId);
+                    logger.LogHttpDependency(request, statusCode, measurement, dependencyId, options.TelemetryContext);
                 } 
             }
         }

--- a/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
+++ b/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
@@ -25,12 +25,15 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
+++ b/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
     <DocumentationFile>Arcus.WebApi.Tests.Integration.Open-Api.xml</DocumentationFile>

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Controllers/ServiceAController.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Controllers/ServiceAController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Arcus.Observability.Correlation;
@@ -18,7 +19,9 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Controllers
                             ServiceBUrlParameterName = "ServiceB_Url",
                             DependencyIdHeaderNameParameter = "DependencyId_HeaderName",
                             TransactionIdHeaderNameParameter = "TransactionId_HeaderName",
-                            DependencyIdGenerationParameter = "DependencyId_Generation";
+                            DependencyIdGenerationParameter = "DependencyId_Generation",
+                            TelemetryContextKey = "TelemetryContext_Key",
+                            TelemetryContextValue = "TelemetryContext_Value";
 
         private readonly HttpClient _client;
         private readonly HttpAssert _assertion;
@@ -53,6 +56,8 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Controllers
         public async Task<IActionResult> GetWithExtension(
             [FromHeader(Name = ServiceBUrlParameterName)] string url,
             [FromHeader(Name = DependencyIdGenerationParameter)] string dependencyIdGeneration,
+            [FromHeader(Name = TelemetryContextKey)] string telemetryContextKey,
+            [FromHeader(Name = TelemetryContextValue)] string telemetryContextValue,
             [FromHeader(Name = DependencyIdHeaderNameParameter)] string dependencyIdHeaderName = HttpCorrelationProperties.UpstreamServiceHeaderName,
             [FromHeader(Name = TransactionIdHeaderNameParameter)] string transactionIdHeaderName = HttpCorrelationProperties.TransactionIdHeaderName)
         {
@@ -68,6 +73,10 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Controllers
                        options.GenerateDependencyId = () => dependencyIdGeneration ?? Guid.NewGuid().ToString();
                        options.UpstreamServiceHeaderName = dependencyIdHeaderName;
                        options.TransactionIdHeaderName = transactionIdHeaderName;
+                       options.AddTelemetryContext(new Dictionary<string, object>
+                       {
+                           [telemetryContextKey ?? "<no-key>"] = telemetryContextValue
+                       });
                    }))
             {
                 return StatusCode((int) response.StatusCode);

--- a/src/Arcus.WebApi.Tests.Integration/Logging/HttpCorrelationMessageHandlerTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/HttpCorrelationMessageHandlerTests.cs
@@ -192,7 +192,6 @@ namespace Arcus.WebApi.Tests.Integration.Logging
 
                     string actualDependencyId = GetDependencyIdFromTrackedDependency(trackedDependency);
                     Assert.Equal(expectedDependencyId, actualDependencyId);
-
                 }
             }
         }

--- a/src/Arcus.WebApi.Tests.Integration/Logging/HttpCorrelationMessageHandlerTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/HttpCorrelationMessageHandlerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -12,6 +13,7 @@ using Arcus.WebApi.Tests.Integration.Logging.Fixture;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyModel;
 using Serilog;
 using Serilog.Events;
 using Xunit;
@@ -71,7 +73,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
                 {
                     // Assert
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                    
+
                     string dependencyIdInTelemetry = GetDependencyIdFromTrackedDependencyTelemetry(spySink);
                     Assert.Equal(dependencyIdInTelemetry, dependencyIdAtServiceB);
                 }
@@ -133,8 +135,8 @@ namespace Arcus.WebApi.Tests.Integration.Logging
             string dependencyIdHeaderName)
         {
             // Arrange
-            var expectedDependencyId = Guid.NewGuid().ToString();
-            var expectedTransactionId = Guid.NewGuid().ToString();
+            string expectedDependencyId = Guid.NewGuid().ToString(), expectedTransactionId = Guid.NewGuid().ToString();
+            string telemetryContextKey = $"key-{Guid.NewGuid()}", telemetryContextValue = $"value-{Guid.NewGuid()}";
 
             var spySink = new InMemorySink();
             var options = new TestApiServerOptions()
@@ -162,6 +164,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
                                 options.GenerateDependencyId = () => expectedDependencyId;
                                 options.TransactionIdHeaderName = transactionIdHeaderName;
                                 options.UpstreamServiceHeaderName = dependencyIdHeaderName;
+                                options.AddTelemetryContext(new Dictionary<string, object> { [telemetryContextKey] = telemetryContextValue });
                             });
                 })
                 .Configure(app => app.UseHttpCorrelation())
@@ -169,7 +172,9 @@ namespace Arcus.WebApi.Tests.Integration.Logging
 
             HttpRequestBuilder request =
                 CreateHttpRequestToServiceA(ServiceAController.RouteWithMessageHandler, options)
-                    .WithHeader(transactionIdHeaderName, expectedTransactionId);
+                    .WithHeader(transactionIdHeaderName, expectedTransactionId)
+                    .WithHeader(ServiceAController.TelemetryContextKey, telemetryContextKey)
+                    .WithHeader(ServiceAController.TelemetryContextValue, telemetryContextValue);
 
             await using (var server = await TestApiServer.StartNewAsync(options, _logger))
             {
@@ -179,8 +184,15 @@ namespace Arcus.WebApi.Tests.Integration.Logging
                     // Assert
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-                    string actualDependencyId = GetDependencyIdFromTrackedDependencyTelemetry(spySink);
+                    StructureValue trackedDependency = GetTrackedDependency(spySink);
+                    Assert.Single(trackedDependency.Properties, 
+                        prop => prop.Name == "Context" 
+                                && prop.Value.ToStringValue().Contains(telemetryContextKey) 
+                                && prop.Value.ToStringValue().Contains(telemetryContextValue));
+
+                    string actualDependencyId = GetDependencyIdFromTrackedDependency(trackedDependency);
                     Assert.Equal(expectedDependencyId, actualDependencyId);
+
                 }
             }
         }
@@ -244,7 +256,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging
             }
         }
 
-        private static HttpRequestBuilder CreateHttpRequestToServiceA(string routeToServiceA, TestApiServerOptions options)
+        private HttpRequestBuilder CreateHttpRequestToServiceA(string routeToServiceA, TestApiServerOptions options)
         {
             var request = HttpRequestBuilder
                 .Get(routeToServiceA)
@@ -293,28 +305,38 @@ namespace Arcus.WebApi.Tests.Integration.Logging
         private static string AssertHeaderAvailable(HttpContext context, string headerName)
         {
             string headerValue = context.Request.Headers[headerName];
-            Assert.NotNull(headerValue);
-            Assert.NotEmpty(headerValue);
+            Assert.False(string.IsNullOrWhiteSpace(headerValue), $"HTTP request header '{headerName}' only contains a blank header value");
 
             return headerValue;
         }
 
         private static string GetDependencyIdFromTrackedDependencyTelemetry(InMemorySink spySink)
         {
+            StructureValue dependency = GetTrackedDependency(spySink);
+
+            string dependencyId = GetDependencyIdFromTrackedDependency(dependency);
+            return dependencyId;
+        }
+
+        private static string GetDependencyIdFromTrackedDependency(StructureValue trackedDependency)
+        {
+            string actualDependencyId = Assert.Single(trackedDependency.Properties, prop => prop.Name == "DependencyId").Value.ToStringValue();
+            Assert.False(string.IsNullOrWhiteSpace(actualDependencyId), "Logged dependency ID only contains blank value");
+
+            return actualDependencyId;
+        }
+
+        private static StructureValue GetTrackedDependency(InMemorySink spySink)
+        {
             LogEvent[] logEvents = spySink.DequeueLogEvents().ToArray();
             Assert.NotEmpty(logEvents);
 
             LogEvent dependencyLogEvent = Assert.Single(logEvents, ev => ev.MessageTemplate.Text == "{@Dependency}");
-
             LogEventPropertyValue dependencyProperty = Assert.Contains("Dependency", dependencyLogEvent.Properties);
             var dependency = Assert.IsType<StructureValue>(dependencyProperty);
             Assert.Contains(dependency.Properties, prop => prop.Name == "DependencyName" && prop.Value.ToStringValue() == "GET /service-b");
-            string actualDependencyId = Assert.Single(dependency.Properties, prop => prop.Name == "DependencyId").Value.ToStringValue();
-            
-            Assert.NotNull(actualDependencyId);
-            Assert.NotEmpty(actualDependencyId);
 
-            return actualDependencyId;
+            return dependency;
         }
     }
 }

--- a/src/Arcus.WebApi.Tests.Runtimes.AzureFunction/Dockerfile
+++ b/src/Arcus.WebApi.Tests.Runtimes.AzureFunction/Dockerfile
@@ -4,7 +4,7 @@ FROM mcr.microsoft.com/azure-functions/dotnet:4.0 AS base
 WORKDIR /home/site/wwwroot
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-bullseye-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0.400-bullseye-slim AS build
 WORKDIR /src
 COPY ["Arcus.WebApi.Tests.Runtimes.AzureFunction/Arcus.WebApi.Tests.Runtimes.AzureFunction.csproj", "Arcus.WebApi.Tests.Runtimes.AzureFunction/"]
 RUN dotnet restore "Arcus.WebApi.Tests.Runtimes.AzureFunction/Arcus.WebApi.Tests.Runtimes.AzureFunction.csproj"

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpClientExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpClientExtensionsTests.cs
@@ -54,7 +54,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             string key1 = Guid.NewGuid().ToString(), value1 = Guid.NewGuid().ToString();
             var context1 = new Dictionary<string, object> { [key1] = value1 };
             string key2 = Guid.NewGuid().ToString(), value2 = Guid.NewGuid().ToString();
-            var context2 = new Dictionary<string, object> { [key2] = value2 };
+            var context2 = new Dictionary<string, object> { [key2] = value2, [key1] = value2 };
 
             var assertion = new AssertHttpMessageHandler(statusCode, req =>
             {
@@ -78,7 +78,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             AssertLoggedHttpDependency(message, request, statusCode);
             Assert.Contains(key1, message);
             Assert.Contains(key2, message);
-            Assert.Contains(value1, message);
+            Assert.DoesNotContain(value1, message);
             Assert.Contains(value2, message);
         }
 

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpClientExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpClientExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -40,6 +41,37 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             // Assert
             string message = Assert.Single(logger.Messages);
             AssertLoggedHttpDependency(message, request, statusCode);
+        }
+
+        [Fact]
+        public async Task SendWithAccessor_TelemetryContext_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var accessor = new StubHttpCorrelationInfoAccessor(correlation);
+            var logger = new InMemoryLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            string key = Guid.NewGuid().ToString(), value = Guid.NewGuid().ToString();
+            var telemetryContext = new Dictionary<string, object> { [key] = value };
+
+            var assertion = new AssertHttpMessageHandler(statusCode, req =>
+            {
+                // Assert
+                AssertHeaderValue(req, HttpCorrelationProperties.TransactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderAvailable(req, HttpCorrelationProperties.UpstreamServiceHeaderName);
+            });
+
+            var client = new HttpClient(assertion);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+
+            // Act
+            await client.SendAsync(request, accessor, logger, options => options.AddTelemetryContext(telemetryContext));
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, statusCode);
+            Assert.Contains(key, message);
+            Assert.Contains(value, message);
         }
 
         [Fact]
@@ -146,6 +178,36 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             // Assert
             string message = Assert.Single(logger.Messages);
             AssertLoggedHttpDependency(message, request, statusCode);
+        }
+
+        [Fact]
+        public async Task SendWithCorrelation_TelemetryContext_TracksRequest()
+        {
+            // Arrange
+            CorrelationInfo correlation = GenerateCorrelationInfo();
+            var logger = new InMemoryLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            string key = Guid.NewGuid().ToString(), value = Guid.NewGuid().ToString();
+            var telemetryContext = new Dictionary<string, object> { [key] = value };
+
+            var assertion = new AssertHttpMessageHandler(statusCode, req =>
+            {
+                // Assert
+                AssertHeaderValue(req, HttpCorrelationProperties.TransactionIdHeaderName, correlation.TransactionId);
+                AssertHeaderAvailable(req, HttpCorrelationProperties.UpstreamServiceHeaderName);
+            });
+
+            var client = new HttpClient(assertion);
+            HttpRequestMessage request = GenerateHttpRequestMessage();
+
+            // Act
+            await client.SendAsync(request, correlation, logger, options => options.AddTelemetryContext(telemetryContext));
+
+            // Assert
+            string message = Assert.Single(logger.Messages);
+            AssertLoggedHttpDependency(message, request, statusCode);
+            Assert.Contains(key, message);
+            Assert.Contains(value, message);
         }
 
         [Fact]

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpClientExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpClientExtensionsTests.cs
@@ -51,8 +51,10 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             var accessor = new StubHttpCorrelationInfoAccessor(correlation);
             var logger = new InMemoryLogger();
             var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
-            string key = Guid.NewGuid().ToString(), value = Guid.NewGuid().ToString();
-            var telemetryContext = new Dictionary<string, object> { [key] = value };
+            string key1 = Guid.NewGuid().ToString(), value1 = Guid.NewGuid().ToString();
+            var context1 = new Dictionary<string, object> { [key1] = value1 };
+            string key2 = Guid.NewGuid().ToString(), value2 = Guid.NewGuid().ToString();
+            var context2 = new Dictionary<string, object> { [key2] = value2 };
 
             var assertion = new AssertHttpMessageHandler(statusCode, req =>
             {
@@ -65,13 +67,19 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             HttpRequestMessage request = GenerateHttpRequestMessage();
 
             // Act
-            await client.SendAsync(request, accessor, logger, options => options.AddTelemetryContext(telemetryContext));
+            await client.SendAsync(request, accessor, logger, options =>
+            {
+                options.AddTelemetryContext(context1);
+                options.AddTelemetryContext(context2);
+            });
 
             // Assert
             string message = Assert.Single(logger.Messages);
             AssertLoggedHttpDependency(message, request, statusCode);
-            Assert.Contains(key, message);
-            Assert.Contains(value, message);
+            Assert.Contains(key1, message);
+            Assert.Contains(key2, message);
+            Assert.Contains(value1, message);
+            Assert.Contains(value2, message);
         }
 
         [Fact]

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationClientOptionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationClientOptionsTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Arcus.WebApi.Logging.Core.Correlation;
 using Xunit;
 
@@ -31,7 +30,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             options.TransactionIdHeaderName = headerName;
 
             // Assert
-            Assert.True(string.IsNullOrWhiteSpace(headerName));
+            Assert.False(string.IsNullOrWhiteSpace(headerName));
         }
 
         [Theory]
@@ -69,7 +68,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             options.UpstreamServiceHeaderName = headerName;
 
             // Assert
-            Assert.True(string.IsNullOrWhiteSpace(headerName));
+            Assert.False(string.IsNullOrWhiteSpace(headerName));
         }
 
         [Theory]

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationClientOptionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationClientOptionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Arcus.WebApi.Logging.Core.Correlation;
 using Xunit;
 

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationClientOptionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpCorrelationClientOptionsTests.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using Arcus.WebApi.Logging.Core.Correlation;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Logging
+{
+    public class HttpCorrelationClientOptionsTests
+    {
+        [Fact]
+        public void TransactionIdHeaderName_WithNoAction_UsesDefault()
+        {
+            // Arrange
+            var options = new HttpCorrelationClientOptions();
+
+            // Act
+            string headerName = options.TransactionIdHeaderName;
+
+            // Assert
+            Assert.False(string.IsNullOrWhiteSpace(headerName));
+        }
+
+        [Fact]
+        public void TransactionIdHeaderName_SetValue_UsesValue()
+        {
+            // Arrange
+            var options = new HttpCorrelationClientOptions();
+            string headerName = Guid.NewGuid().ToString();
+
+            // Act
+            options.TransactionIdHeaderName = headerName;
+
+            // Assert
+            Assert.True(string.IsNullOrWhiteSpace(headerName));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void TransactionIdHeaderName_WithoutValue_Fails(string headerName)
+        {
+            // Arrange
+            var options = new HttpCorrelationClientOptions();
+
+            // ACt / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.TransactionIdHeaderName = headerName);
+        }
+
+        [Fact]
+        public void UpstreamServiceHeaderName_WithNoAction_UsesDefault()
+        {
+            // Arrange
+            var options = new HttpCorrelationClientOptions();
+
+            // Act
+            string headerName = options.UpstreamServiceHeaderName;
+
+            // Assert
+            Assert.False(string.IsNullOrWhiteSpace(headerName));
+        }
+
+        [Fact]
+        public void UpstreamServiceHeaderName_SetValue_UsesValue()
+        {
+            // Arrange
+            var options = new HttpCorrelationClientOptions();
+            string headerName = Guid.NewGuid().ToString();
+
+            // Act
+            options.UpstreamServiceHeaderName = headerName;
+
+            // Assert
+            Assert.True(string.IsNullOrWhiteSpace(headerName));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void UpstreamServiceHeaderName_WithoutValue_Fails(string headerName)
+        {
+            // Arrange
+            var options = new HttpCorrelationClientOptions();
+
+            // ACt / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.UpstreamServiceHeaderName = headerName);
+        }
+
+        [Fact]
+        public void GenerateDependencyId_WithoutAction_GeneratesDefault()
+        {
+            // Arrange
+            var options = new HttpCorrelationClientOptions();
+
+            // Act
+            string dependencyId = options.GenerateDependencyId();
+
+            // Assert
+            Assert.False(string.IsNullOrWhiteSpace(dependencyId));
+        }
+
+        [Fact]
+        public void GenerateDependencyId_WithValue_UsesValue()
+        {
+            // Arrange
+            var options = new HttpCorrelationClientOptions();
+            string dependencyId = Guid.NewGuid().ToString();
+
+            // Act
+            options.GenerateDependencyId = () => dependencyId;
+
+            // Assert
+            Assert.Equal(dependencyId, options.GenerateDependencyId());
+        }
+
+        [Fact]
+        public void GenerateDependencyId_WithoutValue_Fails()
+        {
+            // Arrange
+            var options = new HttpCorrelationClientOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.GenerateDependencyId = null);
+        }
+
+        [Fact]
+        public void AddTelemetryContext_WithoutValue_Fails()
+        {
+            // Arrange
+            var options = new HttpCorrelationClientOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.AddTelemetryContext(telemetryContext: null));
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpMessageHandlerTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpMessageHandlerTests.cs
@@ -182,7 +182,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
         public void Create_WithoutHttpContextAccessor_Fails()
         {
             // Arrange
-            var options = new HttpCorrelationClientOptions();
+            var options = new HttpCorrelationClientOptionsTests();
             var logger = NullLogger<HttpCorrelationMessageHandler>.Instance;
 
             // Act / Assert
@@ -207,7 +207,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
         {
             // Arrange
             var accessor = Mock.Of<IHttpCorrelationInfoAccessor>();
-            var options = new HttpCorrelationClientOptions();
+            var options = new HttpCorrelationClientOptionsTests();
 
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(() =>

--- a/src/Arcus.WebApi.Tests.Unit/Logging/HttpMessageHandlerTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/HttpMessageHandlerTests.cs
@@ -182,7 +182,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
         public void Create_WithoutHttpContextAccessor_Fails()
         {
             // Arrange
-            var options = new HttpCorrelationClientOptionsTests();
+            var options = new HttpCorrelationClientOptions();
             var logger = NullLogger<HttpCorrelationMessageHandler>.Instance;
 
             // Act / Assert
@@ -207,7 +207,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging
         {
             // Arrange
             var accessor = Mock.Of<IHttpCorrelationInfoAccessor>();
-            var options = new HttpCorrelationClientOptionsTests();
+            var options = new HttpCorrelationClientOptions();
 
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(() =>


### PR DESCRIPTION
Enhances HTTP client correlation options to pass telemetry context so that the following tracked HTTP dependency has additional custom dimensions.

Closes #370