### PR TITLE
docs: remove non-configurable traceparent http header

### DIFF
--- a/docs/preview/03-Features/correlation.md
+++ b/docs/preview/03-Features/correlation.md
@@ -114,12 +114,6 @@ builder.Services.AddHttpCorrelation(options =>
 
     // The header that will contain the operation ID in the HTTP response (default: X-Operation-Id).
     options.Operation.HeaderName = "X-MyOperation-Id";
-
-    // Configuration on operation parent ID request header (`traceparent`).
-    // ------------------------------------------------------------------
-
-    // The header that will contain the operation parent ID in the HTTP request (default: traceparent).
-    options.UpstreamService.HeaderName = "x-request-id";
 });
 ```
 

--- a/docs/versioned_docs/version-v1.7.0/03-Features/correlation.md
+++ b/docs/versioned_docs/version-v1.7.0/03-Features/correlation.md
@@ -114,12 +114,6 @@ builder.Services.AddHttpCorrelation(options =>
 
     // The header that will contain the operation ID in the HTTP response (default: X-Operation-Id).
     options.Operation.HeaderName = "X-MyOperation-Id";
-
-    // Configuration on operation parent ID request header (`traceparent`).
-    // ------------------------------------------------------------------
-
-    // The header that will contain the operation parent ID in the HTTP request (default: traceparent).
-    options.UpstreamService.HeaderName = "x-request-id";
 });
 ```
 


### PR DESCRIPTION
Remove the options configuration of the non-configurable `traceparent` in the HTTP correlation options. This is only available in the Hierarchical setup.