### PR TITLE
chore: use new major versions of arcus packages

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -52,7 +52,7 @@ stages:
           - template: 'build/build-solution.yml@templates'
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              includePreviewVersions: true
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
               versionSuffix: '$(packageVersion)'
           - task: CopyFiles@2
             displayName: 'Copy build artifacts'
@@ -83,7 +83,7 @@ stages:
           - template: test/run-unit-tests.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              includePreviewVersions: true
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
               projectName: '$(Project).Tests.Unit'
 
   - stage: DockerIntegrationTests
@@ -121,7 +121,7 @@ stages:
           - template: test/run-integration-tests.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              includePreviewVersions: true
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
               projectName: '$(Project).Tests.Integration'
               category: 'Integration'
 

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -37,7 +37,7 @@ stages:
           - template: build/build-solution.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              includePreviewVersions: true
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
               version: $(Build.BuildNumber)
           - task: CopyFiles@2
             displayName: 'Copy build artifacts'
@@ -73,7 +73,7 @@ stages:
           - template: test/run-unit-tests.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              includePreviewVersions: true
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
               projectName: '$(Project).Tests.Unit'
 
   - stage: DockerIntegrationTests
@@ -111,7 +111,7 @@ stages:
           - template: test/run-integration-tests.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              includePreviewVersions: true
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
               projectName: '$(Project).Tests.Integration'
               category: 'Integration'
 

--- a/build/templates/run-docker-integration-tests.yml
+++ b/build/templates/run-docker-integration-tests.yml
@@ -4,7 +4,7 @@ steps:
     inputs:
       packageType: 'sdk'
       version: '$(DotNet.Sdk.Version)'
-      includePreviewVersions: true
+      includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
   # .NET 8 not available yet for Azure Functions in-process
   # - template: start-docker-project.yml
   #   parameters:
@@ -17,7 +17,7 @@ steps:
   - template: test/run-integration-tests.yml@templates
     parameters:
       dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-      includePreviewVersions: true
+      includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
       projectName: '$(Project).Tests.Integration'
       category: 'Docker'
   # .NET 8 not available yet for Azure Functions in-process

--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -2,5 +2,6 @@ variables:
   DotNet.Sdk.Version: '8.0.x'
   # Backwards compatible .NET SDK version
   DotNet.Sdk.VersionBC: '6.0.100'
+  DotNet.Sdk.IncludePreviewVersions: false
   Project: 'Arcus.WebApi'
   Vm.Image: 'ubuntu-latest'

--- a/src/Arcus.WebApi.Logging.AzureFunctions/Arcus.WebApi.Logging.AzureFunctions.csproj
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Arcus.WebApi.Logging.AzureFunctions.csproj
@@ -17,11 +17,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <!-- Allows (for now) preview packages, as we are referencing Arcus' preview .NET 8 package. -->
-    <NoWarn>NU5104</NoWarn>
-  </PropertyGroup>
   
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
@@ -30,8 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[3.0.0-preview-1-net8.0,4.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="[3.0.0-preview-1-net8.0,4.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[3.0.0,4.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.33" />

--- a/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
+++ b/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
@@ -18,11 +18,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Allows (for now) preview packages, as we are referencing Arcus' preview .NET 8 package. -->
-    <NoWarn>NU5104</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
@@ -40,9 +35,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[3.0.0-preview-1-net8.0,4.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[3.0.0-preview-1-net8.0,4.0.0)" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[3.0.0-preview-1-net8.0,4.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[3.0.0,4.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[3.0.0,4.0.0)" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
   </ItemGroup>

--- a/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
@@ -6,7 +6,7 @@ using Microsoft.Net.Http.Headers;
 namespace Arcus.WebApi.Logging.Core.Correlation
 {
     /// <summary>
-    /// Correlation options specific to the upstream services, used in the <see cref="CorrelationInfoOptions"/>.
+    /// Correlation options specific to the upstream services, used in the <see cref="HttpCorrelationInfoOptions"/>.
     /// </summary>
     public class CorrelationInfoUpstreamServiceOptions
     {

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelation.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelation.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Options;
 namespace Arcus.WebApi.Logging.Correlation
 {
     /// <summary>
-    /// Provides the functionality to correlate HTTP requests and responses according to configured <see cref="CorrelationInfoOptions"/>,
+    /// Provides the functionality to correlate HTTP requests and responses according to configured <see cref="HttpCorrelationInfoOptions"/>,
     /// using the <see cref="ICorrelationInfoAccessor"/> to expose the result.
     /// </summary>
     /// <seealso cref="HttpCorrelationInfoAccessor"/>
@@ -70,7 +70,7 @@ namespace Arcus.WebApi.Logging.Correlation
         }
 
         /// <summary>
-        /// Correlate the current HTTP request according to the previously configured <see cref="CorrelationInfoOptions"/>;
+        /// Correlate the current HTTP request according to the previously configured <see cref="HttpCorrelationInfoOptions"/>;
         /// returning an <see cref="HttpCorrelationResult"/> which acts as the current scope in which additional dependencies should be tracked.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when the given <see cref="HttpContext"/> is not available to correlate the request with the response.</exception>

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoOptions.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using Arcus.Observability.Correlation;
-
-namespace Arcus.WebApi.Logging.Core.Correlation
+﻿namespace Arcus.WebApi.Logging.Core.Correlation
 {
     /// <summary>
     ///  Options for handling correlation ID on incoming HTTP requests.
     /// </summary>
-#pragma warning disable CS0618
-    public class HttpCorrelationInfoOptions : CorrelationInfoOptions
-#pragma warning restore CS0618
+    public class HttpCorrelationInfoOptions 
     {
         /// <summary>
         /// Gets or sets the format within the Arcus HTTP correlation system will correlate HTTP requests.
@@ -18,20 +13,16 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         /// <summary>
         /// Gets the correlation options specific for the operation ID.
         /// </summary>
-        public new HttpCorrelationInfoOperationOptions Operation { get; } = new HttpCorrelationInfoOperationOptions();
+        public HttpCorrelationInfoOperationOptions Operation { get; } = new HttpCorrelationInfoOperationOptions();
 
         /// <summary>
         /// Gets the correlation options specific for the transaction ID.
         /// </summary>
-        public new HttpCorrelationInfoTransactionOptions Transaction { get; } = new HttpCorrelationInfoTransactionOptions();
+        public HttpCorrelationInfoTransactionOptions Transaction { get; } = new HttpCorrelationInfoTransactionOptions();
 
         /// <summary>
         /// Gets the correlation options specific for the upstream service.
         /// </summary>
         public CorrelationInfoUpstreamServiceOptions UpstreamService { get; } = new CorrelationInfoUpstreamServiceOptions();
-
-        /// <summary/>
-        [Obsolete("Use " + nameof(UpstreamService) + " instead")]
-        public new Arcus.Observability.Correlation.CorrelationInfoUpstreamServiceOptions OperationParent { get; } = new Observability.Correlation.CorrelationInfoUpstreamServiceOptions();
     }
 }

--- a/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
+++ b/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
@@ -17,16 +17,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <!-- Allows (for now) preview packages, as we are referencing Arcus' preview .NET 8 package. -->
-    <NoWarn>NU5104</NoWarn>
-  </PropertyGroup>
-
+  
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
-    <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
@@ -43,10 +38,10 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="3.0.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[3.0.0-preview-1-net8.0,4.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="[3.0.0-preview-1-net8.0,4.0.0)" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[3.0.0-preview-1-net8.0,4.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[3.0.0-preview-1-net8.0,4.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[3.0.0,4.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="[3.0.0,4.0.0)" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[3.0.0,4.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
   </ItemGroup>
 

--- a/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
+++ b/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
@@ -18,11 +18,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Allows (for now) preview packages, as we are referencing Arcus' preview .NET 8 package. -->
-    <NoWarn>NU5104</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
@@ -40,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[2.0.0-preview-1-net8.0,3.0.0)" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[2.0.0,3.0.0)" />
     <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
   </ItemGroup>

--- a/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
+++ b/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
@@ -20,6 +20,7 @@
  
   <ItemGroup>
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="3.0.0" />
+    <PackageReference Include="Arcus.Security.Core" Version="2.0.0" />
     <PackageReference Include="Arcus.Testing.Logging" Version="0.4.0" />
     <PackageReference Include="Arcus.Testing.Security.Providers.InMemory" Version="0.4.0" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.3" />

--- a/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
+++ b/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
  
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="3.0.0-preview-1-net8.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="3.0.0" />
     <PackageReference Include="Arcus.Testing.Logging" Version="0.4.0" />
     <PackageReference Include="Arcus.Testing.Security.Providers.InMemory" Version="0.4.0" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.3" />

--- a/src/Arcus.WebApi.Tests.Integration/Logging/AzureFunctionsJsonFormattingDockerTests.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/AzureFunctionsJsonFormattingDockerTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Arcus.Testing.Logging;
 using Arcus.WebApi.Tests.Integration.Fixture;
 using Microsoft.Extensions.Logging;
-using Microsoft.Rest;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/Arcus.WebApi.Tests.Unit/Arcus.WebApi.Tests.Unit.csproj
+++ b/src/Arcus.WebApi.Tests.Unit/Arcus.WebApi.Tests.Unit.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Arcus.Security.Core" Version="2.0.0" />
     <PackageReference Include="Arcus.Testing.Logging" Version="0.5.0" />
     <PackageReference Include="Arcus.Testing.Security.Providers.InMemory" Version="0.5.0" />
     <PackageReference Include="BouncyCastle.NetCoreSdk" Version="1.9.0.1" />


### PR DESCRIPTION
Use the new major release versions of the Arcus packages Observability and Security, both with the .NET 8 support.

Relates to https://github.com/arcus-azure/arcus/issues/311