### PR TITLE
fix: relaxed allow header json formatting

### DIFF
--- a/src/Arcus.WebApi.Hosting.AzureFunctions/Formatting/AzureFunctionsJsonFormattingMiddleware.cs
+++ b/src/Arcus.WebApi.Hosting.AzureFunctions/Formatting/AzureFunctionsJsonFormattingMiddleware.cs
@@ -80,7 +80,7 @@ namespace Arcus.WebApi.Hosting.AzureFunctions.Formatting
         {
             if (request.Headers.TryGetValues("Accept", out IEnumerable<string> headerValues))
             {
-                if (headerValues.Any(value => value == "application/json" || value == "*/*"))
+                if (headerValues.Any(value => value?.Contains("application/json") is true || value?.Contains("*/*") is true))
                 {
                     return true;
                 }

--- a/src/Arcus.WebApi.Tests.Unit/Hosting/Formatting/AzureFunctionsJsonFormattingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Hosting/Formatting/AzureFunctionsJsonFormattingMiddlewareTests.cs
@@ -2,8 +2,8 @@
 using System.Text;
 using System.Threading.Tasks;
 using Arcus.WebApi.Hosting.AzureFunctions.Formatting;
-using Arcus.WebApi.Logging.AzureFunctions;
 using Arcus.WebApi.Tests.Unit.Logging.Fixture.AzureFunctions;
+using Bogus;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Xunit;
@@ -12,6 +12,8 @@ namespace Arcus.WebApi.Tests.Unit.Hosting.Formatting
 {
     public class AzureFunctionsJsonFormattingMiddlewareTests
     {
+        private static readonly Faker BogusGenerator = new Faker();
+
         [Fact]
         public async Task Request_WithoutJsonFormattingHeaders_ReturnsFailure()
         {
@@ -136,9 +138,10 @@ namespace Arcus.WebApi.Tests.Unit.Hosting.Formatting
         {
             // Arrange
             var middleware = new AzureFunctionsJsonFormattingMiddleware();
+            var weight = BogusGenerator.Random.Double();
             var context = TestFunctionContext.Create(req =>
             {
-                req.Headers.TryAddWithoutValidation("allow", "application/json, q=4");
+                req.Headers.TryAddWithoutValidation("allow", $"application/json, q={weight}");
             });
 
             // Act

--- a/src/Arcus.WebApi.Tests.Unit/Hosting/Formatting/AzureFunctionsJsonFormattingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Hosting/Formatting/AzureFunctionsJsonFormattingMiddlewareTests.cs
@@ -131,6 +131,43 @@ namespace Arcus.WebApi.Tests.Unit.Hosting.Formatting
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
+        
+        [Fact]
+        public async Task Request_WithJsonAllowHeaderWithExtension_ReturnsOk()
+        {
+            // Arrange
+            var middleware = new AzureFunctionsJsonFormattingMiddleware();
+            var context = TestFunctionContext.Create(req =>
+            {
+                req.Headers.TryAddWithoutValidation("allow", "application/json, q=4");
+            });
+
+            // Act
+            await middleware.Invoke(context, CreateOkResponse);
+
+            // Assert
+            HttpResponseData response = context.GetHttpResponseData();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Request_WithAllAllowHeaderWithExtension_ReturnsOk()
+        {
+            // Arrange
+            var middleware = new AzureFunctionsJsonFormattingMiddleware();
+            var context = TestFunctionContext.Create(req =>
+            {
+                req.Headers.TryAddWithoutValidation("allow", "q=0.8, */*");
+            });
+
+            // Act
+            await middleware.Invoke(context, CreateOkResponse);
+
+            // Assert
+            HttpResponseData response = context.GetHttpResponseData();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
         private static async Task CreateOkResponse(FunctionContext context)
         {
             HttpRequestData request = await context.GetHttpRequestDataAsync();

--- a/src/Arcus.WebApi.Tests.Unit/Hosting/Formatting/AzureFunctionsJsonFormattingMiddlewareTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Hosting/Formatting/AzureFunctionsJsonFormattingMiddlewareTests.cs
@@ -131,7 +131,6 @@ namespace Arcus.WebApi.Tests.Unit.Hosting.Formatting
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
-        
         [Fact]
         public async Task Request_WithJsonAllowHeaderWithExtension_ReturnsOk()
         {


### PR DESCRIPTION
We need to make sure that we also accept headers with a factor weighting (`q=`).

Closes #405