### PR TITLE
refactor: Removing all dependency to Guard.NET.

### DIFF
--- a/src/Arcus.WebApi.Hosting.AzureFunctions/Arcus.WebApi.Hosting.AzureFunctions.csproj
+++ b/src/Arcus.WebApi.Hosting.AzureFunctions/Arcus.WebApi.Hosting.AzureFunctions.csproj
@@ -26,7 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0" />
-    <PackageReference Include="Guard.Net" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.WebApi.Hosting.AzureFunctions/Formatting/AzureFunctionsJsonFormattingMiddleware.cs
+++ b/src/Arcus.WebApi.Hosting.AzureFunctions/Formatting/AzureFunctionsJsonFormattingMiddleware.cs
@@ -44,6 +44,7 @@ namespace Arcus.WebApi.Hosting.AzureFunctions.Formatting
         private static async Task<HttpRequestData> DetermineHttpRequestAsync(FunctionContext context)
         {
             HttpRequestData request = await context.GetHttpRequestDataAsync();
+
             if (request is null)
             {
                 throw new InvalidOperationException(

--- a/src/Arcus.WebApi.Hosting.AzureFunctions/Formatting/Extensions/IFunctionsWorkerApplicationBuilderExtensions.cs
+++ b/src/Arcus.WebApi.Hosting.AzureFunctions/Formatting/Extensions/IFunctionsWorkerApplicationBuilderExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.WebApi.Hosting.AzureFunctions.Formatting;
-using GuardNet;
 using Microsoft.Azure.Functions.Worker;
 
 // ReSharper disable once CheckNamespace
@@ -20,7 +19,10 @@ namespace Microsoft.Extensions.Hosting
         public static IFunctionsWorkerApplicationBuilder UseOnlyJsonFormatting(
             this IFunctionsWorkerApplicationBuilder builder)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a function worker builder instance to add the JSON formatting middleware");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the JSON formatting middleware");
+            }
 
             builder.UseMiddleware<AzureFunctionsJsonFormattingMiddleware>();
             return builder;

--- a/src/Arcus.WebApi.Hosting.AzureFunctions/Formatting/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Hosting.AzureFunctions/Formatting/Extensions/IServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Text.Json;
 using Azure.Core.Serialization;
-using GuardNet;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -24,8 +23,14 @@ namespace Microsoft.Extensions.Hosting
             this IFunctionsWorkerApplicationBuilder builder,
             Action<JsonSerializerOptions> configureOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires an Azure Functions application builder instance to add the JSON serializer to the application services");
-            Guard.NotNull(configureOptions, nameof(configureOptions), "Requires a function to configure the JSON serialization options to add the JSON serializer to the application services");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires an Azure Functions application builder instance to add the JSON serializer to the application services");
+            }
+            if (configureOptions is null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions), "Requires a function to configure the JSON serialization options to add the JSON serializer to the application services");
+            }
 
             var options = new JsonSerializerOptions();
             configureOptions(options);

--- a/src/Arcus.WebApi.Hosting.AzureFunctions/Formatting/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Hosting.AzureFunctions/Formatting/Extensions/IServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Extensions.Hosting
             {
                 throw new ArgumentNullException(nameof(builder), "Requires an Azure Functions application builder instance to add the JSON serializer to the application services");
             }
+
             if (configureOptions is null)
             {
                 throw new ArgumentNullException(nameof(configureOptions), "Requires a function to configure the JSON serialization options to add the JSON serializer to the application services");

--- a/src/Arcus.WebApi.Hosting/Arcus.WebApi.Hosting.csproj
+++ b/src/Arcus.WebApi.Hosting/Arcus.WebApi.Hosting.csproj
@@ -28,8 +28,4 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Guard.Net" Version="3.0.0" />
-  </ItemGroup>
-
 </Project>

--- a/src/Arcus.WebApi.Hosting/Formatting/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Hosting/Formatting/Extensions/MvcOptionsExtensions.cs
@@ -52,6 +52,7 @@ namespace Microsoft.AspNetCore.Mvc
             {
                 throw new ArgumentNullException(nameof(options), "Requires MVC options to configure the JSON formatters");
             }
+
             if (configureOptions is null)
             {
                 throw new ArgumentNullException(nameof(configureOptions), "Requires a function to configure the JSON formatters in the MVC options");

--- a/src/Arcus.WebApi.Hosting/Formatting/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Hosting/Formatting/Extensions/MvcOptionsExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Text.Json;
-using GuardNet;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,7 +19,10 @@ namespace Microsoft.AspNetCore.Mvc
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         public static MvcOptions OnlyAllowJsonFormatting(this MvcOptions options)
         {
-            Guard.NotNull(options, nameof(options), "Requires MVC options to restrict the formatting to only JSON formatting");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires MVC options to restrict the formatting to only JSON formatting");
+            }
             
             IInputFormatter[] allButJsonInputFormatters = 
                 options.InputFormatters.Where(formatter => !(formatter is SystemTextJsonInputFormatter))
@@ -46,8 +48,14 @@ namespace Microsoft.AspNetCore.Mvc
         [Obsolete("Use the " + nameof(MvcCoreMvcBuilderExtensions) + "." + nameof(MvcCoreMvcBuilderExtensions.AddJsonOptions) + " instead to configure the JSON formatters")]
         public static MvcOptions ConfigureJsonFormatting(this MvcOptions options, Action<JsonSerializerOptions> configureOptions)
         {
-            Guard.NotNull(options, nameof(options), "Requires MVC options to configure the JSON formatters");
-            Guard.NotNull(configureOptions, nameof(configureOptions), "Requires a function to configure the JSON formatters in the MVC options");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires MVC options to configure the JSON formatters");
+            }
+            if (configureOptions is null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions), "Requires a function to configure the JSON formatters in the MVC options");
+            }
 
             SystemTextJsonInputFormatter[] onlyJsonInputFormatters = 
                 options.InputFormatters.OfType<SystemTextJsonInputFormatter>()

--- a/src/Arcus.WebApi.Logging.AzureFunctions/AzureFunctionsRequestTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/AzureFunctionsRequestTrackingMiddleware.cs
@@ -37,6 +37,7 @@ namespace Arcus.WebApi.Logging.AzureFunctions
             ILogger logger = context.GetLogger<AzureFunctionsRequestTrackingMiddleware>();
 
             HttpRequestData request = await context.GetHttpRequestDataAsync();
+
             if (request is null || IsRequestPathOmitted(PathString.FromUriComponent(request.Url), logger))
             {
                 await next(context);
@@ -72,13 +73,8 @@ namespace Arcus.WebApi.Logging.AzureFunctions
 
         private static async Task<HttpRequestData> EnableHttpRequestBufferingAsync(FunctionContext context)
         {
-            BindingMetadata bindingMetadata = context.FunctionDefinition.InputBindings.Values.FirstOrDefault(a => a.Type == "httpTrigger");
-            if (bindingMetadata is null)
-            {
-                throw new InvalidOperationException(
+            BindingMetadata bindingMetadata = context.FunctionDefinition.InputBindings.Values.FirstOrDefault(a => a.Type == "httpTrigger") ?? throw new InvalidOperationException(
                     "Cannot enable HTTP request body buffering because it cannot find the Azure Functions' HTTP trigger input binding representing the HTTP request");
-            }
-
             InputBindingData<HttpRequestData> bindingData = await context.BindInputAsync<HttpRequestData>(bindingMetadata);
             bindingData.Value = new BufferedHttpRequestData(bindingData.Value);
 

--- a/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsCorrelationMiddleware.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsCorrelationMiddleware.cs
@@ -2,7 +2,6 @@
 using System.Net;
 using System.Threading.Tasks;
 using Arcus.WebApi.Logging.Core.Correlation;
-using GuardNet;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Middleware;
@@ -25,8 +24,14 @@ namespace Arcus.WebApi.Logging.AzureFunctions.Correlation
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="context"/> or <paramref name="next"/> is <c>nul</c>.</exception>
         public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
         {
-            Guard.NotNull(context, nameof(context), "Requires a function context instance of the current Azure Function invocation to HTTP correlate the HTTP request");
-            Guard.NotNull(next, nameof(next), "Requires a 'next' function to chain this HTTP correlation middleware to the next action in the HTTP request pipeline");
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context), "Requires a function context instance of the current Azure Function invocation to HTTP correlate the HTTP request");
+            }
+            if (next is null)
+            {
+                throw new ArgumentNullException(nameof(next), "Requires a 'next' function to chain this HTTP correlation middleware to the next action in the HTTP request pipeline");
+            }
 
             var service = context.InstanceServices.GetRequiredService<AzureFunctionsHttpCorrelation>();
             HttpRequestData request = await DetermineHttpRequestAsync(context);

--- a/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsCorrelationMiddleware.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsCorrelationMiddleware.cs
@@ -28,6 +28,7 @@ namespace Arcus.WebApi.Logging.AzureFunctions.Correlation
             {
                 throw new ArgumentNullException(nameof(context), "Requires a function context instance of the current Azure Function invocation to HTTP correlate the HTTP request");
             }
+
             if (next is null)
             {
                 throw new ArgumentNullException(nameof(next), "Requires a 'next' function to chain this HTTP correlation middleware to the next action in the HTTP request pipeline");

--- a/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsHttpCorrelation.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsHttpCorrelation.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using Arcus.Observability.Correlation;
 using Arcus.WebApi.Logging.Core.Correlation;
-using GuardNet;
 using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -63,7 +62,10 @@ namespace Arcus.WebApi.Logging.AzureFunctions.Correlation
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="request"/> is <c>null</c>.</exception>
         protected override IHeaderDictionary GetRequestHeaders(HttpRequestData request)
         {
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to retrieve the HTTP request headers");
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request), "Requires a HTTP request instance to retrieve the HTTP request headers");
+            }
 
             Dictionary<string, StringValues> dictionary = 
                 request.Headers.ToDictionary(
@@ -128,9 +130,18 @@ namespace Arcus.WebApi.Logging.AzureFunctions.Correlation
         /// <exception cref="ArgumentException">Thrown when the <paramref name="headerName"/> or <paramref name="headerValue"/> is blank.</exception>
         protected override void SetHttpResponseHeader(HttpResponseData response, string headerName, string headerValue)
         {
-            Guard.NotNull(response, nameof(response), "Requires a HTTP response to set the HTTP correlation headers");
-            Guard.NotNullOrWhitespace(headerName, nameof(headerName), "Requires a non-blank HTTP correlation header name to set the HTTP correlation header in the HTTP request");
-            Guard.NotNullOrWhitespace(headerValue, nameof(headerValue), "Requires a non-blank HTTP correlation header value to set the HTTP correlation header in the HTTP request");
+            if (response is null)
+            {
+                throw new ArgumentNullException(nameof(response), "Requires a HTTP response to set the HTTP correlation headers");
+            }
+            if (string.IsNullOrWhiteSpace(headerName))
+            {
+                throw new ArgumentException("Requires a non-blank HTTP correlation header name to set the HTTP correlation header in the HTTP request", nameof(headerName));
+            }
+            if (string.IsNullOrWhiteSpace(headerValue))
+            {
+                throw new ArgumentException("Requires a non-blank HTTP correlation header value to set the HTTP correlation header in the HTTP request", nameof(headerValue));
+            }
 
             response.Headers.Add(headerName, headerValue);
         }

--- a/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsHttpCorrelation.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsHttpCorrelation.cs
@@ -134,10 +134,12 @@ namespace Arcus.WebApi.Logging.AzureFunctions.Correlation
             {
                 throw new ArgumentNullException(nameof(response), "Requires a HTTP response to set the HTTP correlation headers");
             }
+
             if (string.IsNullOrWhiteSpace(headerName))
             {
                 throw new ArgumentException("Requires a non-blank HTTP correlation header name to set the HTTP correlation header in the HTTP request", nameof(headerName));
             }
+
             if (string.IsNullOrWhiteSpace(headerValue))
             {
                 throw new ArgumentException("Requires a non-blank HTTP correlation header value to set the HTTP correlation header in the HTTP request", nameof(headerValue));

--- a/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsHttpCorrelationInfoAccessor.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsHttpCorrelationInfoAccessor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Observability.Correlation;
 using Arcus.WebApi.Logging.Core.Correlation;
-using GuardNet;
 using Microsoft.Azure.Functions.Worker;
 
 namespace Arcus.WebApi.Logging.AzureFunctions.Correlation
@@ -20,8 +19,7 @@ namespace Arcus.WebApi.Logging.AzureFunctions.Correlation
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="contextAccessor"/> is <c>null</c>.</exception>
         public AzureFunctionsHttpCorrelationInfoAccessor(IFunctionContextAccessor contextAccessor)
         {
-            Guard.NotNull(contextAccessor, nameof(contextAccessor), "Requires a function context accessor instance to get/set the correlation information in the function context");
-            _contextAccessor = contextAccessor;
+            _contextAccessor = contextAccessor ?? throw new ArgumentNullException(nameof(contextAccessor),  "Requires a function context accessor instance to get/set the correlation information in the function context");
         }
 
         /// <summary>

--- a/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsInProcessHttpCorrelation.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsInProcessHttpCorrelation.cs
@@ -36,10 +36,12 @@ namespace Arcus.WebApi.Logging.AzureFunctions.Correlation
             {
                 throw new ArgumentNullException(nameof(options), "Requires a set of HTTP correlation options to determine where the correlation information should be added to the HTTP response headers");
             }
+
             if (correlationInfoAccessor is null)
             {
                 throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a HTTP correlation accessor to retrieve the current correlation information");
             }
+
             if (logger is null)
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logging instance to write diagnostic trace messages while adding the correlation information to the HTTP response headers");
@@ -69,6 +71,7 @@ namespace Arcus.WebApi.Logging.AzureFunctions.Correlation
             {
                 throw new ArgumentNullException(nameof(httpContext), "Requires a HTTP context to add the correlation information to the response headers");
             }
+
             if (httpContext.Response is null)
             {
                 throw new ArgumentNullException(nameof(httpContext), "Requires a HTTP response in the HTTP context to add the correlation information to the response headers");

--- a/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsInProcessHttpCorrelation.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Correlation/AzureFunctionsInProcessHttpCorrelation.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Arcus.Observability.Correlation;
 using Arcus.WebApi.Logging.Core.Correlation;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
@@ -33,9 +32,18 @@ namespace Arcus.WebApi.Logging.AzureFunctions.Correlation
             IHttpCorrelationInfoAccessor correlationInfoAccessor,
             ILogger<AzureFunctionsInProcessHttpCorrelation> logger)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of HTTP correlation options to determine where the correlation information should be added to the HTTP response headers");
-            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires a HTTP correlation accessor to retrieve the current correlation information");
-            Guard.NotNull(logger, nameof(logger), "Requires a logging instance to write diagnostic trace messages while adding the correlation information to the HTTP response headers");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a set of HTTP correlation options to determine where the correlation information should be added to the HTTP response headers");
+            }
+            if (correlationInfoAccessor is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a HTTP correlation accessor to retrieve the current correlation information");
+            }
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logging instance to write diagnostic trace messages while adding the correlation information to the HTTP response headers");
+            }
 
             _options = options;
             _correlationInfoAccessor = correlationInfoAccessor;
@@ -57,8 +65,14 @@ namespace Arcus.WebApi.Logging.AzureFunctions.Correlation
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="httpContext"/> is <c>null</c> or does not have a response present.</exception>
         public void AddCorrelationResponseHeaders(HttpContext httpContext)
         {
-            Guard.NotNull(httpContext, nameof(httpContext), "Requires a HTTP context to add the correlation information to the response headers");
-            Guard.NotNull(httpContext.Response, nameof(httpContext), "Requires a HTTP response in the HTTP context to add the correlation information to the response headers");
+            if (httpContext is null)
+            {
+                throw new ArgumentNullException(nameof(httpContext), "Requires a HTTP context to add the correlation information to the response headers");
+            }
+            if (httpContext.Response is null)
+            {
+                throw new ArgumentNullException(nameof(httpContext), "Requires a HTTP response in the HTTP context to add the correlation information to the response headers");
+            }
 
             if (_options.Operation.IncludeInResponse)
             {

--- a/src/Arcus.WebApi.Logging.AzureFunctions/Extensions/IFunctionsWorkerApplicationBuilderExtensions.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Extensions/IFunctionsWorkerApplicationBuilderExtensions.cs
@@ -4,7 +4,6 @@ using Arcus.WebApi.Logging;
 using Arcus.WebApi.Logging.AzureFunctions;
 using Arcus.WebApi.Logging.AzureFunctions.Correlation;
 using Arcus.WebApi.Logging.Core.Correlation;
-using GuardNet;
 using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,7 +26,10 @@ namespace Microsoft.Extensions.Hosting
         public static IFunctionsWorkerApplicationBuilder UseFunctionContext(
             this IFunctionsWorkerApplicationBuilder builder)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a function worker builder instance to add the function context middleware");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the function context middleware");
+            }
 
             builder.Services.AddSingleton<IFunctionContextAccessor, DefaultFunctionContextAccessor>();
             builder.UseMiddleware<FunctionContextMiddleware>();
@@ -43,7 +45,10 @@ namespace Microsoft.Extensions.Hosting
         public static IFunctionsWorkerApplicationBuilder UseHttpCorrelation(
             this IFunctionsWorkerApplicationBuilder builder)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a function worker builder instance to add the HTTP correlation middleware");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the HTTP correlation middleware");
+            }
 
             return UseHttpCorrelation(builder, options => { });
         }
@@ -58,7 +63,10 @@ namespace Microsoft.Extensions.Hosting
             this IFunctionsWorkerApplicationBuilder builder,
             Action<HttpCorrelationInfoOptions> configureOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a function worker builder instance to add the HTTP correlation middleware");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the HTTP correlation middleware");
+            }
 
             builder.Services.AddApplicationInsightsTelemetryWorkerService();
             builder.Services.ConfigureFunctionsApplicationInsights();
@@ -98,7 +106,10 @@ namespace Microsoft.Extensions.Hosting
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         public static IFunctionsWorkerApplicationBuilder UseExceptionHandling(this IFunctionsWorkerApplicationBuilder builder)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a function worker builder instance to add the HTTP exception handling middleware");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the HTTP exception handling middleware");
+            }
              return builder.UseMiddleware<AzureFunctionsExceptionHandlingMiddleware>();
         }
 
@@ -111,7 +122,10 @@ namespace Microsoft.Extensions.Hosting
         public static IFunctionsWorkerApplicationBuilder UseExceptionHandling<TMiddleware>(this IFunctionsWorkerApplicationBuilder builder)
             where TMiddleware : AzureFunctionsExceptionHandlingMiddleware
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a function worker builder instance to add the HTTP exception handling middleware");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the HTTP exception handling middleware");
+            }
             return builder.UseMiddleware<TMiddleware>();
         }
 
@@ -123,7 +137,10 @@ namespace Microsoft.Extensions.Hosting
         public static IFunctionsWorkerApplicationBuilder UseRequestTracking(
             this IFunctionsWorkerApplicationBuilder builder)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a function worker builder instance to add the HTTP request tracking middleware");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the HTTP request tracking middleware");
+            }
             return UseRequestTracking(builder, configureOptions: null);
         }
 
@@ -137,7 +154,10 @@ namespace Microsoft.Extensions.Hosting
             this IFunctionsWorkerApplicationBuilder builder,
             Action<RequestTrackingOptions> configureOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a function worker builder instance to add the HTTP request tracking middleware");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the HTTP request tracking middleware");
+            }
 
             return UseRequestTracking<AzureFunctionsRequestTrackingMiddleware>(builder, configureOptions);
         }
@@ -152,7 +172,10 @@ namespace Microsoft.Extensions.Hosting
             this IFunctionsWorkerApplicationBuilder builder)
             where TMiddleware : AzureFunctionsRequestTrackingMiddleware
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a function worker builder instance to add the HTTP request tracking middleware");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the HTTP request tracking middleware");
+            }
 
             return UseRequestTracking<TMiddleware>(builder, configureOptions: null);
         }
@@ -169,7 +192,10 @@ namespace Microsoft.Extensions.Hosting
             Action<RequestTrackingOptions> configureOptions)
             where TMiddleware : AzureFunctionsRequestTrackingMiddleware
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a function worker builder instance to add the HTTP request tracking middleware");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the HTTP request tracking middleware");
+            }
 
             var options = new RequestTrackingOptions();
             configureOptions?.Invoke(options);

--- a/src/Arcus.WebApi.Logging.AzureFunctions/Extensions/IFunctionsWorkerApplicationBuilderExtensions.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Extensions/IFunctionsWorkerApplicationBuilderExtensions.cs
@@ -44,14 +44,7 @@ namespace Microsoft.Extensions.Hosting
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         public static IFunctionsWorkerApplicationBuilder UseHttpCorrelation(
             this IFunctionsWorkerApplicationBuilder builder)
-        {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the HTTP correlation middleware");
-            }
-
-            return UseHttpCorrelation(builder, options => { });
-        }
+            => UseHttpCorrelation(builder, options => { });
 
         /// <summary>
         /// Adds a middleware component that exposes the <see cref="FunctionContext"/> in a scoped service <see cref="IFunctionContextAccessor"/>.
@@ -110,7 +103,8 @@ namespace Microsoft.Extensions.Hosting
             {
                 throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the HTTP exception handling middleware");
             }
-             return builder.UseMiddleware<AzureFunctionsExceptionHandlingMiddleware>();
+
+            return builder.UseMiddleware<AzureFunctionsExceptionHandlingMiddleware>();
         }
 
         /// <summary>
@@ -126,6 +120,7 @@ namespace Microsoft.Extensions.Hosting
             {
                 throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the HTTP exception handling middleware");
             }
+
             return builder.UseMiddleware<TMiddleware>();
         }
 
@@ -141,6 +136,7 @@ namespace Microsoft.Extensions.Hosting
             {
                 throw new ArgumentNullException(nameof(builder), "Requires a function worker builder instance to add the HTTP request tracking middleware");
             }
+
             return UseRequestTracking(builder, configureOptions: null);
         }
 

--- a/src/Arcus.WebApi.Logging.AzureFunctions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Extensions/IServiceCollectionExtensions.cs
@@ -23,14 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">The functions host builder containing the dependency injection services.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         public static IServiceCollection AddHttpCorrelation(this IFunctionsHostBuilder builder)
-        {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder), "Requires a function host builder instance to add the HTTP correlation services");
-            }
-
-            return AddHttpCorrelation(builder, options => { });
-        }
+            => AddHttpCorrelation(builder, options => { });
 
         /// <summary>
         /// Adds operation and transaction correlation to the application.

--- a/src/Arcus.WebApi.Logging.AzureFunctions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/Extensions/IServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@ using Arcus.Observability.Correlation;
 using Arcus.WebApi.Logging.AzureFunctions.Correlation;
 using Arcus.WebApi.Logging.Core.Correlation;
 using Arcus.WebApi.Logging.Correlation;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -25,7 +24,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         public static IServiceCollection AddHttpCorrelation(this IFunctionsHostBuilder builder)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a function host builder instance to add the HTTP correlation services");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a function host builder instance to add the HTTP correlation services");
+            }
 
             return AddHttpCorrelation(builder, options => { });
         }
@@ -38,7 +40,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         public static IServiceCollection AddHttpCorrelation(this IFunctionsHostBuilder builder, Action<HttpCorrelationInfoOptions> configureOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a function host builder instance to add the HTTP correlation services");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a function host builder instance to add the HTTP correlation services");
+            }
 
             IServiceCollection services = builder.Services;
 

--- a/src/Arcus.WebApi.Logging.AzureFunctions/FunctionContextMiddleware.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/FunctionContextMiddleware.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using GuardNet;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Middleware;
 
@@ -19,9 +18,8 @@ namespace Arcus.WebApi.Logging.AzureFunctions
         /// <param name="contextAccessor">The instance to manage the <see cref="FunctionContext"/> in this request.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="contextAccessor"/> is <c>null</c>.</exception>
         public FunctionContextMiddleware(IFunctionContextAccessor contextAccessor)
-        {
-            Guard.NotNull(contextAccessor, nameof(contextAccessor), "Requires a function context accessor to assign the current function context instance");
-            _contextAccessor = contextAccessor;
+        {   
+            _contextAccessor = contextAccessor ?? throw new ArgumentNullException(nameof(contextAccessor), "Requires a function context accessor to assign the current function context instance");
         }
 
         /// <summary>
@@ -32,8 +30,14 @@ namespace Arcus.WebApi.Logging.AzureFunctions
         /// <returns>A <see cref="T:System.Threading.Tasks.Task" /> that represents the asynchronous invocation.</returns>
         public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
         {
-            Guard.NotNull(context, nameof(context), "Requires a function context instance to assign the context to the function context accessor");
-            Guard.NotNull(next, nameof(next), "Requires a 'next' function to chain this middleware to the next action in the HTTP request pipeline");
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context), "Requires a function context instance to assign the context to the function context accessor");
+            }
+            if (next is null)
+            {
+                throw new ArgumentNullException(nameof(next), "Requires a 'next' function to chain this middleware to the next action in the HTTP request pipeline");
+            }
 
             _contextAccessor.FunctionContext = context;
             await next(context);

--- a/src/Arcus.WebApi.Logging.AzureFunctions/FunctionContextMiddleware.cs
+++ b/src/Arcus.WebApi.Logging.AzureFunctions/FunctionContextMiddleware.cs
@@ -34,6 +34,7 @@ namespace Arcus.WebApi.Logging.AzureFunctions
             {
                 throw new ArgumentNullException(nameof(context), "Requires a function context instance to assign the context to the function context accessor");
             }
+    
             if (next is null)
             {
                 throw new ArgumentNullException(nameof(next), "Requires a 'next' function to chain this middleware to the next action in the HTTP request pipeline");

--- a/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
+++ b/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
@@ -38,7 +38,6 @@
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Arcus.Observability.Correlation" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
   </ItemGroup>
 

--- a/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
@@ -42,6 +42,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
                 {
                     throw new ArgumentException(message: "Requires a non-blank value for the operation parent ID request header name", paramName: nameof(value));
                 }
+
                 _headerName = value;
             }
         }
@@ -62,6 +63,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
                 {
                     throw new ArgumentNullException(paramName: nameof(value), "Requires a function to generate the operation parent ID");
                 }
+
                 _generateId = value;
             }
         }

--- a/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using Arcus.Observability.Correlation;
-using GuardNet;
-using Microsoft.Net.Http.Headers;
 
 namespace Arcus.WebApi.Logging.Core.Correlation
 {
@@ -41,7 +38,10 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             get => _headerName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the operation parent ID request header name");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException(message: "Requires a non-blank value for the operation parent ID request header name", paramName: nameof(value));
+                }
                 _headerName = value;
             }
         }
@@ -58,7 +58,10 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             get => _generateId;
             set
             {
-                Guard.NotNull(value, nameof (value), "Requires a function to generate the operation parent ID");
+                if (value is null)
+                {
+                    throw new ArgumentNullException(paramName: nameof(value), "Requires a function to generate the operation parent ID");
+                }
                 _generateId = value;
             }
         }

--- a/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/CorrelationInfoUpstreamServiceOptions.cs
@@ -40,7 +40,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentException(message: "Requires a non-blank value for the operation parent ID request header name", paramName: nameof(value));
+                    throw new ArgumentException("Requires a non-blank value for the operation parent ID request header name", nameof(value));
                 }
 
                 _headerName = value;
@@ -61,7 +61,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 if (value is null)
                 {
-                    throw new ArgumentNullException(paramName: nameof(value), "Requires a function to generate the operation parent ID");
+                    throw new ArgumentNullException(nameof(value), "Requires a function to generate the operation parent ID");
                 }
 
                 _generateId = value;

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelation.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelation.cs
@@ -40,7 +40,7 @@ namespace Arcus.WebApi.Logging.Correlation
         {
             if (options is null)
             {
-                throw new ArgumentNullException(paramName: nameof(options), message: "Requires a value in the set of options to configure the correlation process");
+                throw new ArgumentNullException(nameof(options), "Requires a value in the set of options to configure the correlation process");
             }
 
             _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(paramName: nameof(httpContextAccessor), message: "Requires a HTTP context accessor to get the current HTTP context");
@@ -68,8 +68,9 @@ namespace Arcus.WebApi.Logging.Correlation
         {
             if (_correlationInfoAccessor is null)
             {
-                throw new ArgumentNullException(paramName: nameof(correlationInfo), message: "Requires a correlation info instance to set and retrieve the correlation information");
+                throw new ArgumentNullException(nameof(correlationInfo), "Requires a correlation info instance to set and retrieve the correlation information");
             }
+
             _correlationInfoAccessor.SetCorrelationInfo(correlationInfo);
         }
 
@@ -85,11 +86,12 @@ namespace Arcus.WebApi.Logging.Correlation
 
             if (httpContext.Response is null)
             {
-                throw new ArgumentException(message: "Requires a 'Response'", paramName: nameof(httpContext.Response));
+                throw new ArgumentException("Requires a 'Response'", nameof(httpContext.Response));
             }
+
             if (httpContext.Response.Headers is null)
             {
-                throw new ArgumentException(message: "Requires a 'Response' object with headers", paramName: nameof(httpContext.Response.Headers));
+                throw new ArgumentException("Requires a 'Response' object with headers", nameof(httpContext.Response.Headers));
             }
 
             HttpCorrelationResult result = TrySettingCorrelationFromRequest(httpContext.Request, httpContext.TraceIdentifier);

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelation.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelation.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Arcus.Observability.Correlation;
 using Arcus.WebApi.Logging.Core.Correlation;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -39,14 +38,16 @@ namespace Arcus.WebApi.Logging.Correlation
             ILogger<HttpCorrelation> logger)
             : base(options?.Value, correlationInfoAccessor, logger)
         {
-            Guard.NotNull(httpContextAccessor, nameof(httpContextAccessor), "Requires a HTTP context accessor to get the current HTTP context");
-            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires a correlation info instance to set and retrieve the correlation information");
-            Guard.NotNull(options, nameof(options), "Requires a value in the set of options to configure the correlation process");
-            Guard.NotNull(options.Value, nameof(options), "Requires a value in the set of options to configure the correlation process");
+            if (options is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(options), message: "Requires a value in the set of options to configure the correlation process");
+            }
 
-            _httpContextAccessor = httpContextAccessor;
-            _options = options.Value;
-            _correlationInfoAccessor = correlationInfoAccessor;
+            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(paramName: nameof(httpContextAccessor), message: "Requires a HTTP context accessor to get the current HTTP context");
+            _correlationInfoAccessor = correlationInfoAccessor ?? throw new ArgumentNullException(paramName: nameof(correlationInfoAccessor), message: "Requires a correlation info instance to set and retrieve the correlation information");
+            _options = options.Value ?? throw new ArgumentNullException(paramName: nameof(options.Value), message: "Requires a value in the set of options to configure the correlation process");
+
+
             _logger = logger ?? NullLogger<HttpCorrelation>.Instance;
         }
 
@@ -65,7 +66,10 @@ namespace Arcus.WebApi.Logging.Correlation
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="correlationInfo"/> is <c>null</c>.</exception>
         public void SetCorrelationInfo(CorrelationInfo correlationInfo)
         {
-            Guard.NotNull(correlationInfo, nameof(correlationInfo));
+            if (_correlationInfoAccessor is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(correlationInfo), message: "Requires a correlation info instance to set and retrieve the correlation information");
+            }
             _correlationInfoAccessor.SetCorrelationInfo(correlationInfo);
         }
 
@@ -77,11 +81,16 @@ namespace Arcus.WebApi.Logging.Correlation
         /// <exception cref="ArgumentException">Thrown when the given <see cref="HttpContext"/> doesn't have any response headers to set the correlation headers.</exception>
         public HttpCorrelationResult CorrelateHttpRequest()
         {
-            HttpContext httpContext = _httpContextAccessor.HttpContext;
+            HttpContext httpContext = _httpContextAccessor.HttpContext ?? throw new ArgumentNullException(paramName: nameof(HttpContext), "Requires a HTTP context from the HTTP context accessor to start correlating the HTTP request");
 
-            Guard.NotNull(httpContext, nameof(httpContext), "Requires a HTTP context from the HTTP context accessor to start correlating the HTTP request");
-            Guard.For<ArgumentException>(() => httpContext.Response is null, "Requires a 'Response'");
-            Guard.For<ArgumentException>(() => httpContext.Response.Headers is null, "Requires a 'Response' object with headers");
+            if (httpContext.Response is null)
+            {
+                throw new ArgumentException(message: "Requires a 'Response'", paramName: nameof(httpContext.Response));
+            }
+            if (httpContext.Response.Headers is null)
+            {
+                throw new ArgumentException(message: "Requires a 'Response' object with headers", paramName: nameof(httpContext.Response.Headers));
+            }
 
             HttpCorrelationResult result = TrySettingCorrelationFromRequest(httpContext.Request, httpContext.TraceIdentifier);
             if (result.IsSuccess)

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelation.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelation.cs
@@ -43,9 +43,9 @@ namespace Arcus.WebApi.Logging.Correlation
                 throw new ArgumentNullException(nameof(options), "Requires a value in the set of options to configure the correlation process");
             }
 
-            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(paramName: nameof(httpContextAccessor), message: "Requires a HTTP context accessor to get the current HTTP context");
-            _correlationInfoAccessor = correlationInfoAccessor ?? throw new ArgumentNullException(paramName: nameof(correlationInfoAccessor), message: "Requires a correlation info instance to set and retrieve the correlation information");
-            _options = options.Value ?? throw new ArgumentNullException(paramName: nameof(options.Value), message: "Requires a value in the set of options to configure the correlation process");
+            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor), "Requires a HTTP context accessor to get the current HTTP context");
+            _correlationInfoAccessor = correlationInfoAccessor ?? throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a correlation info instance to set and retrieve the correlation information");
+            _options = options.Value ?? throw new ArgumentNullException(nameof(options.Value), "Requires a value in the set of options to configure the correlation process");
 
 
             _logger = logger ?? NullLogger<HttpCorrelation>.Instance;
@@ -82,7 +82,7 @@ namespace Arcus.WebApi.Logging.Correlation
         /// <exception cref="ArgumentException">Thrown when the given <see cref="HttpContext"/> doesn't have any response headers to set the correlation headers.</exception>
         public HttpCorrelationResult CorrelateHttpRequest()
         {
-            HttpContext httpContext = _httpContextAccessor.HttpContext ?? throw new ArgumentNullException(paramName: nameof(HttpContext), "Requires a HTTP context from the HTTP context accessor to start correlating the HTTP request");
+            HttpContext httpContext = _httpContextAccessor.HttpContext ?? throw new ArgumentNullException(nameof(HttpContext), "Requires a HTTP context from the HTTP context accessor to start correlating the HTTP request");
 
             if (httpContext.Response is null)
             {

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
@@ -85,6 +85,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 throw new ArgumentNullException(nameof(telemetryContext), "Requires a telemetry context dictionary to add to the HTTP dependency tracking");
             }
+
             foreach (KeyValuePair<string, object> item in telemetryContext)
             {
                 TelemetryContext[item.Key] = item.Value;

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
@@ -62,7 +62,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentNullException(nameof(value), "Requires a non-blank value for the HTTP request header where the transaction ID should be added when tracking HTTP dependencies");
+                    throw new ArgumentException("Requires a non-blank value for the HTTP request header where the transaction ID should be added when tracking HTTP dependencies", nameof(value));
                 }
 
                 _transactionIdHeaderName = value;

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
@@ -44,7 +44,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentNullException(nameof(value), "Requires a non-blank value for the HTTP request header where the dependency ID should be added when tracking HTTP dependencies");
+                    throw new ArgumentException("Requires a non-blank value for the HTTP request header where the dependency ID should be added when tracking HTTP dependencies", nameof(value));
                 }
 
                 _upstreamServiceHeaderName = value;

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
@@ -42,7 +42,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             get => _upstreamServiceHeaderName;
             set
             {
-                if (value is null)
+                if (string.IsNullOrWhiteSpace(value))
                 {
                     throw new ArgumentNullException(nameof(value), "Requires a non-blank value for the HTTP request header where the dependency ID should be added when tracking HTTP dependencies");
                 }
@@ -60,7 +60,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             get => _transactionIdHeaderName;
             set
             {
-                if (value is null)
+                if (string.IsNullOrWhiteSpace(value))
                 {
                     throw new ArgumentNullException(nameof(value), "Requires a non-blank value for the HTTP request header where the transaction ID should be added when tracking HTTP dependencies");
                 }

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
@@ -26,8 +26,9 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 if (value is null)
                 {
-                    throw new ArgumentNullException(paramName: nameof(value), message: "Requires a function to generate the dependency ID used when tracking HTTP dependencies");
+                    throw new ArgumentNullException(nameof(value), "Requires a function to generate the dependency ID used when tracking HTTP dependencies");
                 }
+
                 _generateDependencyId = value;
             }
         }
@@ -43,8 +44,9 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 if (value is null)
                 {
-                    throw new ArgumentNullException(paramName: nameof(value), message: "Requires a non-blank value for the HTTP request header where the dependency ID should be added when tracking HTTP dependencies");
+                    throw new ArgumentNullException(nameof(value), "Requires a non-blank value for the HTTP request header where the dependency ID should be added when tracking HTTP dependencies");
                 }
+
                 _upstreamServiceHeaderName = value;
             }
         }
@@ -60,8 +62,9 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 if (value is null)
                 {
-                    throw new ArgumentNullException(paramName: nameof(value), message: "Requires a non-blank value for the HTTP request header where the transaction ID should be added when tracking HTTP dependencies");
+                    throw new ArgumentNullException(nameof(value), "Requires a non-blank value for the HTTP request header where the transaction ID should be added when tracking HTTP dependencies");
                 }
+
                 _transactionIdHeaderName = value;
             }
         }
@@ -78,9 +81,9 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="telemetryContext"/> is <c>null</c>.</exception>
         public void AddTelemetryContext(Dictionary<string, object> telemetryContext)
         {
-            if (telemetryContext == null)
+            if (telemetryContext is null)
             {
-                throw new ArgumentNullException(paramName: nameof(telemetryContext), message: "Requires a telemetry context dictionary to add to the HTTP dependency tracking");
+                throw new ArgumentNullException(nameof(telemetryContext), "Requires a telemetry context dictionary to add to the HTTP dependency tracking");
             }
             foreach (KeyValuePair<string, object> item in telemetryContext)
             {

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationClientOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 
 namespace Arcus.WebApi.Logging.Core.Correlation
@@ -25,7 +24,10 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             get => _generateDependencyId;
             set
             {
-                Guard.NotNull(value, nameof(value), "Requires a function to generate the dependency ID used when tracking HTTP dependencies");
+                if (value is null)
+                {
+                    throw new ArgumentNullException(paramName: nameof(value), message: "Requires a function to generate the dependency ID used when tracking HTTP dependencies");
+                }
                 _generateDependencyId = value;
             }
         }
@@ -39,7 +41,10 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             get => _upstreamServiceHeaderName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the HTTP request header where the dependency ID should be added when tracking HTTP dependencies");
+                if (value is null)
+                {
+                    throw new ArgumentNullException(paramName: nameof(value), message: "Requires a non-blank value for the HTTP request header where the dependency ID should be added when tracking HTTP dependencies");
+                }
                 _upstreamServiceHeaderName = value;
             }
         }
@@ -53,7 +58,10 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             get => _transactionIdHeaderName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the HTTP request header where the transaction ID should be added when tracking HTTP dependencies");
+                if (value is null)
+                {
+                    throw new ArgumentNullException(paramName: nameof(value), message: "Requires a non-blank value for the HTTP request header where the transaction ID should be added when tracking HTTP dependencies");
+                }
                 _transactionIdHeaderName = value;
             }
         }
@@ -70,7 +78,10 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="telemetryContext"/> is <c>null</c>.</exception>
         public void AddTelemetryContext(Dictionary<string, object> telemetryContext)
         {
-            Guard.NotNull(telemetryContext, nameof(telemetryContext), "Requires a telemetry context dictionary to add to the HTTP dependency tracking");
+            if (telemetryContext == null)
+            {
+                throw new ArgumentNullException(paramName: nameof(telemetryContext), message: "Requires a telemetry context dictionary to add to the HTTP dependency tracking");
+            }
             foreach (KeyValuePair<string, object> item in telemetryContext)
             {
                 TelemetryContext[item.Key] = item.Value;

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoAccessor.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoAccessor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Observability.Correlation;
 using Arcus.WebApi.Logging.Core.Correlation;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 
 // ReSharper disable once CheckNamespace
@@ -21,7 +20,10 @@ namespace Arcus.WebApi.Logging.Correlation
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="contextAccessor"/> is <c>null</c>.</exception>
         public HttpCorrelationInfoAccessor(IHttpContextAccessor contextAccessor)
         {
-            Guard.NotNull(contextAccessor, nameof(contextAccessor));
+            if (contextAccessor is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(contextAccessor));
+            }
 
             _httpContextAccessor = contextAccessor;
         }
@@ -42,7 +44,11 @@ namespace Arcus.WebApi.Logging.Correlation
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="correlationInfo"/> is <c>null</c>.</exception>
         public void SetCorrelationInfo(CorrelationInfo correlationInfo)
         {
-            Guard.NotNull(correlationInfo, nameof(correlationInfo));
+            if (correlationInfo is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(correlationInfo));
+            }
+
             _httpContextAccessor.HttpContext?.Features?.Set(correlationInfo);
         }
     }

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoAccessor.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoAccessor.cs
@@ -22,7 +22,7 @@ namespace Arcus.WebApi.Logging.Correlation
         {
             if (contextAccessor is null)
             {
-                throw new ArgumentNullException(paramName: nameof(contextAccessor));
+                throw new ArgumentNullException(nameof(contextAccessor));
             }
 
             _httpContextAccessor = contextAccessor;
@@ -46,7 +46,7 @@ namespace Arcus.WebApi.Logging.Correlation
         {
             if (correlationInfo is null)
             {
-                throw new ArgumentNullException(paramName: nameof(correlationInfo));
+                throw new ArgumentNullException(nameof(correlationInfo));
             }
 
             _httpContextAccessor.HttpContext?.Features?.Set(correlationInfo);

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoOperationOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoOperationOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.WebApi.Logging.Core.Correlation
 {
@@ -27,7 +26,11 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             get => _headerName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof (value), "Correlation operation header cannot be blank");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException(message: "Correlation operation header cannot be blank", paramName: nameof(value));
+                }
+
                 _headerName = value;
             }
         }
@@ -43,7 +46,11 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             get => _generateId;
             set
             {
-                Guard.NotNull(value, nameof (value), "Correlation function to generate an operation ID cannot be 'null'");
+                if (value is null)
+                {
+                    throw new ArgumentNullException(paramName: nameof(value), message: "Correlation function to generate an operation ID cannot be 'null'");
+                }
+
                 _generateId = value;
             }
         }

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoOperationOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoOperationOptions.cs
@@ -28,7 +28,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentException(message: "Correlation operation header cannot be blank", paramName: nameof(value));
+                    throw new ArgumentException("Correlation operation header cannot be blank", nameof(value));
                 }
 
                 _headerName = value;
@@ -48,7 +48,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 if (value is null)
                 {
-                    throw new ArgumentNullException(paramName: nameof(value), message: "Correlation function to generate an operation ID cannot be 'null'");
+                    throw new ArgumentNullException(nameof(value), "Correlation function to generate an operation ID cannot be 'null'");
                 }
 
                 _generateId = value;

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoTransactionOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoTransactionOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.WebApi.Logging.Core.Correlation
 {
@@ -43,7 +42,11 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             get => _headerName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Correlation transaction header cannot be blank");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException(message: "Header name cannot be blank", paramName: nameof(value));
+                }
+
                 _headerName = value;
             }
         }
@@ -62,7 +65,11 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             get => this._generateId;
             set
             {
-                Guard.NotNull(value, nameof(value), "Correlation function to generate an transaction ID cannot be 'null'");
+                if (value is null)
+                {
+                    throw new ArgumentNullException(paramName: nameof(value), message: "Correlation function to generate an transaction ID cannot be 'null'");
+                }
+
                 _generateId = value;
             }
         }

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoTransactionOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationInfoTransactionOptions.cs
@@ -44,7 +44,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentException(message: "Header name cannot be blank", paramName: nameof(value));
+                    throw new ArgumentException("Header name cannot be blank", nameof(value));
                 }
 
                 _headerName = value;
@@ -67,7 +67,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 if (value is null)
                 {
-                    throw new ArgumentNullException(paramName: nameof(value), message: "Correlation function to generate an transaction ID cannot be 'null'");
+                    throw new ArgumentNullException(nameof(value), "Correlation function to generate an transaction ID cannot be 'null'");
                 }
 
                 _generateId = value;

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
@@ -5,8 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Arcus.WebApi.Logging.Core.Correlation
@@ -34,13 +32,9 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             HttpCorrelationClientOptions options, 
             ILogger<HttpCorrelationMessageHandler> logger)
         {
-            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires a HTTP context accessor to retrieve the current HTTP correlation");
-            Guard.NotNull(options, nameof(options), "Requires a set of additional user-configurable options to influence the HTTP dependency tracking");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write the HTTP dependency telemetry");
-
-            _correlationInfoAccessor = correlationInfoAccessor;
-            _options = options;
-            _logger = logger;
+            _correlationInfoAccessor = correlationInfoAccessor ?? throw new ArgumentNullException(paramName: nameof(correlationInfoAccessor), message: "Requires a HTTP context accessor to retrieve the current HTTP correlation");
+            _options = options ?? throw new ArgumentNullException(paramName: nameof(options), message: "Requires a set of additional user-configurable options to influence the HTTP dependency tracking");
+            _logger = logger ?? throw new ArgumentNullException(paramName: nameof(logger), message: "Requires a logger instance to write the HTTP dependency telemetry");
         }
 
         /// <summary>

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
@@ -32,9 +32,9 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             HttpCorrelationClientOptions options, 
             ILogger<HttpCorrelationMessageHandler> logger)
         {
-            _correlationInfoAccessor = correlationInfoAccessor ?? throw new ArgumentNullException(paramName: nameof(correlationInfoAccessor), message: "Requires a HTTP context accessor to retrieve the current HTTP correlation");
-            _options = options ?? throw new ArgumentNullException(paramName: nameof(options), message: "Requires a set of additional user-configurable options to influence the HTTP dependency tracking");
-            _logger = logger ?? throw new ArgumentNullException(paramName: nameof(logger), message: "Requires a logger instance to write the HTTP dependency telemetry");
+            _correlationInfoAccessor = correlationInfoAccessor ?? throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a HTTP context accessor to retrieve the current HTTP correlation");
+            _options = options ?? throw new ArgumentNullException(nameof(options), "Requires a set of additional user-configurable options to influence the HTTP dependency tracking");
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger), "Requires a logger instance to write the HTTP dependency telemetry");
         }
 
         /// <summary>

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationResult.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationResult.cs
@@ -22,6 +22,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 throw new ArgumentException("Cannot create a successful HTTP correlation result with an error user message", nameof(errorMessage));
             }
+
             if (!isSuccess && requestId != null)
             {
                 throw new ArgumentException("Cannot create a failed HTTP correlation result with a request ID", nameof(requestId));
@@ -89,7 +90,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         {
             if (string.IsNullOrWhiteSpace(errorMessage))
             {
-                throw new ArgumentException(paramName:  nameof(errorMessage), message: "Requires an error user message that describes why the HTTP correlation process failed on the current HTTP request");
+                throw new ArgumentException("Requires an error user message that describes why the HTTP correlation process failed on the current HTTP request", nameof(errorMessage));
             }
 
             return new HttpCorrelationResult(isSuccess: false, requestId: null, errorMessage);
@@ -106,11 +107,11 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         {
             if (client is null)
             {
-                throw new ArgumentNullException(paramName: nameof(client), message: "Requires a telemetry client instance to automatically track built-in Microsoft dependencies");
+                throw new ArgumentNullException(nameof(client), "Requires a telemetry client instance to automatically track built-in Microsoft dependencies");
             }
             if (string.IsNullOrWhiteSpace(transactionId))
             {
-                throw new ArgumentException(message: "Requires a non-blank transaction ID for the pending HTTP correlation", paramName: nameof(transactionId));
+                throw new ArgumentException("Requires a non-blank transaction ID for the pending HTTP correlation", nameof(transactionId));
             }
 
             return Success(client, transactionId, operationParentId: null, traceParent: null);
@@ -131,11 +132,11 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         {
             if (client is null)
             {
-                throw new ArgumentNullException(paramName: nameof(client), message: "Requires a telemetry client instance to automatically track built-in Microsoft dependencies");
+                throw new ArgumentNullException(nameof(client), "Requires a telemetry client instance to automatically track built-in Microsoft dependencies");
             }
             if (string.IsNullOrWhiteSpace(transactionId))
             {
-                throw new ArgumentException(message: "Requires a non-blank transaction ID for the pending HTTP correlation", paramName: nameof(transactionId));
+                throw new ArgumentException("Requires a non-blank transaction ID for the pending HTTP correlation", nameof(transactionId));
             }
 
             var telemetry = new RequestTelemetry();

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationResult.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationResult.cs
@@ -109,6 +109,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 throw new ArgumentNullException(nameof(client), "Requires a telemetry client instance to automatically track built-in Microsoft dependencies");
             }
+
             if (string.IsNullOrWhiteSpace(transactionId))
             {
                 throw new ArgumentException("Requires a non-blank transaction ID for the pending HTTP correlation", nameof(transactionId));
@@ -134,6 +135,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             {
                 throw new ArgumentNullException(nameof(client), "Requires a telemetry client instance to automatically track built-in Microsoft dependencies");
             }
+
             if (string.IsNullOrWhiteSpace(transactionId))
             {
                 throw new ArgumentException("Requires a non-blank transaction ID for the pending HTTP correlation", nameof(transactionId));

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationTemplate.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationTemplate.cs
@@ -37,8 +37,8 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             IHttpCorrelationInfoAccessor correlationInfoAccessor,
             ILogger logger)
         {
-            _options = options ?? throw new ArgumentNullException(paramName: nameof(options), message: "Requires a set of options to configure the correlation process"); ;
-            _correlationInfoAccessor = correlationInfoAccessor ?? throw new ArgumentNullException(paramName: nameof(correlationInfoAccessor), message: "Requires a correlation info instance to set and retrieve the correlation information");
+            _options = options ?? throw new ArgumentNullException(nameof(options), "Requires a set of options to configure the correlation process");
+            _correlationInfoAccessor = correlationInfoAccessor ?? throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a correlation info instance to set and retrieve the correlation information");
             Logger = logger ?? NullLogger.Instance;
         }
 
@@ -66,7 +66,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         {
             if (request is null)
             {
-                throw new ArgumentNullException(paramName: nameof(request), message: "Requires a HTTP request to determine the HTTP correlation of the application");
+                throw new ArgumentNullException(nameof(request), "Requires a HTTP request to determine the HTTP correlation of the application");
             }
 
             IHeaderDictionary requestHeaders = GetRequestHeaders(request);
@@ -406,11 +406,12 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         {
             if (response is null)
             {
-                throw new ArgumentNullException(paramName: nameof(response), message: "Requires a HTTP response to set the HTTP correlation headers");
+                throw new ArgumentNullException(nameof(response), "Requires a HTTP response to set the HTTP correlation headers");
             }
+
             if (result is null)
             {
-                throw new ArgumentNullException(paramName: nameof(result), message: "Requires a HTTP correlation result to determine to set the HTTP correlation headers in the HTTP request");
+                throw new ArgumentNullException(nameof(result), "Requires a HTTP correlation result to determine to set the HTTP correlation headers in the HTTP request");
             }
 
             string requestId = result.RequestId;

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationTemplate.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationTemplate.cs
@@ -365,7 +365,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             //     returns: def
             
             Logger.LogTrace("Extracting operation parent ID from request ID '{RequestId}' from the upstream service according to W3C Trace-Context standard", requestId);
-            if (requestId.Contains("."))
+            if (requestId.Contains('.'))
             {
                 string[] ids = requestId.Split('.');
                 string operationParentId = ids.LastOrDefault(id => !string.IsNullOrWhiteSpace(id));

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationTemplate.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationTemplate.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using System.Text.RegularExpressions;
 using Arcus.Observability.Correlation;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Collections.Generic;
@@ -38,11 +37,8 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             IHttpCorrelationInfoAccessor correlationInfoAccessor,
             ILogger logger)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of options to configure the correlation process");
-            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires a correlation info instance to set and retrieve the correlation information");
-
-            _options = options;
-            _correlationInfoAccessor = correlationInfoAccessor;
+            _options = options ?? throw new ArgumentNullException(paramName: nameof(options), message: "Requires a set of options to configure the correlation process"); ;
+            _correlationInfoAccessor = correlationInfoAccessor ?? throw new ArgumentNullException(paramName: nameof(correlationInfoAccessor), message: "Requires a correlation info instance to set and retrieve the correlation information");
             Logger = logger ?? NullLogger.Instance;
         }
 
@@ -68,7 +64,10 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="request"/> is <c>null</c>.</exception>
         public HttpCorrelationResult TrySettingCorrelationFromRequest(THttpRequest request, string traceIdentifier)
         {
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request to determine the HTTP correlation of the application");
+            if (request is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(request), message: "Requires a HTTP request to determine the HTTP correlation of the application");
+            }
 
             IHeaderDictionary requestHeaders = GetRequestHeaders(request);
             if (requestHeaders is null)
@@ -405,8 +404,14 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="response"/> or <paramref name="result"/> is <c>null</c>.</exception>
         public void SetCorrelationHeadersInResponse(THttpResponse response, HttpCorrelationResult result)
         {
-            Guard.NotNull(response, nameof(response), "Requires a HTTP response to set the HTTP correlation headers");
-            Guard.NotNull(result, nameof(result), "Requires a HTTP correlation result to determine to set the HTTP correlation headers in the HTTP request");
+            if (response is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(response), message: "Requires a HTTP response to set the HTTP correlation headers");
+            }
+            if (result is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(result), message: "Requires a HTTP correlation result to determine to set the HTTP correlation headers in the HTTP request");
+            }
 
             string requestId = result.RequestId;
             CorrelationInfo correlationInfo = _correlationInfoAccessor.GetCorrelationInfo();

--- a/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
@@ -2,7 +2,6 @@
 using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.WebApi.Logging.Core.Correlation;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -37,10 +36,22 @@ namespace System.Net.Http
             IHttpCorrelationInfoAccessor correlationAccessor,
             ILogger logger)
         {
-            Guard.NotNull(client, nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
-            Guard.NotNull(correlationAccessor, nameof(correlationAccessor), "Requires a HTTP correlation accessor instance to retrieve the current correlation to include in the HTTP request");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+            if (client is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(client), message: "Requires a HTTP client to track the HTTP request with HTTP correlation");
+            }
+            if (request is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(request), message: "Requires a HTTP request to enrich with HTTP correlation");
+            }
+            if (correlationAccessor is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(correlationAccessor), "Requires a HTTP correlation accessor instance to retrieve the current correlation to include in the HTTP request");
+            }
+            if (logger is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+            }
 
             return await SendAsync(client, request, correlationAccessor, logger, configureOptions: null);
         }
@@ -70,10 +81,22 @@ namespace System.Net.Http
             ILogger logger,
             Action<HttpCorrelationClientOptions> configureOptions)
         {
-            Guard.NotNull(client, nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
-            Guard.NotNull(correlationAccessor, nameof(correlationAccessor), "Requires a HTTP correlation accessor instance to retrieve the current correlation to include in the HTTP request");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+            if (client is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(client), message: "Requires a HTTP client to track the HTTP request with HTTP correlation");
+            }
+            if (request is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(request), message: "Requires a HTTP request to enrich with HTTP correlation");
+            }
+            if (correlationAccessor is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(correlationAccessor), "Requires a HTTP correlation accessor instance to retrieve the current correlation to include in the HTTP request");
+            }
+            if (logger is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+            }
 
             CorrelationInfo correlation = correlationAccessor.GetCorrelationInfo();
             return await SendAsync(client, request, correlation, logger, configureOptions);
@@ -102,10 +125,22 @@ namespace System.Net.Http
             CorrelationInfo correlationInfo,
             ILogger logger)
         {
-            Guard.NotNull(client, nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a HTTP correlation instance to include in the HTTP request");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+            if (client is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(client), message: "Requires a HTTP client to track the HTTP request with HTTP correlation");
+            }
+            if (request is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(request), message: "Requires a HTTP request to enrich with HTTP correlation");
+            }
+            if (correlationInfo is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(correlationInfo), "Requires a HTTP correlation instance to include in the HTTP request");
+            }
+            if (logger is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+            }
 
             return await SendAsync(client, request, correlationInfo, logger, configureOptions: null);
         }
@@ -135,10 +170,22 @@ namespace System.Net.Http
             ILogger logger,
             Action<HttpCorrelationClientOptions> configureOptions)
         {
-            Guard.NotNull(client, nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a HTTP correlation instance to include in the HTTP request");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+            if (client is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(client), message: "Requires a HTTP client to track the HTTP request with HTTP correlation");
+            }
+            if (request is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(request), message: "Requires a HTTP request to enrich with HTTP correlation");
+            }
+            if (correlationInfo is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(correlationInfo), "Requires a HTTP correlation instance to include in the HTTP request");
+            }
+            if (logger is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+            }
 
             var options = new HttpCorrelationClientOptions();
             configureOptions?.Invoke(options);

--- a/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
@@ -35,29 +35,7 @@ namespace System.Net.Http
             HttpRequestMessage request,
             IHttpCorrelationInfoAccessor correlationAccessor,
             ILogger logger)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
-            }
-
-            if (request is null)
-            {
-                throw new ArgumentNullException(nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
-            }
-
-            if (correlationAccessor is null)
-            {
-                throw new ArgumentNullException(nameof(correlationAccessor), "Requires a HTTP correlation accessor instance to retrieve the current correlation to include in the HTTP request");
-            }
-
-            if (logger is null)
-            {
-                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track the correlated HTTP request");
-            }
-
-            return await SendAsync(client, request, correlationAccessor, logger, configureOptions: null);
-        }
+            => await SendAsync(client, request, correlationAccessor, logger, configureOptions: null);
 
         /// <summary>
         /// Sends an HTTP request as an asynchronous operation while tracking the HTTP correlation.
@@ -84,24 +62,9 @@ namespace System.Net.Http
             ILogger logger,
             Action<HttpCorrelationClientOptions> configureOptions)
         {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
-            }
-
-            if (request is null)
-            {
-                throw new ArgumentNullException(nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
-            }
-
             if (correlationAccessor is null)
             {
                 throw new ArgumentNullException(nameof(correlationAccessor), "Requires a HTTP correlation accessor instance to retrieve the current correlation to include in the HTTP request");
-            }
- 
-            if (logger is null)
-            {
-                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track the correlated HTTP request");
             }
 
             CorrelationInfo correlation = correlationAccessor.GetCorrelationInfo();
@@ -130,29 +93,7 @@ namespace System.Net.Http
             HttpRequestMessage request,
             CorrelationInfo correlationInfo,
             ILogger logger)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
-            }
-
-            if (request is null)
-            {
-                throw new ArgumentNullException(nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
-            }
-
-            if (correlationInfo is null)
-            {
-                throw new ArgumentNullException(nameof(correlationInfo), "Requires a HTTP correlation instance to include in the HTTP request");
-            }
-
-            if (logger is null)
-            {
-                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track the correlated HTTP request");
-            }
-
-            return await SendAsync(client, request, correlationInfo, logger, configureOptions: null);
-        }
+            => await SendAsync(client, request, correlationInfo, logger, configureOptions: null);
 
         /// <summary>
         /// Sends an HTTP request as an asynchronous operation while tracking the HTTP correlation.

--- a/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
@@ -38,19 +38,22 @@ namespace System.Net.Http
         {
             if (client is null)
             {
-                throw new ArgumentNullException(paramName: nameof(client), message: "Requires a HTTP client to track the HTTP request with HTTP correlation");
+                throw new ArgumentNullException(nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
             }
+
             if (request is null)
             {
-                throw new ArgumentNullException(paramName: nameof(request), message: "Requires a HTTP request to enrich with HTTP correlation");
+                throw new ArgumentNullException(nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
             }
+
             if (correlationAccessor is null)
             {
-                throw new ArgumentNullException(paramName: nameof(correlationAccessor), "Requires a HTTP correlation accessor instance to retrieve the current correlation to include in the HTTP request");
+                throw new ArgumentNullException(nameof(correlationAccessor), "Requires a HTTP correlation accessor instance to retrieve the current correlation to include in the HTTP request");
             }
+
             if (logger is null)
             {
-                throw new ArgumentNullException(paramName: nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track the correlated HTTP request");
             }
 
             return await SendAsync(client, request, correlationAccessor, logger, configureOptions: null);
@@ -83,19 +86,22 @@ namespace System.Net.Http
         {
             if (client is null)
             {
-                throw new ArgumentNullException(paramName: nameof(client), message: "Requires a HTTP client to track the HTTP request with HTTP correlation");
+                throw new ArgumentNullException(nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
             }
+
             if (request is null)
             {
-                throw new ArgumentNullException(paramName: nameof(request), message: "Requires a HTTP request to enrich with HTTP correlation");
+                throw new ArgumentNullException(nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
             }
+
             if (correlationAccessor is null)
             {
-                throw new ArgumentNullException(paramName: nameof(correlationAccessor), "Requires a HTTP correlation accessor instance to retrieve the current correlation to include in the HTTP request");
+                throw new ArgumentNullException(nameof(correlationAccessor), "Requires a HTTP correlation accessor instance to retrieve the current correlation to include in the HTTP request");
             }
+ 
             if (logger is null)
             {
-                throw new ArgumentNullException(paramName: nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track the correlated HTTP request");
             }
 
             CorrelationInfo correlation = correlationAccessor.GetCorrelationInfo();
@@ -127,19 +133,22 @@ namespace System.Net.Http
         {
             if (client is null)
             {
-                throw new ArgumentNullException(paramName: nameof(client), message: "Requires a HTTP client to track the HTTP request with HTTP correlation");
+                throw new ArgumentNullException(nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
             }
+
             if (request is null)
             {
-                throw new ArgumentNullException(paramName: nameof(request), message: "Requires a HTTP request to enrich with HTTP correlation");
+                throw new ArgumentNullException(nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
             }
+
             if (correlationInfo is null)
             {
-                throw new ArgumentNullException(paramName: nameof(correlationInfo), "Requires a HTTP correlation instance to include in the HTTP request");
+                throw new ArgumentNullException(nameof(correlationInfo), "Requires a HTTP correlation instance to include in the HTTP request");
             }
+
             if (logger is null)
             {
-                throw new ArgumentNullException(paramName: nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track the correlated HTTP request");
             }
 
             return await SendAsync(client, request, correlationInfo, logger, configureOptions: null);
@@ -172,19 +181,22 @@ namespace System.Net.Http
         {
             if (client is null)
             {
-                throw new ArgumentNullException(paramName: nameof(client), message: "Requires a HTTP client to track the HTTP request with HTTP correlation");
+                throw new ArgumentNullException(nameof(client), "Requires a HTTP client to track the HTTP request with HTTP correlation");
             }
+
             if (request is null)
             {
-                throw new ArgumentNullException(paramName: nameof(request), message: "Requires a HTTP request to enrich with HTTP correlation");
+                throw new ArgumentNullException(nameof(request), "Requires a HTTP request to enrich with HTTP correlation");
             }
+
             if (correlationInfo is null)
             {
-                throw new ArgumentNullException(paramName: nameof(correlationInfo), "Requires a HTTP correlation instance to include in the HTTP request");
+                throw new ArgumentNullException(nameof(correlationInfo), "Requires a HTTP correlation instance to include in the HTTP request");
             }
+
             if (logger is null)
             {
-                throw new ArgumentNullException(paramName: nameof(logger), "Requires a logger instance to track the correlated HTTP request");
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track the correlated HTTP request");
             }
 
             var options = new HttpCorrelationClientOptions();

--- a/src/Arcus.WebApi.Logging.Core/Extensions/HttpCorrelationEnricherExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/HttpCorrelationEnricherExtensions.cs
@@ -28,11 +28,12 @@ namespace Serilog.Configuration
         {
             if (enrichmentConfiguration is null)
             {
-                throw new ArgumentNullException(paramName: nameof(enrichmentConfiguration), message: "Requires a Serilog logger enrichment configuration to register the HTTP correlation as enrichment");
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires a Serilog logger enrichment configuration to register the HTTP correlation as enrichment");
             }
+
             if (serviceProvider is null)
             {
-                throw new ArgumentNullException(paramName: nameof(serviceProvider), message: "Requires a service provider to retrieve the HTTP correlation from the registered services when enriching the Serilog with the HTTP correlation");
+                throw new ArgumentNullException(nameof(serviceProvider), "Requires a service provider to retrieve the HTTP correlation from the registered services when enriching the Serilog with the HTTP correlation");
             }
 
             var correlationInfoAccessor = serviceProvider.GetService<IHttpCorrelationInfoAccessor>();

--- a/src/Arcus.WebApi.Logging.Core/Extensions/HttpCorrelationEnricherExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/HttpCorrelationEnricherExtensions.cs
@@ -3,7 +3,6 @@ using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Serilog.Enrichers;
 using Arcus.WebApi.Logging.Core.Correlation;
 using Arcus.WebApi.Logging.Correlation;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -27,8 +26,14 @@ namespace Serilog.Configuration
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> or <paramref name="serviceProvider"/> is <c>null</c>.</exception>
         public static LoggerConfiguration WithHttpCorrelationInfo(this LoggerEnrichmentConfiguration enrichmentConfiguration, IServiceProvider serviceProvider)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires a Serilog logger enrichment configuration to register the HTTP correlation as enrichment");
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider to retrieve the HTTP correlation from the registered services when enriching the Serilog with the HTTP correlation");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(enrichmentConfiguration), message: "Requires a Serilog logger enrichment configuration to register the HTTP correlation as enrichment");
+            }
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(serviceProvider), message: "Requires a service provider to retrieve the HTTP correlation from the registered services when enriching the Serilog with the HTTP correlation");
+            }
 
             var correlationInfoAccessor = serviceProvider.GetService<IHttpCorrelationInfoAccessor>();
             if (correlationInfoAccessor is null)

--- a/src/Arcus.WebApi.Logging.Core/Extensions/IDictionaryExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/IDictionaryExtensions.cs
@@ -23,11 +23,12 @@ namespace System.Collections.Generic
         {
             if (dictionary is null)
             {
-                throw new ArgumentNullException(paramName: nameof(dictionary));
+                throw new ArgumentNullException(nameof(dictionary));
             }
+
             if (predicate is null)
             {
-                throw new ArgumentNullException(paramName: nameof(predicate));
+                throw new ArgumentNullException(nameof(predicate));
             }
 
             return Enumerable.Where(dictionary, predicate)

--- a/src/Arcus.WebApi.Logging.Core/Extensions/IDictionaryExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/IDictionaryExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace System.Collections.Generic
@@ -22,8 +21,14 @@ namespace System.Collections.Generic
         /// </returns>
         public static IDictionary<TKey, TValue> Where<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, Func<KeyValuePair<TKey, TValue>, bool> predicate)
         {
-            Guard.NotNull(dictionary, nameof(dictionary));
-            Guard.NotNull(predicate, nameof(predicate));
+            if (dictionary is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(dictionary));
+            }
+            if (predicate is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(predicate));
+            }
 
             return Enumerable.Where(dictionary, predicate)
                              .ToDictionary(item => item.Key, item => item.Value);

--- a/src/Arcus.WebApi.Logging.Core/Extensions/IHeaderDictionaryExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/IHeaderDictionaryExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Http
         {
             if (headers is null)
             {
-                throw new ArgumentNullException(paramName: nameof(headers), message: "Requires a HTTP request headers dictionary instance to retrieve the 'traceparent' header value");
+                throw new ArgumentNullException(nameof(headers), "Requires a HTTP request headers dictionary instance to retrieve the 'traceparent' header value");
             }
 #if NET6_0
             StringValues traceParent = headers.TraceParent;
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Http
         {
             if (headers is null)
             {
-                throw new ArgumentNullException(paramName: nameof(headers), message: "Requires a HTTP request headers dictionary instance to retrieve the 'tracestate' header value");
+                throw new ArgumentNullException(nameof(headers), "Requires a HTTP request headers dictionary instance to retrieve the 'tracestate' header value");
             }
 #if NET6_0
             return headers.TraceState; 

--- a/src/Arcus.WebApi.Logging.Core/Extensions/IHeaderDictionaryExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/IHeaderDictionaryExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 using Microsoft.Extensions.Primitives;
 
 // ReSharper disable once CheckNamespace
@@ -18,7 +17,10 @@ namespace Microsoft.AspNetCore.Http
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="headers"/> is <c>null</c>.</exception>
         public static StringValues GetTraceParent(this IHeaderDictionary headers)
         {
-            Guard.NotNull(headers, nameof(headers), "Requires a HTTP request headers dictionary instance to retrieve the 'traceparent' header value");
+            if (headers is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(headers), message: "Requires a HTTP request headers dictionary instance to retrieve the 'traceparent' header value");
+            }
 #if NET6_0
             StringValues traceParent = headers.TraceParent;
 #else
@@ -40,7 +42,10 @@ namespace Microsoft.AspNetCore.Http
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="headers"/> is <c>null</c>.</exception>
         internal static StringValues GetTraceState(this IHeaderDictionary headers)
         {
-            Guard.NotNull(headers, nameof(headers), "Requires a HTTP request headers dictionary instance to retrieve the 'tracestate' header value");
+            if (headers is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(headers), message: "Requires a HTTP request headers dictionary instance to retrieve the 'tracestate' header value");
+            }
 #if NET6_0
             return headers.TraceState; 
 #else

--- a/src/Arcus.WebApi.Logging.Core/Extensions/IHttpClientBuilderExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/IHttpClientBuilderExtensions.cs
@@ -25,8 +25,9 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             if (builder is null)
             {
-                throw new ArgumentNullException(paramName: nameof(builder), message: "Requires a HTTP client builder instance to add the HTTP correlation message handler");
+                throw new ArgumentNullException(nameof(builder), "Requires a HTTP client builder instance to add the HTTP correlation message handler");
             }
+
             return WithHttpCorrelationTracking(builder, configureOptions: null);
         }
 
@@ -44,7 +45,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             if (builder is null)
             {
-                throw new ArgumentNullException(paramName: nameof(builder), message: "Requires a HTTP client builder instance to add the HTTP correlation message handler");
+                throw new ArgumentNullException(nameof(builder), "Requires a HTTP client builder instance to add the HTTP correlation message handler");
             }
 
             return builder.AddHttpMessageHandler(serviceProvider =>

--- a/src/Arcus.WebApi.Logging.Core/Extensions/IHttpClientBuilderExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/IHttpClientBuilderExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.WebApi.Logging.Core.Correlation;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
@@ -24,7 +23,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="InvalidOperationException">Thrown when the no <see cref="IHttpContextAccessor"/> was found in the dependency injection container.</exception>
         public static IHttpClientBuilder WithHttpCorrelationTracking(this IHttpClientBuilder builder)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a HTTP client builder instance to add the HTTP correlation message handler");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(builder), message: "Requires a HTTP client builder instance to add the HTTP correlation message handler");
+            }
             return WithHttpCorrelationTracking(builder, configureOptions: null);
         }
 
@@ -40,7 +42,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="InvalidOperationException">Thrown when the no <see cref="IHttpContextAccessor"/> was found in the dependency injection container.</exception>
         public static IHttpClientBuilder WithHttpCorrelationTracking(this IHttpClientBuilder builder, Action<HttpCorrelationClientOptions> configureOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a HTTP client builder instance to add the HTTP correlation message handler");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(builder), message: "Requires a HTTP client builder instance to add the HTTP correlation message handler");
+            }
 
             return builder.AddHttpMessageHandler(serviceProvider =>
             {

--- a/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingOptions.cs
@@ -36,6 +36,7 @@ namespace Arcus.WebApi.Logging
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), "Requires a request body buffer size greater than zero");
                 }
+
                 _requestBodyBufferSize = value;
             }
         }
@@ -58,6 +59,7 @@ namespace Arcus.WebApi.Logging
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), "Requires a response body buffer size greater than zero");
                 }
+
                 _responseBodyBufferSize = value;
             }
         }

--- a/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingOptions.cs
@@ -34,7 +34,7 @@ namespace Arcus.WebApi.Logging
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException(paramName: nameof(value), message: "Requires a request body buffer size greater than zero");
+                    throw new ArgumentOutOfRangeException(nameof(value), "Requires a request body buffer size greater than zero");
                 }
                 _requestBodyBufferSize = value;
             }
@@ -56,7 +56,7 @@ namespace Arcus.WebApi.Logging
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException(paramName: nameof(value), message: "Requires a response body buffer size greater than zero");
+                    throw new ArgumentOutOfRangeException(nameof(value), "Requires a response body buffer size greater than zero");
                 }
                 _responseBodyBufferSize = value;
             }

--- a/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingOptions.cs
+++ b/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingOptions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Net;
-using GuardNet;
 
 namespace Arcus.WebApi.Logging
 {
@@ -33,7 +32,10 @@ namespace Arcus.WebApi.Logging
             get => _requestBodyBufferSize;
             set
             {
-                Guard.For<ArgumentOutOfRangeException>(() => value < 0, "Requires a request body buffer size greater than zero");
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(paramName: nameof(value), message: "Requires a request body buffer size greater than zero");
+                }
                 _requestBodyBufferSize = value;
             }
         }
@@ -52,7 +54,10 @@ namespace Arcus.WebApi.Logging
             get => _responseBodyBufferSize;
             set
             {
-                Guard.For<ArgumentOutOfRangeException>(() => value < 0, "Requires a response body buffer size greater than zero");
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(paramName: nameof(value), message: "Requires a response body buffer size greater than zero");
+                }
                 _responseBodyBufferSize = value;
             }
         }

--- a/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingTemplate.cs
+++ b/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingTemplate.cs
@@ -26,7 +26,7 @@ namespace Arcus.WebApi.Logging.Core.RequestTracking
         {
             if (options is null)
             {
-                throw new ArgumentNullException(paramName: nameof(options), message: "Requires a set of additional user-configurable options to influence the behavior of the HTTP request tracking");
+                throw new ArgumentNullException(nameof(options), "Requires a set of additional user-configurable options to influence the behavior of the HTTP request tracking");
             }
             Options = options;
         }
@@ -122,12 +122,12 @@ namespace Arcus.WebApi.Logging.Core.RequestTracking
                 IDictionary<string, StringValues> headers = GetSanitizedRequestHeaders(requestHeaders, logger);
                 Dictionary<string, string> telemetryContext = headers.ToDictionary(header => header.Key, header => string.Join(",", header.Value));
 
-                if (string.IsNullOrWhiteSpace(requestBody) == false)
+                if (!string.IsNullOrWhiteSpace(requestBody))
                 {
                     telemetryContext.Add("RequestBody", requestBody);
                 }
 
-                if (string.IsNullOrWhiteSpace(responseBody) == false)
+                if (!string.IsNullOrWhiteSpace(responseBody))
                 {
                     telemetryContext.Add("ResponseBody", responseBody);
                 }
@@ -186,8 +186,9 @@ namespace Arcus.WebApi.Logging.Core.RequestTracking
         {
             if (body is null)
             {
-                throw new ArgumentNullException(paramName: nameof(body), message: $"Requires a streamed body to read the string representation of the {targetName}");
+                throw new ArgumentNullException(nameof(body), $"Requires a streamed body to read the string representation of the {targetName}");
             }
+
             logger = logger ?? NullLogger.Instance;
 
             logger.LogTrace("Prepare for {Target} body to be tracked...", targetName);

--- a/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingTemplate.cs
+++ b/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingTemplate.cs
@@ -24,11 +24,7 @@ namespace Arcus.WebApi.Logging.Core.RequestTracking
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         protected RequestTrackingTemplate(RequestTrackingOptions options)
         {
-            if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options), "Requires a set of additional user-configurable options to influence the behavior of the HTTP request tracking");
-            }
-            Options = options;
+            Options = options ?? throw new ArgumentNullException(nameof(options), "Requires a set of additional user-configurable options to influence the behavior of the HTTP request tracking");
         }
 
         /// <summary>

--- a/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingTemplate.cs
+++ b/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingTemplate.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -25,7 +24,10 @@ namespace Arcus.WebApi.Logging.Core.RequestTracking
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         protected RequestTrackingTemplate(RequestTrackingOptions options)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of additional user-configurable options to influence the behavior of the HTTP request tracking");
+            if (options is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(options), message: "Requires a set of additional user-configurable options to influence the behavior of the HTTP request tracking");
+            }
             Options = options;
         }
 
@@ -182,7 +184,10 @@ namespace Arcus.WebApi.Logging.Core.RequestTracking
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="body"/> is <c>null</c>.</exception>
         protected async Task<string> GetBodyAsync(Stream body, int? maxLength, string targetName, ILogger logger)
         {
-            Guard.NotNull(body, nameof(body), $"Requires a streamed body to read the string representation of the {targetName}");
+            if (body is null)
+            {
+                throw new ArgumentNullException(paramName: nameof(body), message: $"Requires a streamed body to read the string representation of the {targetName}");
+            }
             logger = logger ?? NullLogger.Instance;
 
             logger.LogTrace("Prepare for {Target} body to be tracked...", targetName);

--- a/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingTemplate.cs
+++ b/src/Arcus.WebApi.Logging.Core/RequestTracking/RequestTrackingTemplate.cs
@@ -48,7 +48,7 @@ namespace Arcus.WebApi.Logging.Core.RequestTracking
             IEnumerable<string> allOmittedRoutes = Options.OmittedRoutes ?? new Collection<string>();
             string[] matchedOmittedRoutes =
                 allOmittedRoutes
-                    .Select(omittedRoute => omittedRoute?.StartsWith("/") == true ? omittedRoute : "/" + omittedRoute)
+                    .Select(omittedRoute => omittedRoute?.StartsWith('/') == true ? omittedRoute : "/" + omittedRoute)
                     .Where(omittedRoute => requestPath.StartsWithSegments(omittedRoute, StringComparison.OrdinalIgnoreCase))
                     .ToArray();
 

--- a/src/Arcus.WebApi.Logging.Core/RequestTracking/StatusCodeRange.cs
+++ b/src/Arcus.WebApi.Logging.Core/RequestTracking/StatusCodeRange.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.WebApi.Logging
 {
@@ -30,9 +29,18 @@ namespace Arcus.WebApi.Logging
         /// </exception>
         public StatusCodeRange(int minimum, int maximum)
         {
-            Guard.NotLessThan(minimum, 100, nameof(minimum), "Requires the minimum HTTP status code threshold not be less than 100");
-            Guard.NotGreaterThan(maximum, 599, nameof(maximum), "Requires the maximum HTTP status code threshold not be greater than 599");
-            Guard.NotGreaterThan(minimum, maximum, nameof(minimum), "Requires the minimum HTTP status code threshold to be less than the maximum HTTP status code threshold");
+            if (minimum < 100)
+            {
+                throw new ArgumentOutOfRangeException(paramName: nameof(minimum), message: "Requires the minimum HTTP status code threshold to not be less than 100");
+            }
+            if (maximum > 599)
+            {
+                throw new ArgumentOutOfRangeException(paramName: nameof(maximum), message: "Requires the maximum HTTP status code threshold to not be greater than 599");
+            }
+            if (minimum > maximum)
+            {
+                throw new ArgumentOutOfRangeException(paramName: nameof(minimum), message: "Requires the minimum HTTP status code threshold to be less than the maximum HTTP status code threshold");
+            }
             
             Minimum = minimum;
             Maximum = maximum;
@@ -58,8 +66,14 @@ namespace Arcus.WebApi.Logging
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="statusCode"/> is less than 100 or greater than 599.</exception>
         public bool IsWithinRange(int statusCode)
         {
-            Guard.NotLessThan(statusCode, 100, nameof(statusCode), "Requires the response HTTP status code not be less than 100");
-            Guard.NotGreaterThan(statusCode, 599, nameof(statusCode), "Requires the response HTTP status code not be greater than 599");
+            if (statusCode < 100)
+            {
+                throw new ArgumentOutOfRangeException(paramName: nameof(statusCode), message: "Requires the response HTTP status code to not be less than 100");
+            }
+            if (statusCode > 599)
+            {
+                throw new ArgumentOutOfRangeException(paramName: nameof(statusCode), message: "Requires the response HTTP status code to not be greater than 599");
+            }
             
             return Minimum <= statusCode && statusCode <= Maximum;
         }

--- a/src/Arcus.WebApi.Logging.Core/RequestTracking/StatusCodeRange.cs
+++ b/src/Arcus.WebApi.Logging.Core/RequestTracking/StatusCodeRange.cs
@@ -31,15 +31,17 @@ namespace Arcus.WebApi.Logging
         {
             if (minimum < 100)
             {
-                throw new ArgumentOutOfRangeException(paramName: nameof(minimum), message: "Requires the minimum HTTP status code threshold to not be less than 100");
+                throw new ArgumentOutOfRangeException(nameof(minimum), "Requires the minimum HTTP status code threshold to not be less than 100");
             }
+
             if (maximum > 599)
             {
-                throw new ArgumentOutOfRangeException(paramName: nameof(maximum), message: "Requires the maximum HTTP status code threshold to not be greater than 599");
+                throw new ArgumentOutOfRangeException(nameof(maximum), "Requires the maximum HTTP status code threshold to not be greater than 599");
             }
+
             if (minimum > maximum)
             {
-                throw new ArgumentOutOfRangeException(paramName: nameof(minimum), message: "Requires the minimum HTTP status code threshold to be less than the maximum HTTP status code threshold");
+                throw new ArgumentOutOfRangeException(nameof(minimum), "Requires the minimum HTTP status code threshold to be less than the maximum HTTP status code threshold");
             }
             
             Minimum = minimum;
@@ -68,11 +70,12 @@ namespace Arcus.WebApi.Logging
         {
             if (statusCode < 100)
             {
-                throw new ArgumentOutOfRangeException(paramName: nameof(statusCode), message: "Requires the response HTTP status code to not be less than 100");
+                throw new ArgumentOutOfRangeException(nameof(statusCode), "Requires the response HTTP status code to not be less than 100");
             }
+
             if (statusCode > 599)
             {
-                throw new ArgumentOutOfRangeException(paramName: nameof(statusCode), message: "Requires the response HTTP status code to not be greater than 599");
+                throw new ArgumentOutOfRangeException(nameof(statusCode), "Requires the response HTTP status code to not be greater than 599");
             }
             
             return Minimum <= statusCode && statusCode <= Maximum;

--- a/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
+++ b/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
@@ -37,7 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Arcus.Observability.Correlation" Version="[3.0.0,4.0.0)" />

--- a/src/Arcus.WebApi.Logging/Correlation/CorrelationMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/Correlation/CorrelationMiddleware.cs
@@ -44,14 +44,17 @@ namespace Arcus.WebApi.Logging.Correlation
             {
                 throw new ArgumentNullException(nameof(httpContext), "Requires a HTTP context");
             }
+
             if (service is null)
             {
                 throw new ArgumentNullException(nameof(service), "Requires the HTTP correlation service");
             }
+
             if (httpContext.Response is null)
             {
                 throw new ArgumentException("Requires a 'Response'", nameof(httpContext));
             }
+
             if (httpContext.Response.Headers is null)
             {
                 throw new ArgumentException("Requires a 'Response' object with headers", nameof(httpContext));

--- a/src/Arcus.WebApi.Logging/ExceptionHandlingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/ExceptionHandlingMiddleware.cs
@@ -3,7 +3,6 @@ using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using GuardNet;
 using Microsoft.Extensions.Logging.Abstractions;
 
 // ReSharper disable once CheckNamespace
@@ -45,11 +44,8 @@ namespace Arcus.WebApi.Logging
         /// <exception cref="ArgumentNullException">When the <paramref name="getLoggingCategory"/> is <c>null</c>.</exception>
         public ExceptionHandlingMiddleware(RequestDelegate next, Func<string> getLoggingCategory)
         {
-            Guard.NotNull(next, nameof(next), "The next request delegate in the application request pipeline cannot be null");
-            Guard.NotNull(getLoggingCategory, nameof(getLoggingCategory), "The retrieval of the logging category function cannot be null");
-
-            _next = next;
-            _getLoggingCategory = getLoggingCategory;
+            _next = next ?? throw new ArgumentNullException(nameof(next), "The next request delegate in the application request pipeline cannot be null");
+            _getLoggingCategory = getLoggingCategory ?? throw new ArgumentNullException(nameof(getLoggingCategory), "The retrieval of the logging category function cannot be null");
         }
 
         /// <summary>

--- a/src/Arcus.WebApi.Logging/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Arcus.WebApi.Logging/Extensions/IApplicationBuilderExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.WebApi.Logging;
 using Arcus.WebApi.Logging.Correlation;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.AspNetCore.Builder 
@@ -19,7 +18,10 @@ namespace Microsoft.AspNetCore.Builder
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="app"/> is <c>null</c>.</exception>
         public static IApplicationBuilder UseExceptionHandling(this IApplicationBuilder app)
         {
-            Guard.NotNull(app, nameof(app), "Requires an application builder instance to add the exception middleware component");
+            if (app is null)
+            {
+                throw new ArgumentNullException(nameof(app), "Requires an application builder instance to add the exception middleware component");
+            }
 
             return app.UseMiddleware<ExceptionHandlingMiddleware>();
         }
@@ -33,7 +35,10 @@ namespace Microsoft.AspNetCore.Builder
         public static IApplicationBuilder UseExceptionHandling<TMiddleware>(this IApplicationBuilder app)
             where TMiddleware : ExceptionHandlingMiddleware
         {
-            Guard.NotNull(app, nameof(app), "Requires an application builder instance to add the exception middleware component");
+            if (app is null)
+            {
+                throw new ArgumentNullException(nameof(app), "Requires an application builder instance to add the exception middleware component");
+            }
 
             return app.UseMiddleware<TMiddleware>();
         }
@@ -47,7 +52,10 @@ namespace Microsoft.AspNetCore.Builder
             this IApplicationBuilder app,
             Action<RequestTrackingOptions> configureOptions = null)
         {
-            Guard.NotNull(app, nameof(app));
+            if (app is null)
+            {
+                throw new ArgumentNullException(nameof(app), "Requires an application builder instance to add the request tracking middleware component");
+            }
 
             return UseRequestTracking<RequestTrackingMiddleware>(app, configureOptions);
         }
@@ -62,7 +70,10 @@ namespace Microsoft.AspNetCore.Builder
             Action<RequestTrackingOptions> configureOptions = null)
             where TMiddleware : RequestTrackingMiddleware
         {
-            Guard.NotNull(app, nameof(app));
+            if (app is null)
+            {
+                throw new ArgumentNullException(nameof(app), "Requires an application builder instance to add the request tracking middleware component");
+            }
 
             var options = new RequestTrackingOptions();
             configureOptions?.Invoke(options);
@@ -76,7 +87,10 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="app">The builder to configure the application's request pipeline.</param>
         public static IApplicationBuilder UseHttpCorrelation(this IApplicationBuilder app)
         {
-            Guard.NotNull(app, nameof(app));
+            if (app is null)
+            {
+                throw new ArgumentNullException(nameof(app), "Requires an application builder instance to add the request tracking middleware component");
+            }
 
             return app.UseMiddleware<CorrelationMiddleware>();
         }
@@ -94,7 +108,10 @@ namespace Microsoft.AspNetCore.Builder
         /// </remarks>
         public static IApplicationBuilder UseVersionTracking(this IApplicationBuilder app, Action<VersionTrackingOptions> configureOptions = null)
         {
-            Guard.NotNull(app, nameof(app), "Requires an application builder to add the version tracking middleware");
+            if (app is null)
+            {
+                throw new ArgumentNullException(nameof(app), "Requires an application builder instance to add the request tracking middleware component");
+            }
 
             var options = new VersionTrackingOptions();
             configureOptions?.Invoke(options);

--- a/src/Arcus.WebApi.Logging/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Logging/Extensions/IServiceCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using Arcus.Observability.Correlation;
 using Arcus.WebApi.Logging.Core.Correlation;
 using Arcus.WebApi.Logging.Correlation;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
@@ -21,7 +20,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The services collection containing the dependency injection services.</param>
         public static IServiceCollection AddHttpCorrelation(this IServiceCollection services)
         {
-            Guard.NotNull(services, nameof(services), "Requires a services collection to add the HTTP correlation services");
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services), "Requires a services collection to add the HTTP correlation services");
+            }
 
             return AddHttpCorrelation(services, configureOptions: (HttpCorrelationInfoOptions options) => { });
         }
@@ -36,7 +38,10 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection services,
             Action<HttpCorrelationInfoOptions> configureOptions)
         {
-            Guard.NotNull(services, nameof(services), "Requires a services collection to add the HTTP correlation services");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), "Requires a services collection to add the HTTP correlation services");
+            }
 
             services.AddHttpContextAccessor();
             services.AddSingleton<IHttpCorrelationInfoAccessor>(serviceProvider =>

--- a/src/Arcus.WebApi.Logging/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Logging/Extensions/IServiceCollectionExtensions.cs
@@ -19,14 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services">The services collection containing the dependency injection services.</param>
         public static IServiceCollection AddHttpCorrelation(this IServiceCollection services)
-        {
-            if (services == null)
-            {
-                throw new ArgumentNullException(nameof(services), "Requires a services collection to add the HTTP correlation services");
-            }
-
-            return AddHttpCorrelation(services, configureOptions: (HttpCorrelationInfoOptions options) => { });
-        }
+            => AddHttpCorrelation(services, configureOptions: (HttpCorrelationInfoOptions options) => { });
 
         /// <summary>
         /// Adds operation and transaction correlation to the application.

--- a/src/Arcus.WebApi.Logging/RequestTrackingAttribute.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingAttribute.cs
@@ -21,9 +21,10 @@ namespace Arcus.WebApi.Logging
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="filter"/> is outside the range of the enumeration.</exception>
         public RequestTrackingAttribute(Exclude filter)
         {
-            Guard.For<ArgumentOutOfRangeException>(
-                () => !Enum.IsDefined(typeof(Exclude), filter) || filter is Exclude.None,
-                $"Requires the exclusion filter to be within these bounds of the enumeration '{ExcludeFilterNames}'; 'None' is not allowed");
+            if (!Enum.IsDefined(typeof(Exclude), filter) || filter is Exclude.None)
+            {
+                throw new ArgumentOutOfRangeException(nameof(filter), $"Requires the exclusion filter to be within these bounds of the enumeration '{ExcludeFilterNames}'; 'None' is not allowed",);
+            }
 
             Filter = filter;
         }
@@ -44,8 +45,10 @@ namespace Arcus.WebApi.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="trackedStatusCode"/> is outside the expected range (100-599).</exception>
         public RequestTrackingAttribute(int trackedStatusCode)
         {
-            Guard.NotLessThan(trackedStatusCode, 100, nameof(trackedStatusCode), "Requires the allowed tracked HTTP status code to not be less than 100");
-            Guard.NotGreaterThan(trackedStatusCode, 599, nameof(trackedStatusCode), "Requires the allowed tracked HTTP status code to not be greater than 599");
+            if (trackedStatusCode < 100 || trackedStatusCode > 599)
+            {
+                throw new ArgumentOutOfRangeException(nameof(trackedStatusCode), "Requires the allowed tracked HTTP status code to be within the range of 100-599");
+            }
             
             StatusCodeRange = new StatusCodeRange(trackedStatusCode);
         }

--- a/src/Arcus.WebApi.Logging/RequestTrackingAttribute.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingAttribute.cs
@@ -65,9 +65,18 @@ namespace Arcus.WebApi.Logging
         /// </exception>
         public RequestTrackingAttribute(int minimumStatusCode, int maximumStatusCode)
         {
-            Guard.NotLessThan(minimumStatusCode, 100, nameof(minimumStatusCode), "Requires the minimum HTTP status code threshold not be less than 100");
-            Guard.NotGreaterThan(maximumStatusCode, 599, nameof(maximumStatusCode), "Requires the maximum HTTP status code threshold not be greater than 599");
-            Guard.NotGreaterThan(minimumStatusCode, maximumStatusCode, nameof(minimumStatusCode), "Requires the minimum HTTP status code threshold to be less than the maximum HTTP status code threshold");
+            if (minimumStatusCode < 100)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minimumStatusCode), "Requires the minimum HTTP status code threshold to not be less than 100");
+            }
+            if (maximumStatusCode > 599)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximumStatusCode), "Requires the maximum HTTP status code threshold to not be greater than 599");
+            }
+            if (minimumStatusCode >= maximumStatusCode)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minimumStatusCode), "Requires the minimum HTTP status code threshold to be less than the maximum HTTP status code threshold");
+            }
             
             StatusCodeRange = new StatusCodeRange(minimumStatusCode, maximumStatusCode);
         }

--- a/src/Arcus.WebApi.Logging/RequestTrackingAttribute.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingAttribute.cs
@@ -22,7 +22,7 @@ namespace Arcus.WebApi.Logging
         {
             if (!Enum.IsDefined(typeof(Exclude), filter) || filter is Exclude.None)
             {
-                throw new ArgumentOutOfRangeException(nameof(filter), $"Requires the exclusion filter to be within these bounds of the enumeration '{ExcludeFilterNames}'; 'None' is not allowed",);
+                throw new ArgumentOutOfRangeException(nameof(filter), $"Requires the exclusion filter to be within these bounds of the enumeration '{ExcludeFilterNames}'; 'None' is not allowed");
             }
 
             Filter = filter;

--- a/src/Arcus.WebApi.Logging/RequestTrackingAttribute.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingAttribute.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Net;
-using GuardNet;
 
 namespace Arcus.WebApi.Logging
 {

--- a/src/Arcus.WebApi.Logging/RequestTrackingAttribute.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingAttribute.cs
@@ -68,10 +68,12 @@ namespace Arcus.WebApi.Logging
             {
                 throw new ArgumentOutOfRangeException(nameof(minimumStatusCode), "Requires the minimum HTTP status code threshold to not be less than 100");
             }
+
             if (maximumStatusCode > 599)
             {
                 throw new ArgumentOutOfRangeException(nameof(maximumStatusCode), "Requires the maximum HTTP status code threshold to not be greater than 599");
             }
+
             if (minimumStatusCode >= maximumStatusCode)
             {
                 throw new ArgumentOutOfRangeException(nameof(minimumStatusCode), "Requires the minimum HTTP status code threshold to be less than the maximum HTTP status code threshold");

--- a/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
@@ -37,10 +37,12 @@ namespace Arcus.WebApi.Logging
             {
                 throw new ArgumentNullException(nameof(options), "Requires a set of options to control the behavior of the HTTP tracking middleware");
             }
+
             if (next is null)
             {
                 throw new ArgumentNullException(nameof(next), "Requires a function pipeline to delegate the remainder of the request processing");
             }
+
             if (logger is null)
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to write telemetry tracking during the request processing");
@@ -62,10 +64,12 @@ namespace Arcus.WebApi.Logging
             {
                 throw new ArgumentNullException(nameof(httpContext), "Requires a HTTP context instance to track the incoming request and outgoing response");
             }
+
             if (httpContext.Request is null)
             {
                 throw new ArgumentNullException(nameof(httpContext), "Requires a HTTP request in the context to track the request");
             }
+
             if (httpContext.Response is null)
             {
                 throw new ArgumentNullException(nameof(httpContext), "Requires a HTTP response in the context to track the request");

--- a/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.WebApi.Logging.Core.RequestTracking;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
@@ -34,9 +33,18 @@ namespace Arcus.WebApi.Logging
             ILogger<RequestTrackingMiddleware> logger)
             : base(options)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of options to control the behavior of the HTTP tracking middleware");
-            Guard.NotNull(next, nameof(next), "Requires a function pipeline to delegate the remainder of the request processing");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write telemetry tracking during the request processing");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a set of options to control the behavior of the HTTP tracking middleware");
+            }
+            if (next is null)
+            {
+                throw new ArgumentNullException(nameof(next), "Requires a function pipeline to delegate the remainder of the request processing");
+            }
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to write telemetry tracking during the request processing");
+            }
 
             _next = next;
             _logger = logger;
@@ -50,9 +58,18 @@ namespace Arcus.WebApi.Logging
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="httpContext"/> is <c>null</c>.</exception>
         public async Task Invoke(HttpContext httpContext)
         {
-            Guard.NotNull(httpContext, nameof(httpContext), "Requires a HTTP context instance to track the incoming request and outgoing response");
-            Guard.NotNull(httpContext.Request, nameof(httpContext), "Requires a HTTP request in the context to track the request");
-            Guard.NotNull(httpContext.Response, nameof(httpContext), "Requires a HTTP response in the context to track the request");
+            if (httpContext is null)
+            {
+                throw new ArgumentNullException(nameof(httpContext), "Requires a HTTP context instance to track the incoming request and outgoing response");
+            }
+            if (httpContext.Request is null)
+            {
+                throw new ArgumentNullException(nameof(httpContext), "Requires a HTTP request in the context to track the request");
+            }
+            if (httpContext.Response is null)
+            {
+                throw new ArgumentNullException(nameof(httpContext), "Requires a HTTP response in the context to track the request");
+            }
 
             if (IsRequestPathOmitted(httpContext.Request.Path, _logger))
             {

--- a/src/Arcus.WebApi.Logging/VersionTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/VersionTrackingMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -35,9 +34,18 @@ namespace Arcus.WebApi.Logging
             RequestDelegate next,
             ILogger<VersionTrackingMiddleware> logger)
         {
-            Guard.NotNull(appVersion, nameof(appVersion), "Requires an instance to retrieve the current application version to add the version to the response");
-            Guard.NotNull(next, nameof(next), "Requires a continuation delegate to move towards the next functionality in the request pipeline");
-            Guard.NotNull(options, nameof(options), "Requires version tracking options to specify how the application version should be tracked in the response");
+            if (appVersion is null)
+            {
+                throw new ArgumentNullException(nameof(appVersion), "Requires an instance to retrieve the current application version to add the version to the response");
+            }
+            if (next is null)
+            {
+                throw new ArgumentNullException(nameof(next), "Requires a continuation delegate to move towards the next functionality in the request pipeline");
+            }
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires version tracking options to specify how the application version should be tracked in the response");
+            }
 
             _appVersion = appVersion;
             _options = options;
@@ -53,8 +61,14 @@ namespace Arcus.WebApi.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="context"/> doesn't contain a response.</exception>
         public async Task Invoke(HttpContext context)
         {
-            Guard.NotNull(context, nameof(context), "Requires a HTTP context to add the application version to the response");
-            Guard.For(() => context.Response is null, new ArgumentException("Requires a HTTP context with a response to add the application version", nameof(context)));
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context), "Requires a HTTP context to add the application version to the response");
+            }
+            if (context.Response is null)
+            {
+                throw new ArgumentException("Requires a HTTP context with a response to add the application version", nameof(context));
+            }
 
             context.Response.OnStarting(() =>
             {

--- a/src/Arcus.WebApi.Logging/VersionTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/VersionTrackingMiddleware.cs
@@ -38,10 +38,12 @@ namespace Arcus.WebApi.Logging
             {
                 throw new ArgumentNullException(nameof(appVersion), "Requires an instance to retrieve the current application version to add the version to the response");
             }
+
             if (next is null)
             {
                 throw new ArgumentNullException(nameof(next), "Requires a continuation delegate to move towards the next functionality in the request pipeline");
             }
+
             if (options is null)
             {
                 throw new ArgumentNullException(nameof(options), "Requires version tracking options to specify how the application version should be tracked in the response");
@@ -65,6 +67,7 @@ namespace Arcus.WebApi.Logging
             {
                 throw new ArgumentNullException(nameof(context), "Requires a HTTP context to add the application version to the response");
             }
+
             if (context.Response is null)
             {
                 throw new ArgumentException("Requires a HTTP context with a response to add the application version", nameof(context));

--- a/src/Arcus.WebApi.Logging/VersionTrackingOptions.cs
+++ b/src/Arcus.WebApi.Logging/VersionTrackingOptions.cs
@@ -1,4 +1,4 @@
-﻿using GuardNet;
+﻿using System;
 
 namespace Arcus.WebApi.Logging
 {
@@ -17,7 +17,10 @@ namespace Arcus.WebApi.Logging
             get => _headerName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank header name to add the current application version to the response");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Requires a non-blank header name to add the current application version to the response", nameof(value));
+                }
                 _headerName = value;
             }
         }

--- a/src/Arcus.WebApi.Logging/VersionTrackingOptions.cs
+++ b/src/Arcus.WebApi.Logging/VersionTrackingOptions.cs
@@ -21,6 +21,7 @@ namespace Arcus.WebApi.Logging
                 {
                     throw new ArgumentException("Requires a non-blank header name to add the current application version to the response", nameof(value));
                 }
+
                 _headerName = value;
             }
         }

--- a/src/Arcus.WebApi.OpenApi.Extensions/Arcus.WebApi.OpenApi.Extensions.csproj
+++ b/src/Arcus.WebApi.OpenApi.Extensions/Arcus.WebApi.OpenApi.Extensions.csproj
@@ -32,10 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Guard.Net" Version="3.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Arcus.WebApi.Security\Arcus.WebApi.Security.csproj" />
   </ItemGroup>
 

--- a/src/Arcus.WebApi.OpenApi.Extensions/CertificateAuthenticationOperationFilter.cs
+++ b/src/Arcus.WebApi.OpenApi.Extensions/CertificateAuthenticationOperationFilter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Arcus.WebApi.Security.Authentication.Certificates;
-using GuardNet;
 #if !NETSTANDARD2_1
 using Microsoft.OpenApi.Models;
 #endif
@@ -44,16 +43,13 @@ namespace Arcus.WebApi.OpenApi.Extensions
 #endif
         )
         {
-            Guard.NotNullOrWhitespace(securitySchemeName,
-                                      nameof(securitySchemeName),
-                                      "Requires a name for the Certificate security scheme");
-
-            _securitySchemeName = securitySchemeName;
+            _securitySchemeName = securitySchemeName ?? throw new ArgumentNullException(paramName: nameof(securitySchemeName), message: "Requires a name for the Certificate security scheme");
 
 #if !NETSTANDARD2_1
-            Guard.For<ArgumentException>(
-                () => !Enum.IsDefined(typeof(SecuritySchemeType), securitySchemeType), 
-                "Requires a security scheme type for the Certificate authentication that is within the bounds of the enumeration");
+            if (!Enum.IsDefined(typeof(SecuritySchemeType), securitySchemeType))
+            {
+                throw new ArgumentException(paramName: nameof(securitySchemeType), message: "Requires a security scheme type for the Certificate authentication that is within the bounds of the enumeration");
+            }
 
             _securitySchemeType = securitySchemeType;
 #endif

--- a/src/Arcus.WebApi.OpenApi.Extensions/CertificateAuthenticationOperationFilter.cs
+++ b/src/Arcus.WebApi.OpenApi.Extensions/CertificateAuthenticationOperationFilter.cs
@@ -43,12 +43,12 @@ namespace Arcus.WebApi.OpenApi.Extensions
 #endif
         )
         {
-            _securitySchemeName = securitySchemeName ?? throw new ArgumentNullException(paramName: nameof(securitySchemeName), message: "Requires a name for the Certificate security scheme");
+            _securitySchemeName = securitySchemeName ?? throw new ArgumentNullException(nameof(securitySchemeName), "Requires a name for the Certificate security scheme");
 
 #if !NETSTANDARD2_1
             if (!Enum.IsDefined(typeof(SecuritySchemeType), securitySchemeType))
             {
-                throw new ArgumentException(paramName: nameof(securitySchemeType), message: "Requires a security scheme type for the Certificate authentication that is within the bounds of the enumeration");
+                throw new ArgumentException("Requires a security scheme type for the Certificate authentication that is within the bounds of the enumeration", nameof(securitySchemeType));
             }
 
             _securitySchemeType = securitySchemeType;

--- a/src/Arcus.WebApi.OpenApi.Extensions/CertificateAuthenticationOperationFilter.cs
+++ b/src/Arcus.WebApi.OpenApi.Extensions/CertificateAuthenticationOperationFilter.cs
@@ -43,7 +43,12 @@ namespace Arcus.WebApi.OpenApi.Extensions
 #endif
         )
         {
-            _securitySchemeName = securitySchemeName ?? throw new ArgumentNullException(nameof(securitySchemeName), "Requires a name for the Certificate security scheme");
+            if (string.IsNullOrWhiteSpace(securitySchemeName))
+            {
+                throw new ArgumentNullException(nameof(securitySchemeName), "Requires a name for the Certificate security scheme");
+            }
+
+            _securitySchemeName = securitySchemeName;
 
 #if !NETSTANDARD2_1
             if (!Enum.IsDefined(typeof(SecuritySchemeType), securitySchemeType))

--- a/src/Arcus.WebApi.OpenApi.Extensions/OAuthAuthorizeOperationFilter.cs
+++ b/src/Arcus.WebApi.OpenApi.Extensions/OAuthAuthorizeOperationFilter.cs
@@ -37,7 +37,7 @@ namespace Arcus.WebApi.OpenApi.Extensions
 
             if (string.IsNullOrWhiteSpace(securitySchemaName))
             {
-                throw new ArgumentNullException(nameof(securitySchemaName), "Requires a name for the OAuth2 security scheme");
+                throw new ArgumentException("Requires a name for the OAuth2 security scheme", nameof(securitySchemaName));
             }
 
             _securitySchemaName = securitySchemaName;

--- a/src/Arcus.WebApi.OpenApi.Extensions/OAuthAuthorizeOperationFilter.cs
+++ b/src/Arcus.WebApi.OpenApi.Extensions/OAuthAuthorizeOperationFilter.cs
@@ -32,15 +32,16 @@ namespace Arcus.WebApi.OpenApi.Extensions
         {
             if (scopes.Any(String.IsNullOrWhiteSpace))
             {
-                throw new ArgumentException(message: "Requires a list of non-blank API scopes", paramName: nameof(scopes));
+                throw new ArgumentException("Requires a list of non-blank API scopes", nameof(scopes));
             }
+
             if (string.IsNullOrWhiteSpace(securitySchemaName))
             {
-                throw new ArgumentNullException(paramName: nameof(securitySchemaName), message: "Requires a name for the OAuth2 security scheme");
+                throw new ArgumentNullException(nameof(securitySchemaName), "Requires a name for the OAuth2 security scheme");
             }
 
             _securitySchemaName = securitySchemaName;
-            _scopes = scopes ?? throw new ArgumentNullException(paramName: nameof(scopes), message: "Requires a list of API scopes");
+            _scopes = scopes ?? throw new ArgumentNullException(nameof(scopes), "Requires a list of API scopes");
         }
 
         /// <summary>

--- a/src/Arcus.WebApi.OpenApi.Extensions/OAuthAuthorizeOperationFilter.cs
+++ b/src/Arcus.WebApi.OpenApi.Extensions/OAuthAuthorizeOperationFilter.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Authorization;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System.Collections.Generic;
 using System.Linq;
-using GuardNet;
 using Swashbuckle.AspNetCore.Swagger;
 #if !NETSTANDARD2_1
 using Microsoft.OpenApi.Models;
@@ -31,12 +30,17 @@ namespace Arcus.WebApi.OpenApi.Extensions
         /// </exception>
         public OAuthAuthorizeOperationFilter(IEnumerable<string> scopes, string securitySchemaName = "oauth2")
         {
-            Guard.NotNull(scopes, nameof(scopes), "Requires a list of API scopes");
-            Guard.For<ArgumentException>(() => scopes.Any(String.IsNullOrWhiteSpace), "Requires a list of non-blank API scopes");
-            Guard.NotNullOrWhitespace(securitySchemaName, nameof(securitySchemaName), "Requires a name for the OAuth2 security scheme");
+            if (scopes.Any(String.IsNullOrWhiteSpace))
+            {
+                throw new ArgumentException(message: "Requires a list of non-blank API scopes", paramName: nameof(scopes));
+            }
+            if (string.IsNullOrWhiteSpace(securitySchemaName))
+            {
+                throw new ArgumentNullException(paramName: nameof(securitySchemaName), message: "Requires a name for the OAuth2 security scheme");
+            }
 
             _securitySchemaName = securitySchemaName;
-            _scopes = scopes;
+            _scopes = scopes ?? throw new ArgumentNullException(paramName: nameof(scopes), message: "Requires a list of API scopes");
         }
 
         /// <summary>

--- a/src/Arcus.WebApi.OpenApi.Extensions/SharedAccessKeyAuthenticationOperationFilter.cs
+++ b/src/Arcus.WebApi.OpenApi.Extensions/SharedAccessKeyAuthenticationOperationFilter.cs
@@ -36,11 +36,12 @@ namespace Arcus.WebApi.OpenApi.Extensions
         {
             if (string.IsNullOrWhiteSpace(securitySchemeName))
             {
-                throw new ArgumentNullException(paramName: nameof(securitySchemeName), message: "Requires a name for the Shared Access Key security scheme");
+                throw new ArgumentNullException(nameof(securitySchemeName), "Requires a name for the Shared Access Key security scheme");
             }
+
             if (!Enum.IsDefined(typeof(SecuritySchemeType), securitySchemeType))
             {
-                throw new ArgumentException(message: "Requires a security scheme type for the Shared Access Key authentication that is within the bounds of the enumeration", paramName: nameof(securitySchemeType));
+                throw new ArgumentException("Requires a security scheme type for the Shared Access Key authentication that is within the bounds of the enumeration", nameof(securitySchemeType));
             }
 
             _securitySchemeName = securitySchemeName;
@@ -55,7 +56,7 @@ namespace Arcus.WebApi.OpenApi.Extensions
         {
             if (string.IsNullOrWhiteSpace(securitySchemeName))
             {
-                throw new ArgumentNullException(paramName: nameof(securitySchemeName), message: "Requires a name for the Shared Access Key security scheme");
+                throw new ArgumentNullException(nameof(securitySchemeName), "Requires a name for the Shared Access Key security scheme");
             }
 
             _securitySchemeName = securitySchemeName;

--- a/src/Arcus.WebApi.OpenApi.Extensions/SharedAccessKeyAuthenticationOperationFilter.cs
+++ b/src/Arcus.WebApi.OpenApi.Extensions/SharedAccessKeyAuthenticationOperationFilter.cs
@@ -56,7 +56,7 @@ namespace Arcus.WebApi.OpenApi.Extensions
         {
             if (string.IsNullOrWhiteSpace(securitySchemeName))
             {
-                throw new ArgumentNullException(nameof(securitySchemeName), "Requires a name for the Shared Access Key security scheme");
+                throw new ArgumentException("Requires a name for the Shared Access Key security scheme", nameof(securitySchemeName));
             }
 
             _securitySchemeName = securitySchemeName;

--- a/src/Arcus.WebApi.OpenApi.Extensions/SharedAccessKeyAuthenticationOperationFilter.cs
+++ b/src/Arcus.WebApi.OpenApi.Extensions/SharedAccessKeyAuthenticationOperationFilter.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Arcus.WebApi.Security.Authentication.SharedAccessKey;
-using GuardNet;
 #if !NETSTANDARD2_1
 using System;
 using Microsoft.OpenApi.Models;
 #else
+using System;
 using Swashbuckle.AspNetCore.Swagger;
 #endif
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -34,10 +34,14 @@ namespace Arcus.WebApi.OpenApi.Extensions
             string securitySchemeName = DefaultSecuritySchemeName,
             SecuritySchemeType securitySchemeType = SecuritySchemeType.ApiKey)
         {
-            Guard.NotNullOrWhitespace(securitySchemeName, nameof(securitySchemeName), "Requires a name for the Shared Access Key security scheme");
-            Guard.For<ArgumentException>(
-                () => !Enum.IsDefined(typeof(SecuritySchemeType), securitySchemeType), 
-                "Requires a security scheme type for the Shared Access Key authentication that is within the bounds of the enumeration");
+            if (string.IsNullOrWhiteSpace(securitySchemeName))
+            {
+                throw new ArgumentNullException(paramName: nameof(securitySchemeName), message: "Requires a name for the Shared Access Key security scheme");
+            }
+            if (!Enum.IsDefined(typeof(SecuritySchemeType), securitySchemeType))
+            {
+                throw new ArgumentException(message: "Requires a security scheme type for the Shared Access Key authentication that is within the bounds of the enumeration", paramName: nameof(securitySchemeType));
+            }
 
             _securitySchemeName = securitySchemeName;
             _securitySchemeType = securitySchemeType;
@@ -49,7 +53,10 @@ namespace Arcus.WebApi.OpenApi.Extensions
         /// <param name="securitySchemeName">The name of the security scheme. Default value is <c>"sharedaccesskey"</c>.</param>
         public SharedAccessKeyAuthenticationOperationFilter(string securitySchemeName)
         {
-            Guard.NotNullOrWhitespace(securitySchemeName, nameof(securitySchemeName), "Requires a name for the Shared Access Key security scheme");
+            if (string.IsNullOrWhiteSpace(securitySchemeName))
+            {
+                throw new ArgumentNullException(paramName: nameof(securitySchemeName), message: "Requires a name for the Shared Access Key security scheme");
+            }
 
             _securitySchemeName = securitySchemeName;
         }

--- a/src/Arcus.WebApi.OpenApi.Extensions/SharedAccessKeyAuthenticationOperationFilter.cs
+++ b/src/Arcus.WebApi.OpenApi.Extensions/SharedAccessKeyAuthenticationOperationFilter.cs
@@ -36,7 +36,7 @@ namespace Arcus.WebApi.OpenApi.Extensions
         {
             if (string.IsNullOrWhiteSpace(securitySchemeName))
             {
-                throw new ArgumentNullException(nameof(securitySchemeName), "Requires a name for the Shared Access Key security scheme");
+                throw new ArgumentException("Requires a name for the Shared Access Key security scheme", nameof(securitySchemeName));
             }
 
             if (!Enum.IsDefined(typeof(SecuritySchemeType), securitySchemeType))

--- a/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
+++ b/src/Arcus.WebApi.Security/Arcus.WebApi.Security.csproj
@@ -36,7 +36,6 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[2.0.0,3.0.0)" />
-    <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationConfig.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationConfig.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Arcus.WebApi.Security.Authentication.Certificates.Interfaces;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 
 namespace Arcus.WebApi.Security.Authentication.Certificates
@@ -27,10 +26,14 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         internal CertificateAuthenticationConfig(
             IDictionary<X509ValidationRequirement, (IX509ValidationLocation location, string configuredKey)> locationAndKeyByRequirement)
         {
-            Guard.NotNull(locationAndKeyByRequirement, nameof(locationAndKeyByRequirement), "Location and key by certificate requirement dictionary cannot be 'null'");
-            Guard.For<ArgumentException>(
-                () => locationAndKeyByRequirement.Any(keyValue => keyValue.Value.location is null || keyValue.Value.configuredKey is null), 
-                "All locations and configured keys by certificate requirement cannot be 'null'");
+            if (locationAndKeyByRequirement is null)
+            {
+                throw new ArgumentNullException(nameof(locationAndKeyByRequirement), "Location and key by certificate requirement dictionary cannot be 'null'");
+            }
+            if (locationAndKeyByRequirement.Any(keyValue => keyValue.Value.location is null || keyValue.Value.configuredKey is null))
+            {
+                throw new ArgumentException("All locations and configured keys by certificate requirement cannot be 'null'");
+            }
 
             _locationAndKeyByRequirement = locationAndKeyByRequirement;
         }
@@ -45,8 +48,14 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         internal async Task<IDictionary<X509ValidationRequirement, string>> GetAllExpectedCertificateValuesAsync(IServiceProvider services, ILogger logger)
         {
-            Guard.NotNull(services, nameof(services), "Request services cannot be 'null'");
-            Guard.NotNull(logger, nameof(logger), "Logger cannot be 'null'");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), "Request services cannot be 'null'");
+            }
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Logger cannot be 'null'");
+            }
 
             var expectedValuesByRequirement = 
                 await Task.WhenAll(

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationConfig.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationConfig.cs
@@ -30,6 +30,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
             {
                 throw new ArgumentNullException(nameof(locationAndKeyByRequirement), "Location and key by certificate requirement dictionary cannot be 'null'");
             }
+
             if (locationAndKeyByRequirement.Any(keyValue => keyValue.Value.location is null || keyValue.Value.configuredKey is null))
             {
                 throw new ArgumentException("All locations and configured keys by certificate requirement cannot be 'null'");
@@ -52,6 +53,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
             {
                 throw new ArgumentNullException(nameof(services), "Request services cannot be 'null'");
             }
+
             if (logger is null)
             {
                 throw new ArgumentNullException(nameof(logger), "Logger cannot be 'null'");

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationConfigBuilder.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationConfigBuilder.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using Arcus.WebApi.Security.Authentication.Certificates.Interfaces;
-using GuardNet;
 
 namespace Arcus.WebApi.Security.Authentication.Certificates
 {
@@ -29,7 +28,10 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <exception cref="ArgumentException">Thrown when the <paramref name="configuredKey"/> is blank.</exception>
         public CertificateAuthenticationConfigBuilder WithSubject(X509ValidationLocation location, string configuredKey)
         {
-            Guard.NotNullOrWhitespace(configuredKey, nameof(configuredKey), "Configured key to retrieve expected subject cannot be blank");
+            if (string.IsNullOrWhiteSpace(configuredKey))
+            {
+                throw new ArgumentException("Configured key to retrieve expected subject cannot be blank", nameof(configuredKey));
+            }
 
             return WithSubject(GetValidationLocationImplementation(location), configuredKey);
         }
@@ -43,8 +45,14 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <exception cref="ArgumentException">Thrown when the <paramref name="configuredKey"/> is blank.</exception>
         public CertificateAuthenticationConfigBuilder WithSubject(IX509ValidationLocation location, string configuredKey)
         {
-            Guard.NotNull(location, nameof(location), "Location implementation to retrieve the expected subject cannot be 'null'");
-            Guard.NotNullOrWhitespace(configuredKey, nameof(configuredKey), "Configured key to retrieve expected subject cannot be blank");
+            if (location is null)
+            {
+                throw new ArgumentNullException(nameof(location), "Location implementation to retrieve the expected subject cannot be 'null'");
+            }
+            if (configuredKey is null)
+            {
+                throw new ArgumentNullException(nameof(configuredKey), "Configured key to retrieve expected subject cannot be blank");
+            }
 
             return AddCertificateRequirement(X509ValidationRequirement.SubjectName, location, configuredKey);
         }
@@ -57,7 +65,10 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <exception cref="ArgumentException">Thrown when the <paramref name="configuredKey"/> is blank.</exception>
         public CertificateAuthenticationConfigBuilder WithIssuer(X509ValidationLocation location, string configuredKey)
         {
-            Guard.NotNullOrWhitespace(configuredKey, nameof(configuredKey), "Configured key to retrieve expected issuer cannot be blank");
+            if (string.IsNullOrWhiteSpace(configuredKey))
+            {
+                throw new ArgumentException("Configured key to retrieve expected issuer cannot be blank", nameof(configuredKey));
+            }
 
             return WithIssuer(GetValidationLocationImplementation(location), configuredKey);
         }
@@ -71,8 +82,14 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <exception cref="ArgumentException">Thrown when the <paramref name="configuredKey"/> is blank.</exception>
         public CertificateAuthenticationConfigBuilder WithIssuer(IX509ValidationLocation location, string configuredKey)
         {
-            Guard.NotNull(location, nameof(location), "Location implementation to retrieve the expected issuer cannot be 'null'");
-            Guard.NotNullOrWhitespace(configuredKey, nameof(configuredKey), "Configured key to retrieve expected issuer cannot be blank");
+            if (location is null)
+            {
+                throw new ArgumentNullException(nameof(location), "Location implementation to retrieve the expected issuer cannot be 'null'");
+            }
+            if (configuredKey is null)
+            {
+                throw new ArgumentNullException(nameof(configuredKey), "Configured key to retrieve expected issuer cannot be blank");
+            }
 
             return AddCertificateRequirement(X509ValidationRequirement.IssuerName, location, configuredKey);
         }
@@ -85,7 +102,10 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <exception cref="ArgumentException">Thrown when the <paramref name="configuredKey"/> is blank.</exception>
         public CertificateAuthenticationConfigBuilder WithThumbprint(X509ValidationLocation location, string configuredKey)
         {
-            Guard.NotNullOrWhitespace(configuredKey, nameof(configuredKey), "Configured key to retrieve expected thumbprint cannot be blank");
+            if (string.IsNullOrWhiteSpace(configuredKey))
+            {
+                throw new ArgumentException("Configured key to retrieve expected thumbprint cannot be blank", nameof(configuredKey));
+            }
 
             return WithThumbprint(GetValidationLocationImplementation(location), configuredKey);
         }
@@ -99,8 +119,14 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <exception cref="ArgumentException">Thrown when the <paramref name="configuredKey"/> is blank.</exception>
         public CertificateAuthenticationConfigBuilder WithThumbprint(IX509ValidationLocation location, string configuredKey)
         {
-            Guard.NotNull(location, nameof(location), "Location implementation to retrieve the expected thumbprint cannot be 'null'");
-            Guard.NotNullOrWhitespace(configuredKey, nameof(configuredKey), "Configured key to retrieve expected thumbprint cannot be blank");
+            if (location is null)
+            {
+                throw new ArgumentNullException(nameof(location), "Location implementation to retrieve the expected thumbprint cannot be 'null'");
+            }
+            if (configuredKey is null)
+            {
+                throw new ArgumentNullException(nameof(configuredKey), "Configured key to retrieve expected thumbprint cannot be blank");
+            }
 
             return AddCertificateRequirement(X509ValidationRequirement.Thumbprint, location, configuredKey);
         }
@@ -110,8 +136,14 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
             IX509ValidationLocation location,
             string configuredKey)
         {
-            Guard.NotNull(location, nameof(location), "Location cannot be 'null'");
-            Guard.NotNullOrWhitespace(configuredKey, nameof(configuredKey), "Configured key cannot be blank");
+            if (location is null)
+            {
+                throw new ArgumentNullException(nameof(location), "Location cannot be 'null'");
+            }
+            if (string.IsNullOrWhiteSpace(configuredKey))
+            {
+                throw new ArgumentException("Configured key cannot be blank", nameof(configuredKey));
+            }
 
             // Overwrites existing requirements.
             _locationAndKeyByRequirement[requirement] = (location, configuredKey);

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationConfigBuilder.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationConfigBuilder.cs
@@ -27,14 +27,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <param name="configuredKey">The configured key that the <paramref name="location"/> requires to retrieve the expected subject name.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="configuredKey"/> is blank.</exception>
         public CertificateAuthenticationConfigBuilder WithSubject(X509ValidationLocation location, string configuredKey)
-        {
-            if (string.IsNullOrWhiteSpace(configuredKey))
-            {
-                throw new ArgumentException("Configured key to retrieve expected subject cannot be blank", nameof(configuredKey));
-            }
-
-            return WithSubject(GetValidationLocationImplementation(location), configuredKey);
-        }
+            => WithSubject(GetValidationLocationImplementation(location), configuredKey);
 
         /// <summary>
         /// Configures the validation for the <see cref="X509Certificate2.SubjectName"/> from a given <paramref name="location"/> using a specified <paramref name="configuredKey"/>.
@@ -44,18 +37,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="location"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="configuredKey"/> is blank.</exception>
         public CertificateAuthenticationConfigBuilder WithSubject(IX509ValidationLocation location, string configuredKey)
-        {
-            if (location is null)
-            {
-                throw new ArgumentNullException(nameof(location), "Location implementation to retrieve the expected subject cannot be 'null'");
-            }
-            if (configuredKey is null)
-            {
-                throw new ArgumentNullException(nameof(configuredKey), "Configured key to retrieve expected subject cannot be blank");
-            }
-
-            return AddCertificateRequirement(X509ValidationRequirement.SubjectName, location, configuredKey);
-        }
+            => AddCertificateRequirement(X509ValidationRequirement.SubjectName, location, configuredKey);
 
         /// <summary>
         /// Configures the validation for the <see cref="X509Certificate2.IssuerName"/> from a given <paramref name="location"/> using a specified <paramref name="configuredKey"/>.
@@ -64,14 +46,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <param name="configuredKey">The configured key that the <paramref name="location"/> requires to retrieve the expected issuer name.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="configuredKey"/> is blank.</exception>
         public CertificateAuthenticationConfigBuilder WithIssuer(X509ValidationLocation location, string configuredKey)
-        {
-            if (string.IsNullOrWhiteSpace(configuredKey))
-            {
-                throw new ArgumentException("Configured key to retrieve expected issuer cannot be blank", nameof(configuredKey));
-            }
-
-            return WithIssuer(GetValidationLocationImplementation(location), configuredKey);
-        }
+            => WithIssuer(GetValidationLocationImplementation(location), configuredKey);
 
         /// <summary>
         /// Configures the validation for the <see cref="X509Certificate2.IssuerName"/> from a given <paramref name="location"/> using a specified <paramref name="configuredKey"/>.
@@ -81,18 +56,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="location"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="configuredKey"/> is blank.</exception>
         public CertificateAuthenticationConfigBuilder WithIssuer(IX509ValidationLocation location, string configuredKey)
-        {
-            if (location is null)
-            {
-                throw new ArgumentNullException(nameof(location), "Location implementation to retrieve the expected issuer cannot be 'null'");
-            }
-            if (configuredKey is null)
-            {
-                throw new ArgumentNullException(nameof(configuredKey), "Configured key to retrieve expected issuer cannot be blank");
-            }
-
-            return AddCertificateRequirement(X509ValidationRequirement.IssuerName, location, configuredKey);
-        }
+            => AddCertificateRequirement(X509ValidationRequirement.IssuerName, location, configuredKey);
 
         /// <summary>
         /// Configures the validation for the <see cref="X509Certificate2.Thumbprint"/> from a given <paramref name="location"/> using a specified <paramref name="configuredKey"/>.
@@ -101,14 +65,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <param name="configuredKey">The configured key that the <paramref name="location"/> requires to retrieve the expected thumbprint.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="configuredKey"/> is blank.</exception>
         public CertificateAuthenticationConfigBuilder WithThumbprint(X509ValidationLocation location, string configuredKey)
-        {
-            if (string.IsNullOrWhiteSpace(configuredKey))
-            {
-                throw new ArgumentException("Configured key to retrieve expected thumbprint cannot be blank", nameof(configuredKey));
-            }
-
-            return WithThumbprint(GetValidationLocationImplementation(location), configuredKey);
-        }
+            => WithThumbprint(GetValidationLocationImplementation(location), configuredKey);
 
         /// <summary>
         /// Configures the validation for the <see cref="X509Certificate2.Thumbprint"/> from a given <paramref name="location"/> using a specified <paramref name="configuredKey"/>.
@@ -118,18 +75,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="location"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="configuredKey"/> is blank.</exception>
         public CertificateAuthenticationConfigBuilder WithThumbprint(IX509ValidationLocation location, string configuredKey)
-        {
-            if (location is null)
-            {
-                throw new ArgumentNullException(nameof(location), "Location implementation to retrieve the expected thumbprint cannot be 'null'");
-            }
-            if (configuredKey is null)
-            {
-                throw new ArgumentNullException(nameof(configuredKey), "Configured key to retrieve expected thumbprint cannot be blank");
-            }
-
-            return AddCertificateRequirement(X509ValidationRequirement.Thumbprint, location, configuredKey);
-        }
+            => AddCertificateRequirement(X509ValidationRequirement.Thumbprint, location, configuredKey);
 
         private CertificateAuthenticationConfigBuilder AddCertificateRequirement(
             X509ValidationRequirement requirement,
@@ -140,6 +86,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
             {
                 throw new ArgumentNullException(nameof(location), "Location cannot be 'null'");
             }
+
             if (string.IsNullOrWhiteSpace(configuredKey))
             {
                 throw new ArgumentException("Configured key cannot be blank", nameof(configuredKey));

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
@@ -73,14 +73,17 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
             {
                 throw new ArgumentNullException(nameof(context));
             }
+
             if (context.HttpContext is null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
+
             if (context.HttpContext.Connection is null)
             {
                 throw new ArgumentException("Invalid action context given without any HTTP connection");
             }
+
             if (context.HttpContext.RequestServices is null)
             {
                 throw new ArgumentException("Invalid action context given without any HTTP request services");

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationFilter.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using GuardNet;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -47,8 +46,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         [Obsolete("Use the new constructor with the certificate authentication filter instead")]
         public CertificateAuthenticationFilter(CertificateAuthenticationOptions options)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of additional consumer-configurable options to determine the behavior of the certificate authentication");
-            _options = options;
+            _options = options ?? throw new ArgumentNullException(nameof(options), "Requires a set of additional consumer-configurable options to determine the behavior of the certificate authentication");
         }
 
         /// <summary>
@@ -61,11 +59,8 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
             CertificateAuthenticationValidator validator,
             CertificateAuthenticationOptions options)
         {
-            Guard.NotNull(validator, nameof(validator), "Requires an instance to validate the incoming client certificate of the HTTP request");
-            Guard.NotNull(options, nameof(options), "Requires a set of additional consumer-configurable options to determine the behavior of the certificate authentication");
-
-            _validator = validator;
-            _options = options;
+            _validator = validator ?? throw new ArgumentNullException(nameof(validator), "Requires an instance to validate the incoming client certificate of the HTTP request");
+            _options = options ?? throw new ArgumentNullException(nameof(options), "Requires a set of additional consumer-configurable options to determine the behavior of the certificate authentication");
         }
 
         /// <summary>
@@ -74,10 +69,22 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <param name="context">The <see cref="T:Microsoft.AspNetCore.Mvc.Filters.AuthorizationFilterContext" />.</param>
         public async Task OnAuthorizationAsync(AuthorizationFilterContext context)
         {
-            Guard.NotNull(context, nameof(context));
-            Guard.NotNull(context.HttpContext, nameof(context.HttpContext));
-            Guard.For<ArgumentException>(() => context.HttpContext.Connection is null, "Invalid action context given without any HTTP connection");
-            Guard.For<ArgumentException>(() => context.HttpContext.RequestServices is null, "Invalid action context given without any HTTP request services");
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            if (context.HttpContext is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            if (context.HttpContext.Connection is null)
+            {
+                throw new ArgumentException("Invalid action context given without any HTTP connection");
+            }
+            if (context.HttpContext.RequestServices is null)
+            {
+                throw new ArgumentException("Invalid action context given without any HTTP request services");
+            }
 
             IServiceProvider services = context.HttpContext.RequestServices;
             ILogger logger = services.GetLoggerOrDefault<CertificateAuthenticationFilter>();

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationValidator.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationValidator.cs
@@ -43,6 +43,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
             {
                 throw new ArgumentNullException(nameof(clientCertificate), "Certificate authentication validation requires a client certificate");
             }
+
             if (services is null)
             {
                 throw new ArgumentNullException(nameof(services), "Certificate authentication validation requires a service object to retrieve registered services");

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationValidator.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationValidator.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Newtonsoft.Json.Serialization;
 
 namespace Arcus.WebApi.Security.Authentication.Certificates
 {

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationValidator.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/CertificateAuthenticationValidator.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json.Serialization;
 
 namespace Arcus.WebApi.Security.Authentication.Certificates
 {
@@ -24,9 +24,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <exception cref="ArgumentNullException">When the <paramref name="certificateAuthenticationConfig"/> is <c>null</c>.</exception>
         public CertificateAuthenticationValidator(CertificateAuthenticationConfig certificateAuthenticationConfig)
         {
-            Guard.NotNull(certificateAuthenticationConfig, nameof(certificateAuthenticationConfig), "Certificate authentication configuration cannot be 'null'");
-
-            _certificateAuthenticationConfig = certificateAuthenticationConfig;
+            _certificateAuthenticationConfig = certificateAuthenticationConfig ?? throw new ArgumentNullException(nameof(certificateAuthenticationConfig), "Certificate authentication configuration cannot be 'null'");
         }
 
         /// <summary>
@@ -42,8 +40,14 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         internal async Task<bool> IsCertificateAllowedAsync(X509Certificate2 clientCertificate, IServiceProvider services)
         {
-            Guard.NotNull(clientCertificate, nameof(clientCertificate), "Certificate authentication validation requires a client certificate");
-            Guard.NotNull(services, nameof(services), "Certificate authentication validation requires a service object to retrieve registered services");
+            if (clientCertificate is null)
+            {
+                throw new ArgumentNullException(nameof(clientCertificate), "Certificate authentication validation requires a client certificate");
+            }
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), "Certificate authentication validation requires a service object to retrieve registered services");
+            }
 
             ILogger logger = 
                 services.GetService<ILogger<CertificateAuthenticationValidator>>() 

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/ConfigurationValidationLocation.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/ConfigurationValidationLocation.cs
@@ -6,7 +6,7 @@ using Arcus.WebApi.Security.Authentication.Certificates.Interfaces;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Arcus.WebApi.Security.Authentication.Certificates 
+namespace Arcus.WebApi.Security.Authentication.Certificates
 {
     /// <summary>
     /// Certificate location implementation to retrieve the expected <see cref="X509Certificate2"/> value from an <see cref="IConfiguration"/>
@@ -43,9 +43,14 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
                     throw new ArgumentNullException(nameof(services), "Registered services cannot be 'null'");
                 }
 
-                var configuration = services.GetService<IConfiguration>() ?? throw new KeyNotFoundException(
+                var configuration = services.GetService<IConfiguration>();
+                if (configuration is null)
+                {
+                    throw new KeyNotFoundException(
                         $"No configured {nameof(IConfiguration)} implementation found in the request service container. "
                         + "Please configure such an implementation (ex. in the Startup) of your application");
+                }
+
                 string value = configuration[configurationKey];
                 return Task.FromResult(value);
             }

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/ConfigurationValidationLocation.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/ConfigurationValidationLocation.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Arcus.WebApi.Security.Authentication.Certificates.Interfaces;
-using GuardNet;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -34,8 +33,14 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         {
             try
             {
-                Guard.NotNullOrWhitespace(configurationKey, nameof(configurationKey), "Configured key cannot be blank");
-                Guard.NotNull(services, nameof(services), "Registered services cannot be 'null'");
+                if (string.IsNullOrWhiteSpace(configurationKey))
+                {
+                    throw new ArgumentException("Configured key cannot be blank", nameof(configurationKey));
+                }
+                if (services is null)
+                {
+                    throw new ArgumentNullException(nameof(services), "Registered services cannot be 'null'");
+                }
 
                 var configuration = services.GetService<IConfiguration>();
                 if (configuration == null)

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/ConfigurationValidationLocation.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/ConfigurationValidationLocation.cs
@@ -37,19 +37,15 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
                 {
                     throw new ArgumentException("Configured key cannot be blank", nameof(configurationKey));
                 }
+
                 if (services is null)
                 {
                     throw new ArgumentNullException(nameof(services), "Registered services cannot be 'null'");
                 }
 
-                var configuration = services.GetService<IConfiguration>();
-                if (configuration == null)
-                {
-                    throw new KeyNotFoundException(
+                var configuration = services.GetService<IConfiguration>() ?? throw new KeyNotFoundException(
                         $"No configured {nameof(IConfiguration)} implementation found in the request service container. "
                         + "Please configure such an implementation (ex. in the Startup) of your application");
-                }
-
                 string value = configuration[configurationKey];
                 return Task.FromResult(value);
             }

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/IServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.WebApi.Security.Authentication.Certificates;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -33,8 +32,14 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection services,
             Action<CertificateAuthenticationConfigBuilder> configureAuthentication)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of application services to register the certificate authentication validator");
-            Guard.NotNull(configureAuthentication, nameof(configureAuthentication), "Requires a function to configure the certificate validation locations");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), "Requires a set of application services to register the certificate authentication validator");
+            }
+            if (configureAuthentication is null)
+            {
+                throw new ArgumentNullException(nameof(configureAuthentication), "Requires a function to configure the certificate validation locations");
+            }
 
             var builder = new CertificateAuthenticationConfigBuilder();
             configureAuthentication(builder);

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/IServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(services), "Requires a set of application services to register the certificate authentication validator");
             }
+
             if (configureAuthentication is null)
             {
                 throw new ArgumentNullException(nameof(configureAuthentication), "Requires a function to configure the certificate validation locations");

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/MvcOptionsExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.WebApi.Security.Authentication.Certificates;
-using GuardNet;
 using Microsoft.AspNetCore.Mvc;
 
 // ReSharper disable once CheckNamespace
@@ -24,7 +23,10 @@ namespace Microsoft.Extensions.DependencyInjection
         [Obsolete("Use the " + nameof(AddCertificateAuthenticationFilter) + " overload where the certificate validation locations are configured directly")]
         public static MvcOptions AddCertificateAuthenticationFilter(this MvcOptions options)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
+            }
 
             return AddCertificateAuthenticationFilter(options, configureOptions: null);
         }
@@ -46,7 +48,10 @@ namespace Microsoft.Extensions.DependencyInjection
             this MvcOptions options,
             Action<CertificateAuthenticationOptions> configureOptions)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
+            }
 
             var authOptions = new CertificateAuthenticationOptions();
             configureOptions?.Invoke(authOptions);
@@ -77,8 +82,14 @@ namespace Microsoft.Extensions.DependencyInjection
             this MvcOptions options,
             Action<CertificateAuthenticationConfigBuilder> configureAuthentication)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
-            Guard.NotNull(configureAuthentication, nameof(configureAuthentication), "Requires a function to configure the certificate validation locations");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
+            }
+            if (configureAuthentication is null)
+            {
+                throw new ArgumentNullException(nameof(configureAuthentication), "Requires a function to configure the certificate validation locations");
+            }
 
             return AddCertificateAuthenticationFilter(options, configureAuthentication, configureOptions: null);
         }
@@ -109,8 +120,14 @@ namespace Microsoft.Extensions.DependencyInjection
             Action<CertificateAuthenticationConfigBuilder> configureAuthentication,
             Action<CertificateAuthenticationOptions> configureOptions)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
-            Guard.NotNull(configureAuthentication, nameof(configureAuthentication), "Requires a function to configure the certificate validation locations");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
+            }
+            if (configureAuthentication is null)
+            {
+                throw new ArgumentNullException(nameof(configureAuthentication), "Requires a function to configure the certificate validation locations");
+            }
 
             var builder = new CertificateAuthenticationConfigBuilder();
             configureAuthentication(builder);

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/Extensions/MvcOptionsExtensions.cs
@@ -22,15 +22,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         [Obsolete("Use the " + nameof(AddCertificateAuthenticationFilter) + " overload where the certificate validation locations are configured directly")]
         public static MvcOptions AddCertificateAuthenticationFilter(this MvcOptions options)
-        {
-            if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
-            }
+            => AddCertificateAuthenticationFilter(options, configureOptions: null);
 
-            return AddCertificateAuthenticationFilter(options, configureOptions: null);
-        }
-        
         /// <summary>
         /// Adds an certificate authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request.
         /// </summary>
@@ -81,18 +74,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static MvcOptions AddCertificateAuthenticationFilter(
             this MvcOptions options,
             Action<CertificateAuthenticationConfigBuilder> configureAuthentication)
-        {
-            if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
-            }
-            if (configureAuthentication is null)
-            {
-                throw new ArgumentNullException(nameof(configureAuthentication), "Requires a function to configure the certificate validation locations");
-            }
-
-            return AddCertificateAuthenticationFilter(options, configureAuthentication, configureOptions: null);
-        }
+            => AddCertificateAuthenticationFilter(options, configureAuthentication, configureOptions: null);
 
         /// <summary>
         /// Adds an certificate authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request.
@@ -124,6 +106,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(options), "Requires a set of MVC filters to add the certificate authentication MVC filter");
             }
+
             if (configureAuthentication is null)
             {
                 throw new ArgumentNullException(nameof(configureAuthentication), "Requires a function to configure the certificate validation locations");

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/SecretProviderValidationLocation.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/SecretProviderValidationLocation.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Arcus.Security.Core;
 using Arcus.Security.Core.Caching;
 using Arcus.WebApi.Security.Authentication.Certificates.Interfaces;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -34,8 +33,15 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
         /// <param name="services">The services collections of the HTTP request pipeline to retrieve registered instances.</param>
         public async Task<string> GetExpectedCertificateValueForConfiguredKeyAsync(string configurationKey, IServiceProvider services)
         {
-            Guard.NotNullOrWhitespace(configurationKey, nameof(configurationKey), "Configured key cannot be blank");
-            Guard.NotNull(services, nameof(services), "Registered services cannot be 'null'");
+            if (string.IsNullOrWhiteSpace(configurationKey))
+            {
+                throw new ArgumentException("Configured key cannot be blank", nameof(configurationKey));
+            }
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), "Registered services cannot be 'null'");
+            }
+
 
             var userDefinedSecretProvider = services.GetService<ISecretProvider>();
             if (userDefinedSecretProvider is null)

--- a/src/Arcus.WebApi.Security/Authentication/Certificates/SecretProviderValidationLocation.cs
+++ b/src/Arcus.WebApi.Security/Authentication/Certificates/SecretProviderValidationLocation.cs
@@ -37,6 +37,7 @@ namespace Arcus.WebApi.Security.Authentication.Certificates
             {
                 throw new ArgumentException("Configured key cannot be blank", nameof(configurationKey));
             }
+
             if (services is null)
             {
                 throw new ArgumentNullException(nameof(services), "Registered services cannot be 'null'");

--- a/src/Arcus.WebApi.Security/Authentication/JwtBearer/Extensions/AuthenticationBuilderExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/JwtBearer/Extensions/AuthenticationBuilderExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Options;
@@ -21,7 +20,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>A reference to builder after the operation has completed.</returns>
         public static AuthenticationBuilder AddJwtBearer(this AuthenticationBuilder builder, Action<JwtBearerOptions, IServiceProvider> configureOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires an authentication builder instance to add the JWT Bearer authentication");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires an authentication builder instance to add the JWT Bearer authentication");
+            }
 
             if (configureOptions != null)
             {

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(options), "Requires a MVC options instance to add the shared access key authentication filter");
             }
+
             if (string.IsNullOrWhiteSpace(headerName))
             {
                 throw new ArgumentException("Requires a non-blank HTTP request header name to match the stored secret during the shared access key authentication", nameof(headerName));

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
             if (string.IsNullOrWhiteSpace(headerName))
             {
-                throw new ArgumentException("Requires a non-blank HTTP request header name to match the stored secret during the shared access key authentication", nameof(headerName);
+                throw new ArgumentException("Requires a non-blank HTTP request header name to match the stored secret during the shared access key authentication", nameof(headerName));
             }
 
             return AddSharedAccessKeyAuthenticationFilterOnHeader(options, headerName, secretName, configureOptions: null);

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Security.Core;
 using Arcus.WebApi.Security.Authentication.SharedAccessKey;
-using GuardNet;
 using Microsoft.AspNetCore.Mvc;
 
 // ReSharper disable once CheckNamespace
@@ -26,8 +25,14 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentException">Thrown when the <paramref name="headerName"/> or <paramref name="secretName"/> is blank.</exception>
         public static MvcOptions AddSharedAccessKeyAuthenticationFilterOnHeader(this MvcOptions options, string headerName, string secretName)
         {
-             Guard.NotNull(options, nameof(options), "Requires an MVC options instance to add the shared access key authenctication filter");
-            Guard.NotNullOrWhitespace(headerName, nameof(headerName), "Requires a non-blank HTTP request header name to match the stored secret during the shared access key authentication");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires an MVC options instance to add the shared access key authentication filter");
+            }
+            if (string.IsNullOrWhiteSpace(headerName))
+            {
+                throw new ArgumentException("Requires a non-blank HTTP request header name to match the stored secret during the shared access key authentication", nameof(headerName);
+            }
 
             return AddSharedAccessKeyAuthenticationFilterOnHeader(options, headerName, secretName, configureOptions: null);
         }
@@ -53,8 +58,14 @@ namespace Microsoft.Extensions.DependencyInjection
             string secretName, 
             Action<SharedAccessKeyAuthenticationOptions> configureOptions)
         {
-            Guard.NotNull(options, nameof(options), "Requires an MVC options instance to add the shared access key authenctication filter");
-            Guard.NotNullOrWhitespace(headerName, nameof(headerName), "Requires a non-blank HTTP request header name to match the stored secret during the shared access key authentication");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a MVC options instance to add the shared access key authentication filter");
+            }
+            if (string.IsNullOrWhiteSpace(headerName))
+            {
+                throw new ArgumentException("Requires a non-blank HTTP request header name to match the stored secret during the shared access key authentication", nameof(headerName));
+            }
 
             var authOptions = new SharedAccessKeyAuthenticationOptions();
             configureOptions?.Invoke(authOptions);
@@ -80,9 +91,18 @@ namespace Microsoft.Extensions.DependencyInjection
             string parameterName,
             string secretName)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of MVC options to add the shared access authentication MVC filter");
-            Guard.NotNullOrWhitespace(parameterName, nameof(parameterName), "Requires a non-blank HTTP request query parameter name name to match the stored secret during the shared access key authentication");
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to retrieve the stored access key in the secret store during the shared access key authentication");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a set of MVC options to add the shared access authentication MVC filter");
+            }
+            if (string.IsNullOrWhiteSpace(parameterName))
+            {
+                throw new ArgumentException("Requires a non-blank HTTP request query parameter name to match the stored secret during the shared access key authentication", nameof(parameterName));
+            }
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name to retrieve the stored access key in the secret store during the shared access key authentication", nameof(secretName));
+            }
 
             return AddSharedAccessKeyAuthenticationFilterOnQuery(options, parameterName, secretName, configureOptions: null);
         }
@@ -108,9 +128,18 @@ namespace Microsoft.Extensions.DependencyInjection
             string secretName,
             Action<SharedAccessKeyAuthenticationOptions> configureOptions)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of MVC options to add the shared access authentication MVC filter");
-            Guard.NotNullOrWhitespace(parameterName, nameof(parameterName), "Requires a non-blank HTTP request query parameter name name to match the stored secret during the shared access key authentication");
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to retrieve the stored access key in the secret store during the shared access key authentication");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a set of MVC options to add the shared access authentication MVC filter");
+            }
+            if (string.IsNullOrWhiteSpace(parameterName))
+            {
+                throw new ArgumentException("Requires a non-blank HTTP request query parameter name to match the stored secret during the shared access key authentication", nameof(parameterName));
+            }
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name to retrieve the stored access key in the secret store during the shared access key authentication", nameof(secretName));
+            }
             
             var authOptions = new SharedAccessKeyAuthenticationOptions();
             configureOptions?.Invoke(authOptions);

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/Extensions/MvcOptionsExtensions.cs
@@ -24,18 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="headerName"/> or <paramref name="secretName"/> is blank.</exception>
         public static MvcOptions AddSharedAccessKeyAuthenticationFilterOnHeader(this MvcOptions options, string headerName, string secretName)
-        {
-            if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options), "Requires an MVC options instance to add the shared access key authentication filter");
-            }
-            if (string.IsNullOrWhiteSpace(headerName))
-            {
-                throw new ArgumentException("Requires a non-blank HTTP request header name to match the stored secret during the shared access key authentication", nameof(headerName));
-            }
-
-            return AddSharedAccessKeyAuthenticationFilterOnHeader(options, headerName, secretName, configureOptions: null);
-        }
+            => AddSharedAccessKeyAuthenticationFilterOnHeader(options, headerName, secretName, configureOptions: null);
 
         /// <summary>
         /// Adds an shared access key authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request on its header.
@@ -90,22 +79,7 @@ namespace Microsoft.Extensions.DependencyInjection
             this MvcOptions options,
             string parameterName,
             string secretName)
-        {
-            if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options), "Requires a set of MVC options to add the shared access authentication MVC filter");
-            }
-            if (string.IsNullOrWhiteSpace(parameterName))
-            {
-                throw new ArgumentException("Requires a non-blank HTTP request query parameter name to match the stored secret during the shared access key authentication", nameof(parameterName));
-            }
-            if (string.IsNullOrWhiteSpace(secretName))
-            {
-                throw new ArgumentException("Requires a non-blank secret name to retrieve the stored access key in the secret store during the shared access key authentication", nameof(secretName));
-            }
-
-            return AddSharedAccessKeyAuthenticationFilterOnQuery(options, parameterName, secretName, configureOptions: null);
-        }
+            => AddSharedAccessKeyAuthenticationFilterOnQuery(options, parameterName, secretName, configureOptions: null);
 
         /// <summary>
         /// Adds an shared access key authentication MVC filter to the given <paramref name="options"/> that authenticates the incoming HTTP request on its query.
@@ -132,10 +106,12 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(options), "Requires a set of MVC options to add the shared access authentication MVC filter");
             }
+
             if (string.IsNullOrWhiteSpace(parameterName))
             {
                 throw new ArgumentException("Requires a non-blank HTTP request query parameter name to match the stored secret during the shared access key authentication", nameof(parameterName));
             }
+
             if (string.IsNullOrWhiteSpace(secretName))
             {
                 throw new ArgumentException("Requires a non-blank secret name to retrieve the stored access key in the secret store during the shared access key authentication", nameof(secretName));

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationAttribute.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationAttribute.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Security.Core;
-using GuardNet;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Arcus.WebApi.Security.Authentication.SharedAccessKey
@@ -28,10 +27,14 @@ namespace Arcus.WebApi.Security.Authentication.SharedAccessKey
         public SharedAccessKeyAuthenticationAttribute(string secretName, string headerName = null, string queryParameterName = null) 
             : base(typeof(SharedAccessKeyAuthenticationFilter))
         {
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Secret name cannot be blank");
-            Guard.For<ArgumentException>(
-                () => String.IsNullOrWhiteSpace(headerName) && String.IsNullOrWhiteSpace(queryParameterName), 
-                "Requires either a non-blank header name or query parameter name");
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentException(" Secret name cannot be blank", nameof(secretName));
+            }
+            if (string.IsNullOrWhiteSpace(headerName) && string.IsNullOrWhiteSpace(queryParameterName))
+            {
+                throw new ArgumentException("Requires either a non-blank header name or query parameter name");
+            }
 
             _options = new SharedAccessKeyAuthenticationOptions();
             Arguments = new object[] { headerName?? String.Empty, queryParameterName?? String.Empty, secretName, _options };

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationAttribute.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationAttribute.cs
@@ -29,8 +29,9 @@ namespace Arcus.WebApi.Security.Authentication.SharedAccessKey
         {
             if (string.IsNullOrWhiteSpace(secretName))
             {
-                throw new ArgumentException(" Secret name cannot be blank", nameof(secretName));
+                throw new ArgumentException("Secret name cannot be blank", nameof(secretName));
             }
+
             if (string.IsNullOrWhiteSpace(headerName) && string.IsNullOrWhiteSpace(queryParameterName))
             {
                 throw new ArgumentException("Requires either a non-blank header name or query parameter name");

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationFilter.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationFilter.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Threading.Tasks;
 using Arcus.Security.Core;
 using Arcus.Security.Core.Caching;
-using GuardNet;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -52,10 +51,14 @@ namespace Arcus.WebApi.Security.Authentication.SharedAccessKey
         /// <exception cref="ArgumentException">Thrown when the <paramref name="headerName"/> and <paramref name="queryParameterName"/> are blank.</exception>
         public SharedAccessKeyAuthenticationFilter(string headerName, string queryParameterName, string secretName, SharedAccessKeyAuthenticationOptions options)
         {
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name");
-            Guard.For<ArgumentException>(
-                () => String.IsNullOrWhiteSpace(headerName) && String.IsNullOrWhiteSpace(queryParameterName), 
-                "Requires either a non-blank header name or query parameter name");
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name", nameof(secretName));
+            }
+            if (string.IsNullOrWhiteSpace(headerName) && string.IsNullOrWhiteSpace(queryParameterName))
+            {
+                throw new ArgumentException("Requires either a non-blank header name or query parameter name");
+            }
 
             _headerName = headerName;
             _queryParameterName = queryParameterName;
@@ -72,11 +75,26 @@ namespace Arcus.WebApi.Security.Authentication.SharedAccessKey
         /// </returns>
         public async Task OnAuthorizationAsync(AuthorizationFilterContext context)
         {
-            Guard.NotNull(context, nameof(context));
-            Guard.NotNull(context.HttpContext, nameof(context.HttpContext));
-            Guard.For<ArgumentException>(() => context.HttpContext.Request is null, "Invalid action context given without any HTTP request");
-            Guard.For<ArgumentException>(() => context.HttpContext.Request.Headers is null, "Invalid action context given without any HTTP request headers");
-            Guard.For<ArgumentException>(() => context.HttpContext.RequestServices is null, "Invalid action context given without any HTTP request services");
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            if (context.HttpContext is null)
+            {
+                throw new ArgumentNullException(nameof(context.HttpContext));
+            }
+            if (context.HttpContext.Request is null)
+            {
+                throw new ArgumentException("Invalid action context given without any HTTP request");
+            }
+            if (context.HttpContext.Request.Headers is null)
+            {
+                throw new ArgumentException("Invalid action context given without any HTTP request headers");
+            }
+            if (context.HttpContext.RequestServices is null)
+            {
+                throw new ArgumentException("Invalid action context given without any HTTP request services");
+            }
 
             ILogger logger = context.HttpContext.RequestServices.GetLoggerOrDefault<SharedAccessKeyAuthenticationFilter>();
             

--- a/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationFilter.cs
+++ b/src/Arcus.WebApi.Security/Authentication/SharedAccessKey/SharedAccessKeyAuthenticationFilter.cs
@@ -136,7 +136,13 @@ namespace Arcus.WebApi.Security.Authentication.SharedAccessKey
             Task<IEnumerable<string>> rawSecretAsync = userDefinedSecretProvider.GetRawSecretsAsync(_secretName) ?? throw new InvalidOperationException(
                     $"Configured {nameof(ISecretProvider)} is not implemented correctly as it returns 'null' for a {nameof(Task)} value when calling {nameof(ISecretProvider.GetRawSecretAsync)}");
             IEnumerable<string> foundSecrets = await rawSecretAsync;
-            return foundSecrets is null ? throw new SecretNotFoundException(_secretName) : foundSecrets.ToArray();
+
+            if (foundSecrets is null)
+            {
+                throw new SecretNotFoundException(_secretName);
+            }
+
+            return foundSecrets.ToArray();
         }
 
         private void ValidateSharedAccessKeyInRequestHeader(AuthorizationFilterContext context, string[] foundSecrets, ILogger logger)

--- a/src/Arcus.WebApi.Security/Authorization/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authorization/Extensions/MvcOptionsExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Arcus.WebApi.Security.Authorization;
-using GuardNet;
 using Microsoft.AspNetCore.Mvc;
 
 // ReSharper disable once CheckNamespace
@@ -20,7 +19,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         public static MvcOptions AddJwtTokenAuthorizationFilter(this MvcOptions options)
         {
-            Guard.NotNull(options, nameof(options), "Requires a filter collection to add the JWT token authorization filter");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a filter collection to add the JWT token authorization filter");
+            }
 
             return AddJwtTokenAuthorizationFilter(options, configureOptions: null);
         }
@@ -35,7 +37,10 @@ namespace Microsoft.Extensions.DependencyInjection
             this MvcOptions options, 
             Action<JwtTokenAuthorizationOptions> configureOptions)
         {
-            Guard.NotNull(options, nameof(options), "Requires a filter collection to add the JWT token authorization filter");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a filter collection to add the JWT token authorization filter");
+            }
 
             var authOptions= new JwtTokenAuthorizationOptions();
             configureOptions?.Invoke(authOptions);
@@ -54,11 +59,22 @@ namespace Microsoft.Extensions.DependencyInjection
             this MvcOptions options,
             IDictionary<string, string> claimCheck)
         {
-            Guard.NotNull(options, nameof(options), "Requires a filter collection to add the JWT token authorization filter");
-            Guard.NotNull(claimCheck, nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
-            Guard.NotAny(claimCheck, nameof(claimCheck), "Requires at least one entry in the set of claim checks to verify the claims in the request JWT");
-            Guard.For<ArgumentException>(() => claimCheck.Any(item => string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value)), 
-                "Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a filter collection to add the JWT token authorization filter");
+            }
+            if (claimCheck is null)
+            {
+                throw new ArgumentNullException(nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
+            }
+            if (!claimCheck.Any())
+            {
+                throw new ArgumentException("Requires at least one entry in the set of claim checks to verify the claims in the request JWT", nameof(claimCheck));
+            }
+            if (claimCheck.Any(item => string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value)))
+            {
+                throw new ArgumentException("Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT");
+            }
 
             return AddJwtTokenAuthorizationFilter(options, configureOptions: null, claimCheck: claimCheck);
         }
@@ -76,11 +92,22 @@ namespace Microsoft.Extensions.DependencyInjection
             Action<JwtTokenAuthorizationOptions> configureOptions, 
             IDictionary<string, string> claimCheck)
         {
-            Guard.NotNull(options, nameof(options), "Requires a filter collection to add the JWT token authorization filter");
-            Guard.NotNull(claimCheck, nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
-            Guard.NotAny(claimCheck, nameof(claimCheck), "Requires at least one entry in the set of claim checks to verify the claims in the request JWT");
-            Guard.For<ArgumentException>(() => claimCheck.Any(item => string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value)), 
-                "Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a filter collection to add the JWT token authorization filter");
+            }
+            if (claimCheck is null)
+            {
+                throw new ArgumentNullException(nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
+            }
+            if (!claimCheck.Any())
+            {
+                throw new ArgumentException("Requires at least one entry in the set of claim checks to verify the claims in the request JWT", nameof(claimCheck));
+            }
+            if (claimCheck.Any(item => string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value)))
+            {
+                throw new ArgumentException("Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT");
+            }
 
             var authOptions = new JwtTokenAuthorizationOptions(claimCheck);
             configureOptions?.Invoke(authOptions);

--- a/src/Arcus.WebApi.Security/Authorization/Extensions/MvcOptionsExtensions.cs
+++ b/src/Arcus.WebApi.Security/Authorization/Extensions/MvcOptionsExtensions.cs
@@ -18,14 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="options">The options that are being applied to the request pipeline.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         public static MvcOptions AddJwtTokenAuthorizationFilter(this MvcOptions options)
-        {
-            if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options), "Requires a filter collection to add the JWT token authorization filter");
-            }
-
-            return AddJwtTokenAuthorizationFilter(options, configureOptions: null);
-        }
+            => AddJwtTokenAuthorizationFilter(options, configureOptions: null);
 
         /// <summary>
         /// Adds JWT token authorization.
@@ -58,26 +51,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static MvcOptions AddJwtTokenAuthorizationFilter(
             this MvcOptions options,
             IDictionary<string, string> claimCheck)
-        {
-            if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options), "Requires a filter collection to add the JWT token authorization filter");
-            }
-            if (claimCheck is null)
-            {
-                throw new ArgumentNullException(nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
-            }
-            if (!claimCheck.Any())
-            {
-                throw new ArgumentException("Requires at least one entry in the set of claim checks to verify the claims in the request JWT", nameof(claimCheck));
-            }
-            if (claimCheck.Any(item => string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value)))
-            {
-                throw new ArgumentException("Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT");
-            }
-
-            return AddJwtTokenAuthorizationFilter(options, configureOptions: null, claimCheck: claimCheck);
-        }
+            => AddJwtTokenAuthorizationFilter(options, configureOptions: null, claimCheck: claimCheck);
 
         /// <summary>
         /// Adds JWT token authorization.
@@ -96,14 +70,17 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(options), "Requires a filter collection to add the JWT token authorization filter");
             }
+
             if (claimCheck is null)
             {
                 throw new ArgumentNullException(nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
             }
+
             if (!claimCheck.Any())
             {
                 throw new ArgumentException("Requires at least one entry in the set of claim checks to verify the claims in the request JWT", nameof(claimCheck));
             }
+
             if (claimCheck.Any(item => string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value)))
             {
                 throw new ArgumentException("Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT");

--- a/src/Arcus.WebApi.Security/Authorization/Jwt/JwtTokenReader.cs
+++ b/src/Arcus.WebApi.Security/Authorization/Jwt/JwtTokenReader.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Threading.Tasks;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using IdentityModel;
@@ -35,7 +34,10 @@ namespace Arcus.WebApi.Security.Authorization.Jwt
         /// <exception cref="ArgumentException">Thrown when the <paramref name="audience"/> is blank.</exception>
         public JwtTokenReader(string audience) : this(audience, NullLogger<JwtTokenReader>.Instance)
         {
-            Guard.NotNullOrWhitespace(audience, nameof(audience), "Requires an audience to validate against");
+            if (string.IsNullOrWhiteSpace(audience))
+            {
+                throw new ArgumentException("Requires an audience to validate against", nameof(audience));
+            }
         }
 
         /// <summary>
@@ -47,7 +49,10 @@ namespace Arcus.WebApi.Security.Authorization.Jwt
         /// <exception cref="ArgumentException">Thrown when the <paramref name="audience"/> is blank.</exception>
         public JwtTokenReader(string audience, ILogger<JwtTokenReader> logger) : this(new Dictionary<string, string> {{ JwtClaimTypes.Audience, audience}}, logger)
         {
-            Guard.NotNullOrWhitespace(audience, nameof(audience), "Requires an audience to validate against");
+            if (string.IsNullOrWhiteSpace(audience))
+            {
+                throw new ArgumentException("Requires an audience to validate against", nameof(audience));
+            }
         }
 
         /// <summary>
@@ -71,10 +76,18 @@ namespace Arcus.WebApi.Security.Authorization.Jwt
         /// <exception cref="ArgumentException">Thrown when the <paramref name="claimCheck"/> doesn't have any entries or one of the entries has blank key/value inputs.</exception>
         public JwtTokenReader(IDictionary<string, string> claimCheck, ILogger<JwtTokenReader> logger)
         {
-            Guard.NotNull(claimCheck, nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
-            Guard.NotAny(claimCheck, nameof(claimCheck), "Requires at least one entry in the set of claim checks to verify the claims in the request JWT");
-            Guard.For<ArgumentException>(() => claimCheck.Any(item => String.IsNullOrWhiteSpace(item.Key) || String.IsNullOrWhiteSpace(item.Value)), 
-                "Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT");
+            if (claimCheck is null)
+            {
+                throw new ArgumentNullException(nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
+            }
+            if (!claimCheck.Any())
+            {
+                throw new ArgumentException("Requires at least one entry in the set of claim checks to verify the claims in the request JWT", nameof(claimCheck));
+            }
+            if (claimCheck.Any(item => string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value)))
+            {
+                throw new ArgumentException("Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT", nameof(claimCheck));
+            }
 
             _claimCheck = claimCheck;
             _logger = logger ?? NullLogger<JwtTokenReader>.Instance;
@@ -153,8 +166,14 @@ namespace Arcus.WebApi.Security.Authorization.Jwt
         /// <exception cref="ArgumentException">Thrown when the <paramref name="openIdConnectDiscoveryUri"/> is blank.</exception>
         public JwtTokenReader(TokenValidationParameters tokenValidationParameters, string openIdConnectDiscoveryUri, ILogger<JwtTokenReader> logger)
         {
-            Guard.NotNull(tokenValidationParameters, nameof(tokenValidationParameters), "Requires a collection of parameters to influence how the token validation is done");
-            Guard.NotNullOrWhitespace(openIdConnectDiscoveryUri, nameof(openIdConnectDiscoveryUri), "Requires an non-blank OpenId URI connection endpoint for discovering the OpenId configuration");
+            if (tokenValidationParameters is null)
+            {
+                throw new ArgumentNullException(nameof(tokenValidationParameters), "Requires a collection of parameters to influence how the token validation is done");
+            }
+            if (string.IsNullOrWhiteSpace(openIdConnectDiscoveryUri))
+            {
+                throw new ArgumentException("Requires an non-blank OpenId URI connection endpoint for discovering the OpenId configuration", nameof(openIdConnectDiscoveryUri));
+            }
 
             _tokenValidationParameters = tokenValidationParameters;
             _logger = logger ?? NullLogger<JwtTokenReader>.Instance;
@@ -192,12 +211,26 @@ namespace Arcus.WebApi.Security.Authorization.Jwt
             IDictionary<string, string> claimCheck, 
             ILogger<JwtTokenReader> logger)
         {
-            Guard.NotNullOrWhitespace(openIdConnectDiscoveryUri, nameof(openIdConnectDiscoveryUri), "Requires an non-blank OpenId URI connection endpoint for discovering the OpenId configuration");
-            Guard.NotNull(tokenValidationParameters, nameof(tokenValidationParameters), "Requires a collection of parameters to influence how the token validation is done");
-            Guard.NotNull(claimCheck, nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
-            Guard.NotAny(claimCheck, nameof(claimCheck), "Requires at least one entry in the set of claim checks to verify the claims in the request JWT");
-            Guard.For<ArgumentException>(() => claimCheck.Any(item => String.IsNullOrWhiteSpace(item.Key) || String.IsNullOrWhiteSpace(item.Value)), 
-                "Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT");
+            if (string.IsNullOrWhiteSpace(openIdConnectDiscoveryUri))
+            {
+                throw new ArgumentException("Requires an non-blank OpenId URI connection endpoint for discovering the OpenId configuration", nameof(openIdConnectDiscoveryUri));
+            }
+            if (tokenValidationParameters is null)
+            {
+                throw new ArgumentNullException(nameof(tokenValidationParameters), "Requires a collection of parameters to influence how the token validation is done");
+            }
+            if (claimCheck is null)
+            {
+                throw new ArgumentNullException(nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
+            }
+            if (!claimCheck.Any())
+            {
+                throw new ArgumentException("Requires at least one entry in the set of claim checks to verify the claims in the request JWT", nameof(claimCheck));
+            }
+            if (claimCheck.Any(item => string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value)))
+            {
+                throw new ArgumentException("Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT", nameof(claimCheck));
+            }
 
             _tokenValidationParameters = tokenValidationParameters;
             _claimCheck = claimCheck;

--- a/src/Arcus.WebApi.Security/Authorization/Jwt/JwtTokenReader.cs
+++ b/src/Arcus.WebApi.Security/Authorization/Jwt/JwtTokenReader.cs
@@ -80,10 +80,12 @@ namespace Arcus.WebApi.Security.Authorization.Jwt
             {
                 throw new ArgumentNullException(nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
             }
+
             if (!claimCheck.Any())
             {
                 throw new ArgumentException("Requires at least one entry in the set of claim checks to verify the claims in the request JWT", nameof(claimCheck));
             }
+
             if (claimCheck.Any(item => string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value)))
             {
                 throw new ArgumentException("Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT", nameof(claimCheck));
@@ -170,6 +172,7 @@ namespace Arcus.WebApi.Security.Authorization.Jwt
             {
                 throw new ArgumentNullException(nameof(tokenValidationParameters), "Requires a collection of parameters to influence how the token validation is done");
             }
+
             if (string.IsNullOrWhiteSpace(openIdConnectDiscoveryUri))
             {
                 throw new ArgumentException("Requires an non-blank OpenId URI connection endpoint for discovering the OpenId configuration", nameof(openIdConnectDiscoveryUri));
@@ -215,18 +218,23 @@ namespace Arcus.WebApi.Security.Authorization.Jwt
             {
                 throw new ArgumentException("Requires an non-blank OpenId URI connection endpoint for discovering the OpenId configuration", nameof(openIdConnectDiscoveryUri));
             }
+
             if (tokenValidationParameters is null)
             {
                 throw new ArgumentNullException(nameof(tokenValidationParameters), "Requires a collection of parameters to influence how the token validation is done");
             }
+
             if (claimCheck is null)
             {
                 throw new ArgumentNullException(nameof(claimCheck), "Requires a set of claim checks to verify the claims request JWT");
             }
+
             if (!claimCheck.Any())
             {
-                throw new ArgumentException("Requires at least one entry in the set of claim checks to verify the claims in the request JWT", nameof(claimCheck));
+                throw new ArgumentException("Requires at least one entry in the set of claim checks to verify the claims in the " +
+                    "request JWT", nameof(claimCheck));
             }
+
             if (claimCheck.Any(item => string.IsNullOrWhiteSpace(item.Key) || string.IsNullOrWhiteSpace(item.Value)))
             {
                 throw new ArgumentException("Requires all entries in the set of claim checks to be non-blank to correctly verify the claims in the request JWT", nameof(claimCheck));

--- a/src/Arcus.WebApi.Security/Authorization/JwtTokenAuthorizationFilter .cs
+++ b/src/Arcus.WebApi.Security/Authorization/JwtTokenAuthorizationFilter .cs
@@ -5,7 +5,6 @@ using System.Text.RegularExpressions;
 using System.Linq;
 using System.Threading.Tasks;
 using Arcus.WebApi.Security.Authorization.Jwt;
-using GuardNet;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -32,8 +31,10 @@ namespace Arcus.WebApi.Security.Authorization
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="authorizationOptions"/> is <c>null</c>.</exception>
         public JwtTokenAuthorizationFilter(JwtTokenAuthorizationOptions authorizationOptions)
         {
-            Guard.NotNull(authorizationOptions, nameof(authorizationOptions), 
-                "Requires a set of options to configure how the JWT authorization filter should authorize requests");
+            if (authorizationOptions is null)
+            {
+                throw new ArgumentNullException(nameof(authorizationOptions), "Requires a set of options to configure how the JWT authorization filter should authorize requests");
+            }
 
             _authorizationOptions = authorizationOptions;
         }
@@ -47,11 +48,26 @@ namespace Arcus.WebApi.Security.Authorization
         /// </returns>
         public virtual async Task OnAuthorizationAsync(AuthorizationFilterContext context)
         {
-            Guard.NotNull(context, nameof(context));
-            Guard.NotNull(context.HttpContext, nameof(context.HttpContext));
-            Guard.For<ArgumentException>(() => context.HttpContext.Request is null, "Invalid action context given without any HTTP request");
-            Guard.For<ArgumentException>(() => context.HttpContext.Request.Headers is null, "Invalid action context given without any HTTP request headers");
-            Guard.For<ArgumentException>(() => context.HttpContext.RequestServices is null, "Invalid action context given without any HTTP request services");
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            if (context.HttpContext is null)
+            {
+                throw new ArgumentNullException(nameof(context.HttpContext));
+            }
+            if (context.HttpContext.Request is null)
+            {
+                throw new ArgumentNullException(nameof(context), "INvalid action context given without any HTTP request");
+            }
+            if (context.HttpContext.Request.Headers is null)
+            {
+                throw new ArgumentNullException(nameof(context), "Invalid action context given without any HTTP request headers");
+            }
+            if (context.HttpContext.RequestServices is null)
+            {
+                throw new ArgumentNullException(nameof(context), "Invalid action context given without any HTTP request services");
+            }
 
             ILogger logger = context.HttpContext.RequestServices.GetLoggerOrDefault<JwtTokenAuthorizationFilter>();
             

--- a/src/Arcus.WebApi.Security/Authorization/JwtTokenAuthorizationFilter .cs
+++ b/src/Arcus.WebApi.Security/Authorization/JwtTokenAuthorizationFilter .cs
@@ -52,18 +52,22 @@ namespace Arcus.WebApi.Security.Authorization
             {
                 throw new ArgumentNullException(nameof(context));
             }
+
             if (context.HttpContext is null)
             {
                 throw new ArgumentNullException(nameof(context.HttpContext));
             }
+
             if (context.HttpContext.Request is null)
             {
                 throw new ArgumentNullException(nameof(context), "INvalid action context given without any HTTP request");
             }
+
             if (context.HttpContext.Request.Headers is null)
             {
                 throw new ArgumentNullException(nameof(context), "Invalid action context given without any HTTP request headers");
             }
+
             if (context.HttpContext.RequestServices is null)
             {
                 throw new ArgumentNullException(nameof(context), "Invalid action context given without any HTTP request services");

--- a/src/Arcus.WebApi.Security/Authorization/JwtTokenAuthorizationOptions.cs
+++ b/src/Arcus.WebApi.Security/Authorization/JwtTokenAuthorizationOptions.cs
@@ -63,6 +63,7 @@ namespace Arcus.WebApi.Security.Authorization
             {
                 throw new ArgumentNullException(nameof(reader), $"Requires a valid {nameof(IJwtTokenReader)} to verify the JWT token");
             }
+
             if (string.IsNullOrWhiteSpace(headerName))
             {
                 throw new ArgumentException("Requires a non-blank request header name to look for the JWT token", nameof(headerName));
@@ -85,6 +86,7 @@ namespace Arcus.WebApi.Security.Authorization
                 {
                     throw new ArgumentException("Requires a non-blank request header name to look for the JWT token", nameof(value));
                 }
+
                 _headerName = value;
             }
         }
@@ -102,6 +104,7 @@ namespace Arcus.WebApi.Security.Authorization
                 {
                     throw new ArgumentNullException(nameof(value), $"Requires a valid {nameof(IJwtTokenReader)} to verify the JWT token");
                 }
+
                 _jwtTokenReader = value;
                 _createJwtTokenReader = null;
             }
@@ -149,6 +152,7 @@ namespace Arcus.WebApi.Security.Authorization
                     {
                         throw new ArgumentNullException(nameof(serviceProvider), $"Requires a collection of services to create an {nameof(IJwtTokenReader)} instance");
                     }
+
                     return _createJwtTokenReader(serviceProvider);
                 }
                 catch (Exception exception)

--- a/src/Arcus.WebApi.Security/Authorization/JwtTokenAuthorizationOptions.cs
+++ b/src/Arcus.WebApi.Security/Authorization/JwtTokenAuthorizationOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Arcus.WebApi.Security.Authorization.Jwt;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
@@ -60,8 +59,14 @@ namespace Arcus.WebApi.Security.Authorization
         /// <exception cref="ArgumentException">Thrown when the <paramref name="headerName"/> is blank.</exception>
         public JwtTokenAuthorizationOptions(IJwtTokenReader reader, string headerName)
         {
-            Guard.NotNull(reader, nameof(reader), $"Requires a valid {nameof(IJwtTokenReader)} to verify the JWT token");
-            Guard.NotNullOrWhitespace(headerName, nameof(headerName), "Requires a non-blank request header name to look for the JWT token");
+            if (reader is null)
+            {
+                throw new ArgumentNullException(nameof(reader), $"Requires a valid {nameof(IJwtTokenReader)} to verify the JWT token");
+            }
+            if (string.IsNullOrWhiteSpace(headerName))
+            {
+                throw new ArgumentException("Requires a non-blank request header name to look for the JWT token", nameof(headerName));
+            }
 
             JwtTokenReader = reader;
             HeaderName = headerName;
@@ -76,7 +81,10 @@ namespace Arcus.WebApi.Security.Authorization
             get => _headerName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires an non-blank request header name to look for the JWT token");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Requires a non-blank request header name to look for the JWT token", nameof(value));
+                }
                 _headerName = value;
             }
         }
@@ -90,7 +98,10 @@ namespace Arcus.WebApi.Security.Authorization
             get => _jwtTokenReader;
             set
             {
-                Guard.NotNull(value, nameof(value), $"Requires a valid {nameof(IJwtTokenReader)} to verify the JWT token");
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value), $"Requires a valid {nameof(IJwtTokenReader)} to verify the JWT token");
+                }
                 _jwtTokenReader = value;
                 _createJwtTokenReader = null;
             }
@@ -119,10 +130,8 @@ namespace Arcus.WebApi.Security.Authorization
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="createReader"/> is <c>null</c>.</exception>
         public void AddJwtTokenReader(Func<IServiceProvider, IJwtTokenReader> createReader)
         {
-            Guard.NotNull(createReader, nameof(createReader), $"Requires an implementation function to create an {nameof(IJwtTokenReader)} instance");
-
             _jwtTokenReader = null;
-            _createJwtTokenReader = createReader;
+            _createJwtTokenReader = createReader ?? throw new ArgumentNullException(nameof(createReader), $"Requires an implementation function to create an {nameof(IJwtTokenReader)} instance");
         }
 
         /// <summary>
@@ -136,7 +145,10 @@ namespace Arcus.WebApi.Security.Authorization
             {
                 try
                 {
-                    Guard.NotNull(serviceProvider, nameof(serviceProvider), $"Requires an collection of services to create an {nameof(IJwtTokenReader)} instance");
+                    if (serviceProvider is null)
+                    {
+                        throw new ArgumentNullException(nameof(serviceProvider), $"Requires a collection of services to create an {nameof(IJwtTokenReader)} instance");
+                    }
                     return _createJwtTokenReader(serviceProvider);
                 }
                 catch (Exception exception)

--- a/src/Arcus.WebApi.Security/Extensions/IServiceProviderExtensions.cs
+++ b/src/Arcus.WebApi.Security/Extensions/IServiceProviderExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -23,7 +22,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public static ILogger<T> GetLoggerOrDefault<T>(this IServiceProvider services)
         {
-            Guard.NotNull(services, nameof(services), "Requires a services collection to retrieve an logger instance");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), "Requires a services collection to retrieve a logger instance");
+            }
             
             var loggerFactory = services.GetService<ILoggerFactory>();
             ILogger<T> logger = loggerFactory?.CreateLogger<T>();

--- a/src/Arcus.WebApi.Tests.Core/Arcus.WebApi.Tests.Core.csproj
+++ b/src/Arcus.WebApi.Tests.Core/Arcus.WebApi.Tests.Core.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="29.0.2" />
-    <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0" />

--- a/src/Arcus.WebApi.Tests.Core/Logging/AzureFunctions/ReadOnceStream.cs
+++ b/src/Arcus.WebApi.Tests.Core/Logging/AzureFunctions/ReadOnceStream.cs
@@ -17,6 +17,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging.Fixture.AzureFunctions
             {
                 throw new ArgumentNullException(nameof(innerStream));
             }
+
             if (!innerStream.CanRead)
             {
                 throw new ArgumentException("Requires a readable stream to represent a read-once stream", nameof(innerStream));

--- a/src/Arcus.WebApi.Tests.Core/Logging/AzureFunctions/ReadOnceStream.cs
+++ b/src/Arcus.WebApi.Tests.Core/Logging/AzureFunctions/ReadOnceStream.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using GuardNet;
 
 namespace Arcus.WebApi.Tests.Unit.Logging.Fixture.AzureFunctions
 {
@@ -14,8 +13,14 @@ namespace Arcus.WebApi.Tests.Unit.Logging.Fixture.AzureFunctions
         /// </summary>
         public ReadOnceStream(Stream innerStream)
         {
-            Guard.NotNull(innerStream, nameof(innerStream));
-            Guard.For<ArgumentException>(() => !innerStream.CanRead, "Requires a readable stream to represents a read-once stream");
+            if (innerStream is null)
+            {
+                throw new ArgumentNullException(nameof(innerStream));
+            }
+            if (!innerStream.CanRead)
+            {
+                throw new ArgumentException("Requires a readable stream to represent a read-once stream", nameof(innerStream));
+            }
 
             _innerStream = innerStream;
         }

--- a/src/Arcus.WebApi.Tests.Integration/Fixture/HttpRequestBuilder.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Fixture/HttpRequestBuilder.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
-using GuardNet;
+using System.Threading;
 
 namespace Arcus.WebApi.Tests.Integration.Fixture
 {
@@ -33,7 +33,10 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentException">Thrown when the <paramref name="route"/> is blank.</exception>
         public static HttpRequestBuilder Get(string route)
         {
-            Guard.NotNullOrWhitespace(route, nameof(route), "Requires a non-blank HTTP relative route to create a HTTP GET request builder instance");
+            if (string.IsNullOrWhiteSpace(route))
+            {
+                throw new ArgumentException("Requires a non-blank HTTP relative route to create a HTTP GET request builder instance", nameof(route));
+            }
             return new HttpRequestBuilder(HttpMethod.Get, route);
         }
 
@@ -45,7 +48,10 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentException">Thrown when the <paramref name="route"/> is blank.</exception>
         public static HttpRequestBuilder Post(string route)
         {
-            Guard.NotNullOrWhitespace(route, nameof(route), "Requires a non-blank HTTP relative route to create a HTTP POST request builder instance");
+            if (string.IsNullOrWhiteSpace(route))
+            {
+                throw new ArgumentException("Requires a non-blank HTTP relative route to create a HTTP POST request builder instance", nameof(route));
+            }
             return new HttpRequestBuilder(HttpMethod.Post, route);
         }
         
@@ -57,7 +63,10 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentException">Thrown when the <paramref name="headerName"/> is blank.</exception>
         public HttpRequestBuilder WithHeader(string headerName, object headerValue)
         {
-            Guard.NotNullOrWhitespace(headerName, nameof(headerName), "Requires a non-blank header name to add the header to the HTTP request builder instance");
+            if (string.IsNullOrWhiteSpace(headerName))
+            {
+                throw new ArgumentException("Requires a non-blank header name to add the header to the HTTP request builder instance", nameof(headerName));
+            }
             _headers.Add(new KeyValuePair<string, string>(headerName, headerValue?.ToString()));
 
             return this;
@@ -71,7 +80,10 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentException">Thrown when the <paramref name="parameterName"/> is blank.</exception>
         public HttpRequestBuilder WithParameter(string parameterName, object parameterValue)
         {
-            Guard.NotNullOrWhitespace(parameterName, nameof(parameterName), "Requires a non-blank query parameter name to add the parameter to the HTTP request builder instance");
+            if (string.IsNullOrWhiteSpace(parameterName))
+            {
+                throw new ArgumentException("Requires a non-blank query parameter to add the parameter to the HTTP request builder instance", nameof(parameterName));
+            }
             _parameters.Add(new KeyValuePair<string, string>(parameterName, parameterValue.ToString()));
 
             return this;
@@ -85,12 +97,15 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentException">Thrown when the <paramref name="text"/> is blank.</exception>
         public HttpRequestBuilder WithJsonText(string text)
         {
-            Guard.NotNullOrWhitespace(text, nameof(text), "Requires non-blank JSON request text to add the content to the HTTP request builder instance");
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                throw new ArgumentException("Requires a non-blank JSON request text to add the content to the HTTP request builder instance", nameof(text));
+            }
             _createContent = () => new StringContent($"\"{text}\"", Encoding.UTF8, "application/json");
 
             return this;
         }
-        
+
         /// <summary>
         /// Adds a JSON json to the HTTP request.
         /// </summary>
@@ -99,7 +114,10 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentException">Thrown when the <paramref name="json"/> is blank.</exception>
         public HttpRequestBuilder WithJsonBody(string json)
         {
-            Guard.NotNullOrWhitespace(json, nameof(json), "Requires non-blank JSON request body to add the content to the HTTP request builder instance");
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                throw new ArgumentException("Requires a non-blank JSON request body to add the content to the HTTP request builder instance", nameof(json));
+            }
             _createContent = () => new StringContent(json, Encoding.UTF8, "application/json");
 
             return this;
@@ -113,7 +131,10 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentException">Thrown when the <paramref name="text"/> is blank.</exception>
         public HttpRequestBuilder WithTextBody(string text)
         {
-            Guard.NotNullOrWhitespace(text, nameof(text), "Requires a non-blank text input for the request body");
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                throw new ArgumentException("Requires a non-blank text input for the request body", nameof(text));
+            }
             _createContent = () => new StringContent(text, Encoding.UTF8, "text/plain");
 
             return this;
@@ -127,7 +148,10 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="UriFormatException">Thrown when the <paramref name="baseRoute"/> is not in the correct HTTP format.</exception>
         internal HttpRequestMessage Build(string baseRoute)
         {
-            Guard.NotNullOrWhitespace(baseRoute, nameof(baseRoute), "Requires a non-blank base HTTP endpoint to create a HTTP request message from the HTTP request builder instance");
+            if (string.IsNullOrWhiteSpace(baseRoute))
+            {
+                throw new ArgumentException("Requires a non-blank base HTTP endpoint to create a HTTP request message from the HTTP request builder instance", nameof(baseRoute));
+            }
 
             string parameters = "";
             if (_parameters.Count > 0)

--- a/src/Arcus.WebApi.Tests.Integration/Fixture/HttpRequestBuilder.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Fixture/HttpRequestBuilder.cs
@@ -37,6 +37,7 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
             {
                 throw new ArgumentException("Requires a non-blank HTTP relative route to create a HTTP GET request builder instance", nameof(route));
             }
+
             return new HttpRequestBuilder(HttpMethod.Get, route);
         }
 
@@ -52,6 +53,7 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
             {
                 throw new ArgumentException("Requires a non-blank HTTP relative route to create a HTTP POST request builder instance", nameof(route));
             }
+
             return new HttpRequestBuilder(HttpMethod.Post, route);
         }
         
@@ -67,6 +69,7 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
             {
                 throw new ArgumentException("Requires a non-blank header name to add the header to the HTTP request builder instance", nameof(headerName));
             }
+
             _headers.Add(new KeyValuePair<string, string>(headerName, headerValue?.ToString()));
 
             return this;
@@ -84,6 +87,7 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
             {
                 throw new ArgumentException("Requires a non-blank query parameter to add the parameter to the HTTP request builder instance", nameof(parameterName));
             }
+
             _parameters.Add(new KeyValuePair<string, string>(parameterName, parameterValue.ToString()));
 
             return this;
@@ -101,6 +105,7 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
             {
                 throw new ArgumentException("Requires a non-blank JSON request text to add the content to the HTTP request builder instance", nameof(text));
             }
+
             _createContent = () => new StringContent($"\"{text}\"", Encoding.UTF8, "application/json");
 
             return this;
@@ -118,6 +123,7 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
             {
                 throw new ArgumentException("Requires a non-blank JSON request body to add the content to the HTTP request builder instance", nameof(json));
             }
+
             _createContent = () => new StringContent(json, Encoding.UTF8, "application/json");
 
             return this;
@@ -135,6 +141,7 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
             {
                 throw new ArgumentException("Requires a non-blank text input for the request body", nameof(text));
             }
+
             _createContent = () => new StringContent(text, Encoding.UTF8, "text/plain");
 
             return this;
@@ -153,13 +160,16 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
                 throw new ArgumentException("Requires a non-blank base HTTP endpoint to create a HTTP request message from the HTTP request builder instance", nameof(baseRoute));
             }
 
+
             string parameters = "";
+            
             if (_parameters.Count > 0)
             {
                 parameters = "?" + String.Join("&", _parameters.Select(p => $"{p.Key}={p.Value}")); 
             }
 
             string path = _path;
+            
             if (path.StartsWith('/'))
             {
                 path = path.TrimStart('/');

--- a/src/Arcus.WebApi.Tests.Integration/Fixture/HttpRequestBuilder.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Fixture/HttpRequestBuilder.cs
@@ -160,7 +160,7 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
             }
 
             string path = _path;
-            if (path.StartsWith("/"))
+            if (path.StartsWith('/'))
             {
                 path = path.TrimStart('/');
             }

--- a/src/Arcus.WebApi.Tests.Integration/Fixture/TestApiServer.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Fixture/TestApiServer.cs
@@ -50,6 +50,7 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
             {
                 throw new ArgumentNullException(nameof(options), "Requires a set of configurable options to control the behavior of the test API server");
             }
+
             if (logger is null)
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to write diagnostic messages during the lifetime of the test API server");

--- a/src/Arcus.WebApi.Tests.Integration/Fixture/TestApiServer.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Fixture/TestApiServer.cs
@@ -4,12 +4,12 @@ using System.Net.Http;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Arcus.Testing.Logging;
-using GuardNet;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.ApplicationInsights;
+using Microsoft.Extensions.Options;
 
 namespace Arcus.WebApi.Tests.Integration.Fixture
 {
@@ -26,9 +26,7 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
 
         protected TestApiServer(IHost host, TestApiServerOptions options, ILogger logger)
         {
-            Guard.NotNull(host, nameof(host), "Requires a 'IHost' instance to start/stop the test API server");
-
-            _host = host;
+            _host = host ?? throw new ArgumentNullException(nameof(host), "Requires a 'IHost' instance to start/stop the test API server");
             _options = options;
             _logger = logger;
 
@@ -48,8 +46,14 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> or <paramref name="logger"/> is <c>null</c>.</exception>
         public static async Task<TestApiServer> StartNewAsync(TestApiServerOptions options, ILogger logger)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of configurable options to control the behavior of the test API server");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write diagnostic messages during the lifetime of the test API server");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a set of configurable options to control the behavior of the test API server");
+            }
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to write diagnostic messages during the lifetime of the test API server");
+            }
 
             IHostBuilder builder = Host.CreateDefaultBuilder();
             options.ApplyOptions(builder);
@@ -88,7 +92,10 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         public async Task<HttpResponseMessage> SendAsync(HttpRequestBuilder builder)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a HTTP request builder instance to create a HTTP request to the test API server");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a HTTP request builder instance to create a HTTP request to the test API server");
+            }
 
             HttpRequestMessage request = builder.Build(_options.Url);
 

--- a/src/Arcus.WebApi.Tests.Integration/Fixture/TestApiServerOptions.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Fixture/TestApiServerOptions.cs
@@ -124,6 +124,7 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
             {
                 throw new ArgumentNullException(nameof(configure), "Requires a function to configure the application configuration of the test API server");
             }
+
             _appConfigures.Add(configure);
 
             return this;

--- a/src/Arcus.WebApi.Tests.Integration/Fixture/TestApiServerOptions.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Fixture/TestApiServerOptions.cs
@@ -126,6 +126,7 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
             }
             _appConfigures.Add(configure);
 
+            return this;
         }
         
         /// <summary>

--- a/src/Arcus.WebApi.Tests.Integration/Fixture/TestApiServerOptions.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Fixture/TestApiServerOptions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Bogus;
-using GuardNet;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.Functions.Worker;
@@ -47,7 +46,10 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configureServices"/> is <c>null</c>.</exception>
         public TestApiServerOptions ConfigureServices(Action<IServiceCollection> configureServices)
         {
-            Guard.NotNull(configureServices, nameof(configureServices), "Requires a function to configure the dependency services on the test API server");
+            if (configureServices is null)
+            {
+                throw new ArgumentNullException(nameof(configureServices), "Requires a function to configure the dependency services on the test API server");
+            }
             _configureServices.Add(configureServices);
 
             return this;
@@ -64,7 +66,10 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configure"/> is <c>null</c>.</exception>
         public TestApiServerOptions PreConfigure(Action<IApplicationBuilder> configure)
         {
-            Guard.NotNull(configure, nameof(configure), "Requires a function to configure the application on the test API server");
+            if (configure is null)
+            {
+                throw new ArgumentNullException(nameof(configure), "Requires a function to configure the application on the test API server");
+            }
             _preconfigures.Add(configure);
 
             return this;
@@ -81,7 +86,10 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configure"/> is <c>null</c>.</exception>
         public TestApiServerOptions Configure(Action<IApplicationBuilder> configure)
         {
-            Guard.NotNull(configure, nameof(configure), "Requires a function to configure the application on the test API server");
+            if (configure is null)
+            {
+                throw new ArgumentNullException(nameof(configure), "Requires a function to configure the application on the test API server");
+            }
             _configures.Add(configure);
 
             return this;
@@ -95,7 +103,10 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configure"/> is <c>null</c>.</exception>
         public TestApiServerOptions ConfigureHost(Action<IHostBuilder> configure)
         {
-            Guard.NotNull(configure, nameof(configure), "Requires a function to configure the hosting configuration of the test API server");
+            if (configure is null)
+            {
+                throw new ArgumentNullException(nameof(configure), "Requires a function to configure the hosting configuration of the test API server");
+            }
             _hostingConfigures.Add(configure);
 
             return this;
@@ -109,10 +120,12 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configure"/> is <c>null</c>.</exception>
         public TestApiServerOptions ConfigureAppConfiguration(Action<IConfigurationBuilder> configure)
         {
-            Guard.NotNull(configure, nameof(configure), "Requires a function to configure the application configuration of the test API server");
+            if (configure is null)
+            {
+                throw new ArgumentNullException(nameof(configure), "Requires a function to configure the application configuration of the test API server");
+            }
             _appConfigures.Add(configure);
 
-            return this;
         }
         
         /// <summary>

--- a/src/Arcus.WebApi.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Fixture/TestConfig.cs
@@ -18,6 +18,7 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
             {
                 throw new ArgumentNullException(nameof(config));
             }
+
             _config = config;
         }
 

--- a/src/Arcus.WebApi.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Fixture/TestConfig.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using GuardNet;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 
@@ -15,7 +14,10 @@ namespace Arcus.WebApi.Tests.Integration.Fixture
 
         private TestConfig(IConfigurationRoot config)
         {
-            Guard.NotNull(config, nameof(config));
+            if (config is null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
             _config = config;
         }
 

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssert.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssert.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 
 namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
@@ -13,7 +12,10 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
 
         private HttpAssert(Action<HttpContext> assertion)
         {
-            Guard.NotNull(assertion, nameof(assertion), "Requires an assertion function to verify a HTTP context");
+            if (assertion is null)
+            {
+                throw new ArgumentNullException(nameof(assertion), "Requires an assertion function to verify a HTTP context");
+            }
             _assertion = assertion;
         }
 
@@ -24,7 +26,10 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="assertion"/> is <c>null</c>.</exception>
         public static HttpAssert Create(Action<HttpContext> assertion)
         {
-            Guard.NotNull(assertion, nameof(assertion), "Requires an assertion function to verify a HTTP context");
+            if (assertion is null)
+            {
+                throw new ArgumentNullException(nameof(assertion), "Requires an assertion function to verify a HTTP context");
+            }
             return new HttpAssert(assertion);
         }
 
@@ -35,7 +40,10 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="context"/> is <c>null</c>.</exception>
         public void Assert(HttpContext context)
         {
-            Guard.NotNull(context, nameof(context), "Requires a HTTP context to run an assertion function on it");
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context), "Requires a HTTP context to run an assertion function to it");
+            }
             _assertion(context);
         }
     }

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssert.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssert.cs
@@ -16,6 +16,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
             {
                 throw new ArgumentNullException(nameof(assertion), "Requires an assertion function to verify a HTTP context");
             }
+
             _assertion = assertion;
         }
 
@@ -30,6 +31,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
             {
                 throw new ArgumentNullException(nameof(assertion), "Requires an assertion function to verify a HTTP context");
             }
+
             return new HttpAssert(assertion);
         }
 
@@ -44,6 +46,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
             {
                 throw new ArgumentNullException(nameof(context), "Requires a HTTP context to run an assertion function to it");
             }
+
             _assertion(context);
         }
     }

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertProvider.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertProvider.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using GuardNet;
 using Xunit;
 using Xunit.Sdk;
 
@@ -22,11 +22,18 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
         /// <exception cref="ArgumentException">Thrown when the <paramref name="namedAssertions"/> contains <c>null</c> elements or has duplicate names.</exception>
         public HttpAssertProvider(IEnumerable<Tuple<string, HttpAssert>> namedAssertions)
         {
-            Guard.NotNull(namedAssertions, nameof(namedAssertions), "Requires a series of named HTTP assertions to setup the HTTP assertion provider");
-            Guard.For(() => namedAssertions.Any(item => item is null), 
-                new ArgumentException("Requires a series of named HTTP assertions without any 'null' elements to setup the HTTP assertion provider", nameof(namedAssertions)));
-            Guard.For(() => namedAssertions.GroupBy(item => item.Item1).All(group => group.Count() != 1),
-                new ArgumentException("Requires a series of named HTTP assertions with unique names to setup the HTTP assertion provider", nameof(namedAssertions)));
+            if (namedAssertions is null)
+            {
+                throw new ArgumentNullException(nameof(namedAssertions), "Requires a series of named HTTP assertions to setup the HTTP assertion provider");
+            }
+            if (namedAssertions.Any(item => item is null))
+            {
+                throw new ArgumentException("Requires a series of named HTTP assertions without any 'null' elements to setup the HTTP assertion provider", nameof(namedAssertions);
+            }
+            if (namedAssertions.GroupBy(item => item.Item1).All(group => group.Count() != 1))
+            {
+                throw new ArgumentException("Requires a series of named HTTP assertions with unique names to setup the HTTP assertion provider", nameof(namedAssertions));
+            }
 
             _namedAssertions = namedAssertions.ToArray();
         }
@@ -39,7 +46,10 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
         /// <exception cref="SingleException">Thrown when more than one <see cref="HttpAssert"/> was registered under the given <paramref name="name"/>.</exception>
         public HttpAssert GetAssertion(string name)
         {
-            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to retrieve the HTTP assertion");
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Requires a non-blank name to retrieve the HTTP assertion", nameof(name));
+            }
             return Assert.Single(_namedAssertions, item => item.Item1 == name).Item2;
         }
     }

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertProvider.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertProvider.cs
@@ -28,7 +28,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
             }
             if (namedAssertions.Any(item => item is null))
             {
-                throw new ArgumentException("Requires a series of named HTTP assertions without any 'null' elements to setup the HTTP assertion provider", nameof(namedAssertions);
+                throw new ArgumentException("Requires a series of named HTTP assertions without any 'null' elements to setup the HTTP assertion provider", nameof(namedAssertions));
             }
             if (namedAssertions.GroupBy(item => item.Item1).All(group => group.Count() != 1))
             {

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertProvider.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertProvider.cs
@@ -26,10 +26,12 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
             {
                 throw new ArgumentNullException(nameof(namedAssertions), "Requires a series of named HTTP assertions to setup the HTTP assertion provider");
             }
+
             if (namedAssertions.Any(item => item is null))
             {
                 throw new ArgumentException("Requires a series of named HTTP assertions without any 'null' elements to setup the HTTP assertion provider", nameof(namedAssertions));
             }
+
             if (namedAssertions.GroupBy(item => item.Item1).All(group => group.Count() != 1))
             {
                 throw new ArgumentException("Requires a series of named HTTP assertions with unique names to setup the HTTP assertion provider", nameof(namedAssertions));
@@ -50,6 +52,7 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
             {
                 throw new ArgumentException("Requires a non-blank name to retrieve the HTTP assertion", nameof(name));
             }
+
             return Assert.Single(_namedAssertions, item => item.Item1 == name).Item2;
         }
     }

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -22,9 +21,18 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         public static IServiceCollection AddHttpAssert(this IServiceCollection services, string name, Action<HttpContext> assertion)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the HTTP assertion to");
-            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to register the HTTP assertion");
-            Guard.NotNull(assertion, nameof(assertion), "Requires an assertion function to verify the currently available HTTP context");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), "Requires a set of services to add the HTTP assertion to");
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Requires a non-blank name to register the HTTP assertion", nameof(name));
+            }
+            if (assertion is null)
+            {
+                throw new ArgumentNullException(nameof(assertion), "Requires an assertion function to verify the currently available HTTP context");
+            }
 
             services.TryAddSingleton<HttpAssertProvider>();
             return services.AddSingleton(Tuple.Create(name, HttpAssert.Create(assertion)));

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertServiceCollectionExtensions.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/HttpAssertServiceCollectionExtensions.cs
@@ -25,10 +25,12 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
             {
                 throw new ArgumentNullException(nameof(services), "Requires a set of services to add the HTTP assertion to");
             }
+
             if (string.IsNullOrWhiteSpace(name))
             {
                 throw new ArgumentException("Requires a non-blank name to register the HTTP assertion", nameof(name));
             }
+
             if (assertion is null)
             {
                 throw new ArgumentNullException(nameof(assertion), "Requires an assertion function to verify the currently available HTTP context");

--- a/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/TraceIdentifierMiddleware.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Logging/Fixture/TraceIdentifierMiddleware.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 
 namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
@@ -20,11 +19,8 @@ namespace Arcus.WebApi.Tests.Integration.Logging.Fixture
             RequestDelegate next,
             TraceIdentifierOptions options)
         {
-            _next = next;
-            Guard.NotNull(next, nameof(next), "Requires a continuation delegate");
-            Guard.NotNull(options, nameof(options), $"Requires a non-null '{nameof(TraceIdentifierOptions)}' options");
-
-            _options = options;
+            _next = next ?? throw new ArgumentNullException(nameof(next), "Requires a continuation delegate");
+            _options = options ?? throw new ArgumentNullException(nameof(options), $"Requires a non-null '{nameof(TraceIdentifierOptions)}' options instance");
         }
 
         /// <summary>Request handling method.</summary>

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authentication/Fixture/CertificateConfiguration.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authentication/Fixture/CertificateConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Security.Cryptography.X509Certificates;
 using Arcus.WebApi.Tests.Integration.Fixture;
-using GuardNet;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 
@@ -21,9 +20,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication.Fixture
         /// <exception cref="ArgumentNullException">When the <paramref name="clientCertificate"/> is <c>null</c>.</exception>
         public CertificateConfiguration(X509Certificate2 clientCertificate)
         {
-            Guard.NotNull(clientCertificate, nameof(clientCertificate));
-
-            _clientCertificate = clientCertificate;
+            _clientCertificate = clientCertificate ?? throw new ArgumentNullException(nameof(clientCertificate));
         }
 
         /// <inheritdoc />

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authentication/Fixture/SelfSignedCertificate.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authentication/Fixture/SelfSignedCertificate.cs
@@ -56,6 +56,7 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication.Fixture
             {
                 throw new ArgumentException("Subject name should not be blank", nameof(subjectName));
             }
+
             if (string.IsNullOrWhiteSpace(issuerName))
             {
                 throw new ArgumentException("Issuer name should not be blank", nameof(issuerName));

--- a/src/Arcus.WebApi.Tests.Integration/Security/Authentication/Fixture/SelfSignedCertificate.cs
+++ b/src/Arcus.WebApi.Tests.Integration/Security/Authentication/Fixture/SelfSignedCertificate.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
-using GuardNet;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Generators;
@@ -36,7 +35,10 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication.Fixture
         /// <exception cref="ArgumentException">When the <paramref name="subjectName"/> is <c>null</c>.</exception>
         public static X509Certificate2 CreateWithSubject(string subjectName)
         {
-            Guard.NotNullOrWhitespace(subjectName, nameof(subjectName), "Subject name should not be blank");
+            if (string.IsNullOrWhiteSpace(subjectName))
+            {
+                throw new ArgumentException("Subject name should not be blank", nameof(subjectName));
+            }
 
             return CreateWithIssuerAndSubjectName("TestCA", subjectName);
         }
@@ -50,8 +52,14 @@ namespace Arcus.WebApi.Tests.Integration.Security.Authentication.Fixture
         /// <exception cref="ArgumentException">When the <paramref name="issuerName"/> is <c>null</c>.</exception>
         public static X509Certificate2 CreateWithIssuerAndSubjectName(string issuerName, string subjectName)
         {
-            Guard.NotNullOrWhitespace(subjectName, nameof(subjectName), "Subject name should not be blank");
-            Guard.NotNullOrWhitespace(issuerName, nameof(issuerName), "Issuer name should not be blank");
+            if (string.IsNullOrWhiteSpace(subjectName))
+            {
+                throw new ArgumentException("Subject name should not be blank", nameof(subjectName));
+            }
+            if (string.IsNullOrWhiteSpace(issuerName))
+            {
+                throw new ArgumentException("Issuer name should not be blank", nameof(issuerName));
+            }
 
             issuerName = issuerName.StartsWith("CN=") ? issuerName : "CN=" + issuerName;
             subjectName = subjectName.StartsWith("CN=") ? subjectName : "CN=" + subjectName;

--- a/src/Arcus.WebApi.Tests.Runtimes.AzureFunction.Isolated/HttpTriggerFunction.cs
+++ b/src/Arcus.WebApi.Tests.Runtimes.AzureFunction.Isolated/HttpTriggerFunction.cs
@@ -2,7 +2,6 @@ using System.Net;
 using Arcus.Observability.Correlation;
 using Arcus.WebApi.Logging.Core.Correlation;
 using Azure.Core.Serialization;
-using GuardNet;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
@@ -20,11 +19,8 @@ namespace Arcus.WebApi.Tests.Runtimes.AzureFunction.Isolated
             JsonObjectSerializer serializer,
             ILoggerFactory loggerFactory)
         {
-            Guard.NotNull(correlationAccessor, nameof(correlationAccessor));
-            Guard.NotNull(serializer, nameof(serializer));
-
-            _correlationAccessor = correlationAccessor;
-            _serializer = serializer;
+            _correlationAccessor = correlationAccessor ?? throw new ArgumentNullException(nameof(correlationAccessor));
+            _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
             _logger = loggerFactory.CreateLogger<HttpTriggerFunction>();
         }
 

--- a/src/Arcus.WebApi.Tests.Unit/Logging/Fixture/DefaultHttpMessageHandlerBuilder.cs
+++ b/src/Arcus.WebApi.Tests.Unit/Logging/Fixture/DefaultHttpMessageHandlerBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using GuardNet;
 using Microsoft.Extensions.Http;
 
 namespace Arcus.WebApi.Tests.Unit.Logging.Fixture
@@ -18,8 +17,7 @@ namespace Arcus.WebApi.Tests.Unit.Logging.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="provider"/> is <c>null</c>.</exception>
         public DefaultHttpMessageHandlerBuilder(IServiceProvider provider)
         {
-            Guard.NotNull(provider, nameof(provider), "Requires a service provider to retrieve the available application services when registering HTTP message handlers");
-            Services = provider;
+            Services = provider ?? throw new ArgumentNullException(nameof(provider), "Requires a service provider to retrieve the available application services when registering HTTP message handlers");
         }
 
         /// <summary>


### PR DESCRIPTION
As per issue 463. This PR removes all dependency on Guard.NET. All checks done by Guard.NET have been replaced with `if` checks.

Closes #463 