### PR TITLE
chore: remove installation details from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,6 @@ Web API development in a breeze.
 
 ![Arcus](https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png)
 
-# Installation
-Easy to install it via NuGet:
-
-- **Security**
-
-```shell
-PM > Install-Package Arcus.WebApi.Security
-```
-
-- **Logging**
-
-```shell
-PM > Install-Package Arcus.WebApi.Logging
-```
-
-For a more thorough overview, we recommend reading our [documentation](#documentation).
-
 # Documentation
 All documentation can be found on [here](https://webapi.arcus-azure.net/).
 


### PR DESCRIPTION
It is hard to maintain and keep up to date and it does not provide enough added-value as it is a duplication of the documentation, so removed the installation details from the `README.md` file.