### PR TITLE
chore: use `main` branch in az devops status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Arcus - Web API
-[![Build Status](https://dev.azure.com/codit/Arcus/_apis/build/status/Commit%20builds/CI%20-%20Arcus.WebApi?branchName=master)](https://dev.azure.com/codit/Arcus/_build/latest?definitionId=733&branchName=master)
+[![Build Status](https://dev.azure.com/codit/Arcus/_apis/build/status/Commit%20builds/CI%20-%20Arcus.WebApi?branchName=main)](https://dev.azure.com/codit/Arcus/_build/latest?definitionId=733&branchName=main)
 [![NuGet Badge](https://buildstats.info/nuget/Arcus.WebApi.Security?includePreReleases=true)](https://www.nuget.org/packages/Arcus.WebApi.Security/)
 
 Web API development in a breeze.


### PR DESCRIPTION
Use default `main` branch in Azure DevOps status badge.