### PR TITLE
fix: service correlation w/ single api (❗) 

### DIFF
--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationTemplate.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationTemplate.cs
@@ -114,14 +114,15 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         protected virtual HttpCorrelationResult CorrelateW3CForNewParent(IHeaderDictionary requestHeaders)
         {
             Activity newActivity = CreateNewActivity(requestHeaders);
+
+            newActivity.Start();
+            Activity.Current = newActivity;
+
             string transactionId = newActivity.TraceId.ToHexString();
             Logger.LogTrace("Correlation transaction ID '{TransactionId}' generated for incoming HTTP request", transactionId);
 
             string operationId = newActivity.SpanId.ToHexString();
             Logger.LogTrace("Correlation operation ID '{OperationId}' generated for incoming HTTP request", operationId);
-
-            newActivity.Start();
-            Activity.Current = newActivity;
 
             _correlationInfoAccessor.SetCorrelationInfo(new CorrelationInfo(operationId, transactionId));
             return HttpCorrelationResult.Success(requestId: null);
@@ -205,7 +206,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
 
         private static bool IsTraceParentHeaderW3CCompliant(StringValues ids)
         {
-            if (ids == StringValues.Empty)
+            if (ids == StringValues.Empty || string.IsNullOrWhiteSpace(ids))
             {
                 return false;
             }

--- a/src/Arcus.WebApi.Logging.Core/Extensions/IHeaderDictionaryExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/IHeaderDictionaryExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Http
             StringValues traceParent = headers["traceparent"];
 #endif
 
-            if (traceParent == StringValues.Empty)
+            if (traceParent == StringValues.Empty || string.IsNullOrWhiteSpace(traceParent))
             {
                 return traceParent;
             }


### PR DESCRIPTION
Retrieve transaction and operation ID after the Activity is started when there is no above parent from the incoming HTTP request.

Closes https://github.com/arcus-azure/arcus.webapi/issues/408