### PR TITLE
feat: simplify cert auth validation registration

### DIFF
--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationAttribute.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Arcus.WebApi.Security.Authentication.Certificates
@@ -20,7 +21,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         public CertificateAuthenticationAttribute() : base(typeof(CertificateAuthenticationFilter))
         {
             _options = new CertificateAuthenticationOptions();
-            Arguments = new object[] { _options };
+            Arguments = new object[] { new NullCertificateAuthenticationValidator(), _options };
         }
 
         /// <summary>

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
@@ -34,6 +34,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <summary>
         /// Initializes a new instance of the <see cref="CertificateAuthenticationFilter" /> class.
         /// </summary>
+        [Obsolete("Use the new constructor with the certificate authentication filter instead")]
         public CertificateAuthenticationFilter() : this(new CertificateAuthenticationOptions())
         {
         }
@@ -43,6 +44,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// </summary>
         /// <param name="options">The set of additional consumer-configurable options to change the behavior of the certificate authentication.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        [Obsolete("Use the new constructor with the certificate authentication filter instead")]
         public CertificateAuthenticationFilter(CertificateAuthenticationOptions options)
         {
             Guard.NotNull(options, nameof(options), "Requires a set of additional consumer-configurable options to determine the behavior of the certificate authentication");

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
@@ -112,20 +112,20 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
 
         private CertificateAuthenticationValidator DetermineCertificateValidator(IServiceProvider services)
         {
-            if (_validator != null)
+            if (_validator is NullCertificateAuthenticationValidator)
             {
-                return _validator;
+                var validator = services.GetService<CertificateAuthenticationValidator>();
+                if (validator is null)
+                {
+                    throw new InvalidOperationException(
+                        $"No configured {nameof(CertificateAuthenticationValidator)} instance found in the request services container. "
+                        + "Please configure such an instance (ex. in the Startup) of your application");
+                }
+
+                return validator;
             }
 
-            var validator = services.GetService<CertificateAuthenticationValidator>();
-            if (validator is null)
-            {
-                throw new InvalidOperationException(
-                    $"No configured {nameof(CertificateAuthenticationValidator)} instance found in the request services container. "
-                    + "Please configure such an instance (ex. in the Startup) of your application");
-            }
-
-            return validator;
+            return _validator;
         }
 
         private static bool TryGetClientCertificateFromRequest(HttpContext context, ILogger logger, out X509Certificate2 clientCertificate)

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
@@ -112,7 +112,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
 
         private CertificateAuthenticationValidator DetermineCertificateValidator(IServiceProvider services)
         {
-            if (_validator is NullCertificateAuthenticationValidator)
+            if (_validator is null || _validator is NullCertificateAuthenticationValidator)
             {
                 var validator = services.GetService<CertificateAuthenticationValidator>();
                 if (validator is null)

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
@@ -28,6 +28,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         private const string Base64Pattern = @"^[a-zA-Z0-9\+/]*={0,3}$";
         private static readonly Regex Base64Regex = new Regex(Base64Pattern, RegexOptions.Compiled);
 
+        private readonly CertificateAuthenticationValidator _validator;
         private readonly CertificateAuthenticationOptions _options;
 
         /// <summary>
@@ -45,6 +46,23 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         public CertificateAuthenticationFilter(CertificateAuthenticationOptions options)
         {
             Guard.NotNull(options, nameof(options), "Requires a set of additional consumer-configurable options to determine the behavior of the certificate authentication");
+            _options = options;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CertificateAuthenticationFilter" /> class.
+        /// </summary>
+        /// <param name="validator">The instance to validate the incoming client certificate.</param>
+        /// <param name="options">The set of additional consumer-configurable options to change the behavior of the certificate authentication.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="validator"/> or the <paramref name="options"/> is <c>null</c>.</exception>
+        public CertificateAuthenticationFilter(
+            CertificateAuthenticationValidator validator,
+            CertificateAuthenticationOptions options)
+        {
+            Guard.NotNull(validator, nameof(validator), "Requires an instance to validate the incoming client certificate of the HTTP request");
+            Guard.NotNull(options, nameof(options), "Requires a set of additional consumer-configurable options to determine the behavior of the certificate authentication");
+
+            _validator = validator;
             _options = options;
         }
 
@@ -68,13 +86,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
                 return;
             }
 
-            var validator = services.GetService<CertificateAuthenticationValidator>();
-            if (validator is null)
-            {
-                throw new KeyNotFoundException(
-                    $"No configured {nameof(CertificateAuthenticationValidator)} instance found in the request services container. "
-                    + "Please configure such an instance (ex. in the Startup) of your application");
-            }
+            CertificateAuthenticationValidator validator = DetermineCertificateValidator(services);
 
             if (TryGetClientCertificateFromRequest(context.HttpContext, logger, out X509Certificate2 clientCertificate))
             {
@@ -94,6 +106,24 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
                 LogSecurityEvent(logger, "No client certificate is specified in the request while this authentication filter requires a certificate to validate on the configured validation requirements", HttpStatusCode.Unauthorized);
                 context.Result = new UnauthorizedObjectResult("No client certificate found in request");
             }
+        }
+
+        private CertificateAuthenticationValidator DetermineCertificateValidator(IServiceProvider services)
+        {
+            if (_validator != null)
+            {
+                return _validator;
+            }
+
+            var validator = services.GetService<CertificateAuthenticationValidator>();
+            if (validator is null)
+            {
+                throw new InvalidOperationException(
+                    $"No configured {nameof(CertificateAuthenticationValidator)} instance found in the request services container. "
+                    + "Please configure such an instance (ex. in the Startup) of your application");
+            }
+
+            return validator;
         }
 
         private static bool TryGetClientCertificateFromRequest(HttpContext context, ILogger logger, out X509Certificate2 clientCertificate)

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/IServiceCollectionExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Arcus.WebApi.Security.Authentication.Certificates;
+using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extensions on the <see cref="IServiceCollection"/> to more easily register the <see cref="CertificateAuthenticationValidator"/>.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class IServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds certificate authentication validation to the application services.
+        /// This is required if the certificate authentication is set up in the application via attributes instead of global authentication filters.
+        /// </summary>
+        /// <remarks>
+        ///     When the Arcus secret store is used during the <paramref name="configureAuthentication"/> to register the certificate locations,
+        ///     make sure that the secret store is registered to avoid runtime failures.
+        ///     For more information on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.
+        /// </remarks>
+        /// <param name="services">The application services to register the certificate authentication validator.</param>
+        /// <param name="configureAuthentication">
+        ///     The function to configure what information of the certificate should be used to validate the certificate during authentication.
+        ///     Requires at least a single configuration location to validate the certificate.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="configureAuthentication"/> is <c>null</c></exception>
+        /// <exception cref="InvalidOperationException">
+        ///     Thrown when no authentication location on the certificate was configured during the <paramref name="configureAuthentication"/> function.
+        /// </exception>
+        public static IServiceCollection AddCertificateAuthenticationValidation(
+            this IServiceCollection services,
+            Action<CertificateAuthenticationConfigBuilder> configureAuthentication)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a set of application services to register the certificate authentication validator");
+            Guard.NotNull(configureAuthentication, nameof(configureAuthentication), "Requires a function to configure the certificate validation locations");
+
+            var builder = new CertificateAuthenticationConfigBuilder();
+            configureAuthentication(builder);
+            CertificateAuthenticationConfig config = builder.Build();
+
+            return services.AddSingleton(new CertificateAuthenticationValidator(config));
+        }
+    }
+}

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/MvcOptionsExtensions.cs
@@ -11,12 +11,17 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static partial class MvcOptionsExtensions
     {
-         /// <summary>
+        /// <summary>
         /// Adds an certificate authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request.
         /// </summary>
+        /// <remarks>
+        ///     Using this extension requires you to register an <see cref="CertificateAuthenticationValidator"/> instance yourself in the application services.
+        ///     Use <see cref="AddCertificateAuthenticationFilter(MvcOptions,Action{CertificateAuthenticationConfigBuilder})"/> extension overload to configure this validator directly.
+        /// </remarks>
         /// <param name="options">The current MVC options of the application.</param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        [Obsolete("Use the " + nameof(AddCertificateAuthenticationFilter) + " overload where the certificate validation locations are configured directly")]
         public static MvcOptions AddCertificateAuthenticationFilter(this MvcOptions options)
         {
             Guard.NotNull(options, nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
@@ -27,12 +32,16 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds an certificate authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request.
         /// </summary>
+        /// <remarks>
+        ///     Using this extension requires you to register an <see cref="CertificateAuthenticationValidator"/> instance yourself in the application services.
+        ///     Use <see cref="AddCertificateAuthenticationFilter(MvcOptions,Action{CertificateAuthenticationConfigBuilder})"/> extension overload to configure this validator directly.
+        /// </remarks>
         /// <param name="options">The current MVC options of the application.</param>
         /// <param name="configureOptions">
         ///     The optional function to configure the set of additional consumer-configurable options to change the behavior of the certificate authentication.
         /// </param>
-        /// <returns></returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        [Obsolete("Use the " + nameof(AddCertificateAuthenticationFilter) + " overload where the certificate validation locations are configured directly")]
         public static MvcOptions AddCertificateAuthenticationFilter(
             this MvcOptions options,
             Action<CertificateAuthenticationOptions> configureOptions)
@@ -43,6 +52,75 @@ namespace Microsoft.Extensions.DependencyInjection
             configureOptions?.Invoke(authOptions);
 
             options.Filters.Add(new CertificateAuthenticationFilter(authOptions));
+            return options;
+        }
+
+        /// <summary>
+        /// Adds an certificate authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request.
+        /// </summary>
+        /// <remarks>
+        ///     When the Arcus secret store is used during the <paramref name="configureAuthentication"/> to register the certificate locations,
+        ///     make sure that the secret store is registered to avoid runtime failures.
+        ///     For more information on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.
+        /// </remarks>
+        /// <param name="options">The current MVC options of the application.</param>
+        /// <param name="configureAuthentication">
+        ///     The function to configure what information of the certificate should be used to validate the certificate during authentication.
+        ///     Requires at least a single configuration location to validate the certificate.
+        /// </param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     Thrown when no authentication location on the certificate was configured during the <paramref name="configureAuthentication"/> function.
+        /// </exception>
+        public static MvcOptions AddCertificateAuthenticationFilter(
+            this MvcOptions options,
+            Action<CertificateAuthenticationConfigBuilder> configureAuthentication)
+        {
+            Guard.NotNull(options, nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
+            Guard.NotNull(configureAuthentication, nameof(configureAuthentication), "Requires a function to configure the certificate validation locations");
+
+            return AddCertificateAuthenticationFilter(options, configureAuthentication, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Adds an certificate authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request.
+        /// </summary>
+        /// <remarks>
+        ///     When the Arcus secret store is used during the <paramref name="configureAuthentication"/> to register the certificate locations,
+        ///     make sure that the secret store is registered to avoid runtime failures.
+        ///     For more information on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.
+        /// </remarks>
+        /// <param name="options">The current MVC options of the application.</param>
+        /// <param name="configureAuthentication">
+        ///     The function to configure what information of the certificate should be used to validate the certificate during authentication.
+        ///     Requires at least a single configuration location to validate the certificate.
+        /// </param>
+        /// <param name="configureOptions">
+        ///     The optional function to configure the set of additional consumer-configurable options to change the behavior of the certificate authentication.
+        /// </param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> or the <paramref name="configureAuthentication"/> is <c>null</c>.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     Thrown when no authentication location on the certificate was configured during the <paramref name="configureAuthentication"/> function.
+        /// </exception>
+        public static MvcOptions AddCertificateAuthenticationFilter(
+            this MvcOptions options,
+            Action<CertificateAuthenticationConfigBuilder> configureAuthentication,
+            Action<CertificateAuthenticationOptions> configureOptions)
+        {
+            Guard.NotNull(options, nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
+            Guard.NotNull(configureAuthentication, nameof(configureAuthentication), "Requires a function to configure the certificate validation locations");
+
+            var builder = new CertificateAuthenticationConfigBuilder();
+            configureAuthentication(builder);
+            CertificateAuthenticationConfig config = builder.Build();
+            var validator = new CertificateAuthenticationValidator(config);
+
+            var authOptions = new CertificateAuthenticationOptions();
+            configureOptions?.Invoke(authOptions);
+
+            options.Filters.Add(new CertificateAuthenticationFilter(validator, authOptions));
             return options;
         }
     }

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/NullCertificateAuthenticationValidator.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/NullCertificateAuthenticationValidator.cs
@@ -14,7 +14,6 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         internal NullCertificateAuthenticationValidator() 
             : base(new CertificateAuthenticationConfig(new Dictionary<X509ValidationRequirement, (IX509ValidationLocation location, string configuredKey)>()))
         {
-            
         }
     }
 }

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/NullCertificateAuthenticationValidator.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/NullCertificateAuthenticationValidator.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using Arcus.WebApi.Security.Authentication.Certificates.Interfaces;
+
+namespace Arcus.WebApi.Security.Authentication.Certificates
+{
+    /// <summary>
+    /// Null object implementation of the <see cref="CertificateAuthenticationValidator"/> instance to mimic a 'null' value on the <see cref="CertificateAuthenticationFilter"/>.
+    /// </summary>
+    internal class NullCertificateAuthenticationValidator : CertificateAuthenticationValidator
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NullCertificateAuthenticationValidator" /> class.
+        /// </summary>
+        internal NullCertificateAuthenticationValidator() 
+            : base(new CertificateAuthenticationConfig(new Dictionary<X509ValidationRequirement, (IX509ValidationLocation location, string configuredKey)>()))
+        {
+            
+        }
+    }
+}

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/SecretProviderValidationLocation.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/SecretProviderValidationLocation.cs
@@ -42,7 +42,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
             {
                 throw new InvalidOperationException(
                     "Cannot retrieve the certificate value to validate the HTTP request because no Arcus secret store was registered in the application," 
-                    + $"please register the secret store with '{nameof(IHostBuilderExtensions.ConfigureSecretStore)}' on the '{nameof(IHostBuilder)}' or with '{nameof(IServiceCollectionExtensions.AddSecretStore)}' on the '{nameof(IServiceCollection)}'," 
+                    + $"please register the secret store with '{nameof(IHostBuilderExtensions.ConfigureSecretStore)}' on the '{nameof(IHostBuilder)}' or with 'AddSecretStore' on the '{nameof(IServiceCollection)}'," 
                     + "for more information on the Arcus secret store: https://security.arcus-azure.net/features/secret-store");
             }
 

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationFilter.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationFilter.cs
@@ -111,7 +111,7 @@ namespace Arcus.WebApi.Security.Authentication.SharedAccessKey
             {
                 throw new InvalidOperationException(
                     "Cannot retrieve the shared access key to validate the HTTP request because no Arcus secret store was registered in the application," 
-                    + $"please register the secret store with '{nameof(IHostBuilderExtensions.ConfigureSecretStore)}' on the '{nameof(IHostBuilder)}' or with '{nameof(IServiceCollectionExtensions.AddSecretStore)}' on the '{nameof(IServiceCollection)}'," 
+                    + $"please register the secret store with '{nameof(IHostBuilderExtensions.ConfigureSecretStore)}' on the '{nameof(IHostBuilder)}' or with 'AddSecretStore' on the '{nameof(IServiceCollection)}'," 
                     + "for more information on the Arcus secret store: https://security.arcus-azure.net/features/secret-store");
             }
 

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authentication/CertificateAuthenticationAttributeTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authentication/CertificateAuthenticationAttributeTests.cs
@@ -17,6 +17,7 @@ using Serilog;
 using Serilog.Events;
 using Xunit;
 using Xunit.Abstractions;
+using static Arcus.WebApi.Security.Authentication.Certificates.X509ValidationLocation;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 // ReSharper disable AccessToDisposedClosure
 
@@ -52,14 +53,8 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                 var options = new TestApiServerOptions()
                     .ConfigureServices(services =>
                     {
-                        var certificateValidator =
-                            new CertificateAuthenticationValidator(
-                                new CertificateAuthenticationConfigBuilder()
-                                    .WithSubject(X509ValidationLocation.SecretProvider, SubjectKey)
-                                    .Build());
-
                         services.AddSecretStore(stores => stores.AddInMemory(SubjectKey, $"CN={actualSubject}"))
-                                .AddSingleton(certificateValidator);
+                                .AddCertificateAuthenticationValidation(auth => auth.WithSubject(SecretProvider, SubjectKey));
                     });
 
                 await using (var server = await TestApiServer.StartNewAsync(options, _logger))
@@ -90,15 +85,9 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                 var options = new TestApiServerOptions()
                     .ConfigureServices(services =>
                     {
-                        var certificateValidator =
-                            new CertificateAuthenticationValidator(
-                                new CertificateAuthenticationConfigBuilder()
-                                    .WithSubject(X509ValidationLocation.SecretProvider, SubjectKey)
-                                    .Build());
-
                         services.AddSecretStore(stores => stores.AddInMemory(SubjectKey, "CN=subject"))
                                 .AddClientCertificate(clientCertificate)
-                                .AddSingleton(certificateValidator);
+                                .AddCertificateAuthenticationValidation(auth => auth.WithSubject(SecretProvider, SubjectKey));
                     });
 
                 await using (var server = await TestApiServer.StartNewAsync(options, _logger))
@@ -136,15 +125,12 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                 var options = new TestApiServerOptions()
                     .ConfigureServices(services =>
                     {
-                        var certificateValidator =
-                            new CertificateAuthenticationValidator(
-                                new CertificateAuthenticationConfigBuilder()
-                                    .WithSubject(X509ValidationLocation.SecretProvider, SubjectKey)
-                                    .WithIssuer(X509ValidationLocation.SecretProvider, IssuerKey)
-                                    .WithThumbprint(X509ValidationLocation.SecretProvider, ThumbprintKey)
-                                    .Build());
-
-                        services.AddSingleton(certificateValidator)
+                        services.AddCertificateAuthenticationValidation(auth =>
+                                {
+                                    auth.WithSubject(SecretProvider, SubjectKey)
+                                        .WithIssuer(SecretProvider, IssuerKey)
+                                        .WithThumbprint(SecretProvider, ThumbprintKey);
+                                })
                                 .AddClientCertificate(clientCertificate)
                                 .AddSecretStore(stores => stores.AddInMemory(new Dictionary<string, string>
                                 {
@@ -197,15 +183,12 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                     }))
                     .ConfigureServices(services =>
                     {
-                        var certificateValidator =
-                            new CertificateAuthenticationValidator(
-                                new CertificateAuthenticationConfigBuilder()
-                                    .WithSubject(X509ValidationLocation.Configuration, SubjectKey)
-                                    .WithIssuer(X509ValidationLocation.Configuration, IssuerKey)
-                                    .WithThumbprint(X509ValidationLocation.Configuration, ThumbprintKey)
-                                    .Build());
-
-                        services.AddSingleton(certificateValidator)
+                        services.AddCertificateAuthenticationValidation(auth =>
+                                {
+                                    auth.WithSubject(Configuration, SubjectKey)
+                                        .WithIssuer(Configuration, IssuerKey)
+                                        .WithThumbprint(Configuration, ThumbprintKey);
+                                })
                                 .AddClientCertificate(clientCertificate);
                     });
 
@@ -250,17 +233,14 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                     }))
                     .ConfigureServices(services =>
                     {
-                        var certificateValidator =
-                            new CertificateAuthenticationValidator(
-                                new CertificateAuthenticationConfigBuilder()
-                                    .WithSubject(X509ValidationLocation.Configuration, SubjectKey)
-                                    .WithIssuer(X509ValidationLocation.SecretProvider, IssuerKey)
-                                    .WithThumbprint(new StubX509ValidationLocation(clientCertificate.Thumbprint + thumbprintNoise), ThumbprintKey)
-                                    .Build());
-
                         services.AddSecretStore(stores => stores.AddInMemory(IssuerKey, "CN=issuer"))
                                 .AddClientCertificate(clientCertificate)
-                                .AddSingleton(certificateValidator);
+                                .AddCertificateAuthenticationValidation(auth =>
+                                {
+                                    auth.WithSubject(Configuration, SubjectKey)
+                                        .WithIssuer(SecretProvider, IssuerKey)
+                                        .WithThumbprint(new StubX509ValidationLocation(clientCertificate.Thumbprint + thumbprintNoise), ThumbprintKey);
+                                });
                     });
 
                 await using (var server = await TestApiServer.StartNewAsync(options, _logger))
@@ -289,15 +269,9 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                 var options = new TestApiServerOptions()
                     .ConfigureServices(services =>
                     {
-                        var certificateValidator =
-                            new CertificateAuthenticationValidator(
-                                new CertificateAuthenticationConfigBuilder()
-                                    .WithSubject(X509ValidationLocation.SecretProvider, SubjectKey)
-                                    .Build());
-
                         services.AddSecretStore(stores => stores.AddInMemory(SubjectKey, "CN=subject"))
                                 .AddClientCertificate(clientCertificate)
-                                .AddSingleton(certificateValidator);
+                                .AddCertificateAuthenticationValidation(auth => auth.WithSubject(SecretProvider, SubjectKey));
                     })
                     .ConfigureHost(host => host.UseSerilog((context, config) => config.WriteTo.Sink(spySink)));
 
@@ -331,15 +305,9 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
                 var options = new TestApiServerOptions()
                     .ConfigureServices(services =>
                     {
-                        var certificateValidator =
-                            new CertificateAuthenticationValidator(
-                                new CertificateAuthenticationConfigBuilder()
-                                    .WithSubject(X509ValidationLocation.SecretProvider, SubjectKey)
-                                    .Build());
-
                         services.AddSecretStore(stores => stores.AddInMemory(SubjectKey, "CN=subject"))
                                 .AddClientCertificate(clientCertificate)
-                                .AddSingleton(certificateValidator);
+                                .AddCertificateAuthenticationValidation(auth => auth.WithSubject(SecretProvider, SubjectKey));
                     })
                     .ConfigureHost(host => host.UseSerilog((context, config) => config.WriteTo.Sink(spySink)));
 

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authentication/CertificateAuthenticationFilterTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authentication/CertificateAuthenticationFilterTests.cs
@@ -769,7 +769,6 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication
             }
         }
 
-        
         [Fact]
         public async Task AuthorizedRoute_WithCertificateAuthenticationWithDirectValidator_ShouldFailOnInvalidBase64Format()
         {

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authentication/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authentication/IServiceCollectionExtensionsTests.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Arcus.WebApi.Tests.Unit.Security.Authentication
+{
+    // ReSharper disable once InconsistentNaming
+    public class IServiceCollectionExtensionsTests
+    {
+        [Fact]
+        public void AddCertificateAuthenticationValidator_WithoutCertificateConfigurationLocations_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddCertificateAuthenticationValidation(configureAuthentication: null));
+        }
+    }
+}

--- a/src/Arcus.WebApi.Tests.Unit/Security/Authentication/MvcOptionsExtensionsTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Security/Authentication/MvcOptionsExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Arcus.WebApi.Security.Authentication.Certificates;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -15,8 +16,8 @@ namespace Arcus.WebApi.Tests.Unit.Security.Authentication
             var options = new MvcOptions();
             
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() =>
-                options.AddSharedAccessKeyAuthenticationFilterOnHeader(headerName, "MySecret"));
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddSharedAccessKeyAuthenticationFilterOnHeader(headerName, "MySecret"));
         }
         
         [Theory]
@@ -27,8 +28,8 @@ namespace Arcus.WebApi.Tests.Unit.Security.Authentication
             var options = new MvcOptions();
             
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() =>
-                options.AddSharedAccessKeyAuthenticationFilterOnHeader(headerName, "MySecret", options => options.EmitSecurityEvents = true));
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddSharedAccessKeyAuthenticationFilterOnHeader(headerName, "MySecret", options => options.EmitSecurityEvents = true));
         }
         
         [Theory]
@@ -39,8 +40,8 @@ namespace Arcus.WebApi.Tests.Unit.Security.Authentication
             var options = new MvcOptions();
             
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() =>
-                options.AddSharedAccessKeyAuthenticationFilterOnHeader("x-api-key", secretName));
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddSharedAccessKeyAuthenticationFilterOnHeader("x-api-key", secretName));
         }
         
         [Theory]
@@ -51,8 +52,8 @@ namespace Arcus.WebApi.Tests.Unit.Security.Authentication
             var options = new MvcOptions();
             
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() =>
-                options.AddSharedAccessKeyAuthenticationFilterOnHeader("x-api-key", secretName, options => options.EmitSecurityEvents = true));
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddSharedAccessKeyAuthenticationFilterOnHeader("x-api-key", secretName, options => options.EmitSecurityEvents = true));
         }
         
         [Theory]
@@ -63,8 +64,8 @@ namespace Arcus.WebApi.Tests.Unit.Security.Authentication
             var options = new MvcOptions();
             
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() =>
-                options.AddSharedAccessKeyAuthenticationFilterOnHeader(parameterName, "MySecret"));
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddSharedAccessKeyAuthenticationFilterOnHeader(parameterName, "MySecret"));
         }
         
         [Theory]
@@ -75,8 +76,8 @@ namespace Arcus.WebApi.Tests.Unit.Security.Authentication
             var options = new MvcOptions();
             
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() =>
-                options.AddSharedAccessKeyAuthenticationFilterOnQuery(parameterName, "MySecret", options => options.EmitSecurityEvents = true));
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddSharedAccessKeyAuthenticationFilterOnQuery(parameterName, "MySecret", options => options.EmitSecurityEvents = true));
         }
         
         [Theory]
@@ -87,8 +88,8 @@ namespace Arcus.WebApi.Tests.Unit.Security.Authentication
             var options = new MvcOptions();
             
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() =>
-                options.AddSharedAccessKeyAuthenticationFilterOnQuery("x-api-key", secretName));
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddSharedAccessKeyAuthenticationFilterOnQuery("x-api-key", secretName));
         }
         
         [Theory]
@@ -99,8 +100,51 @@ namespace Arcus.WebApi.Tests.Unit.Security.Authentication
             var options = new MvcOptions();
             
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() =>
-                options.AddSharedAccessKeyAuthenticationFilterOnQuery("x-api-key", secretName, options => options.EmitSecurityEvents = true));
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddSharedAccessKeyAuthenticationFilterOnQuery("x-api-key", secretName, options => options.EmitSecurityEvents = true));
+        }
+
+        [Fact]
+        public void AddCertificateAuthenticationFilter_WithoutConfiguredAuthentication_Fails()
+        {
+            // Arrange
+            var options = new MvcOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddCertificateAuthenticationFilter(configureAuthentication: null));
+        }
+
+        [Fact]
+        public void AddCertificateAuthenticationFilter_WithoutConfiguredAuthenticationWithOptions_Fails()
+        {
+            // Arrange
+            var options = new MvcOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => options.AddCertificateAuthenticationFilter(configureAuthentication: null, configureOptions: opt => { }));
+        }
+
+        [Fact]
+        public void AddCertificateAuthenticationFilter_WithoutConfiguredAuthenticationEntries_Fails()
+        {
+            // Arrange
+            var options = new MvcOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(
+                () => options.AddCertificateAuthenticationFilter(configureAuthentication: auth => { }));
+        }
+
+        [Fact]
+        public void AddCertificateAuthenticationFilter_WithConfiguredAuthenticationEntry_Succeeds()
+        {
+            // Arrange
+            var options = new MvcOptions();
+
+            // Act / Assert
+            options.AddCertificateAuthenticationFilter(auth => auth.WithSubject(X509ValidationLocation.Configuration, "SubjectConfig"));
         }
     }
 }


### PR DESCRIPTION
Simplify the registration of the certificate authentication validator by either passing the configuration directly during the global certificate authentication filter or by using the new extension.

Closes #350