### PR TITLE
fix: use still http correlation instance w/ hierarhical (❗)

### DIFF
--- a/src/Arcus.WebApi.Logging.AzureFunctions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Extensions/IServiceCollectionExtensions.cs
@@ -102,6 +102,14 @@ namespace Microsoft.Extensions.DependencyInjection
                     var httpContextAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
                     return new HttpCorrelationInfoAccessor(httpContextAccessor);
                 });
+                services.AddSingleton(serviceProvider =>
+                {
+                    var httpContextAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
+                    var correlationInfoAccessor = serviceProvider.GetRequiredService<IHttpCorrelationInfoAccessor>();
+                    var logger = serviceProvider.GetService<ILogger<HttpCorrelation>>();
+                
+                    return new HttpCorrelation(Options.Options.Create(options), httpContextAccessor, correlationInfoAccessor, logger);
+                });
             }
 
             services.AddSingleton<ICorrelationInfoAccessor<CorrelationInfo>>(provider => provider.GetRequiredService<IHttpCorrelationInfoAccessor>());

--- a/src/Arcus.WebApi.Tests.Unit/Logging/IFunctionsHostBuilderTests.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/IFunctionsHostBuilderTests.cs
@@ -2,6 +2,7 @@
 using Arcus.Observability.Correlation;
 using Arcus.WebApi.Logging.Core.Correlation;
 #if NET6_0
+using Arcus.WebApi.Logging.Correlation;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection; 
 #endif
 using Microsoft.Extensions.DependencyInjection;
@@ -48,6 +49,22 @@ namespace Arcus.WebApi.Tests.Unit.Logging
             Assert.NotNull(provider.GetService<IHttpCorrelationInfoAccessor>());
             Assert.NotNull(provider.GetService<ICorrelationInfoAccessor<CorrelationInfo>>());
             Assert.NotNull(provider.GetService<ICorrelationInfoAccessor>());
+        }
+
+        [Fact]
+        public void AddHttpCorrelation_WithHierarchical_StillRegistersHttpCorrelation()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var builder = new Mock<IFunctionsHostBuilder>();
+            builder.Setup(build => build.Services).Returns(services);
+            
+            // Act
+            builder.Object.AddHttpCorrelation(options => options.Format = HttpCorrelationFormat.Hierarchical);
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            Assert.NotNull(provider.GetService<HttpCorrelation>());
         }
     } 
 #endif


### PR DESCRIPTION
Use still `HttpCorrelation` in deprecated in-process Azure Functions with deprecated Hierachical HTTP correlation system.

Relates to #422