### PR TITLE
feat: add allow all to az func middleware

### DIFF
--- a/src/Arcus.WebApi.Hosting.AzureFunctions/Formatting/AzureFunctionsJsonFormattingMiddleware.cs
+++ b/src/Arcus.WebApi.Hosting.AzureFunctions/Formatting/AzureFunctionsJsonFormattingMiddleware.cs
@@ -80,11 +80,13 @@ namespace Arcus.WebApi.Hosting.AzureFunctions.Formatting
         {
             if (request.Headers.TryGetValues("Accept", out IEnumerable<string> headerValues))
             {
-                if (headerValues.All(value => value != "application/json"))
+                if (headerValues.Any(value => value == "application/json" || value == "*/*"))
                 {
-                    logger.LogError("Could not process current request because the HTTP request does not allow JSON as response (Accept: {Accept})", string.Join(", ", headerValues));
-                    return false;
+                    return true;
                 }
+
+                logger.LogError("Could not process current request because the HTTP request does not allow JSON as response (Accept: {Accept})", string.Join(", ", headerValues));
+                return false;
             }
 
             return true;

--- a/src/Arcus.WebApi.Tests.Unit/Hosting/Formatting/AzureFunctionsJsonFormattingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Hosting/Formatting/AzureFunctionsJsonFormattingMiddlewareTests.cs
@@ -110,6 +110,27 @@ namespace Arcus.WebApi.Tests.Unit.Hosting.Formatting
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
+        [Fact]
+        public async Task Request_WithAllAllowAndJsonContentTypeHeaders_ReturnsOk()
+        {
+            // Arrange
+            var middleware = new AzureFunctionsJsonFormattingMiddleware();
+            var contents = Encoding.UTF8.GetBytes("Something to write so that we require a Content-Type");
+            var context = TestFunctionContext.Create(req =>
+            {
+                req.Body.Write(contents, 0, contents.Length);
+                req.Headers.Add("content-type", "application/json");
+                req.Headers.TryAddWithoutValidation("allow", "*/*");
+            });
+
+            // Act
+            await middleware.Invoke(context, CreateOkResponse);
+
+            // Assert
+            HttpResponseData response = context.GetHttpResponseData();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
         private static async Task CreateOkResponse(FunctionContext context)
         {
             HttpRequestData request = await context.GetHttpRequestDataAsync();


### PR DESCRIPTION
Add allow all header value to Azure Functions JSON formatting middleware.

Closes #393