### PR TITLE
chore(deps): use newest arcus.observability version

### DIFF
--- a/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
+++ b/src/Arcus.WebApi.Logging.Core/Arcus.WebApi.Logging.Core.csproj
@@ -26,9 +26,8 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[3.0.0,4.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="[3.1.1,4.0.0)" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[3.1.1,4.0.0)" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
   </ItemGroup>
 

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
@@ -1,13 +1,11 @@
-﻿using Arcus.Observability.Correlation;
-using Arcus.Observability.Telemetry.Core;
-
-using Microsoft.Extensions.Logging;
-
 using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+﻿using Arcus.Observability.Correlation;
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
 
 namespace Arcus.WebApi.Logging.Core.Correlation
 {

--- a/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
+++ b/src/Arcus.WebApi.Logging.Core/Correlation/HttpCorrelationMessageHandler.cs
@@ -1,11 +1,13 @@
-﻿using System;
+﻿using Arcus.Observability.Correlation;
+using Arcus.Observability.Telemetry.Core;
+
+using Microsoft.Extensions.Logging;
+
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Arcus.Observability.Correlation;
-using Arcus.Observability.Telemetry.Core;
-using Microsoft.Extensions.Logging;
 
 namespace Arcus.WebApi.Logging.Core.Correlation
 {
@@ -28,8 +30,8 @@ namespace Arcus.WebApi.Logging.Core.Correlation
         ///     Thrown when the <paramref name="correlationInfoAccessor"/>, <paramref name="options"/>, or <paramref name="logger"/> is <c>null</c>.
         /// </exception>
         public HttpCorrelationMessageHandler(
-            IHttpCorrelationInfoAccessor correlationInfoAccessor, 
-            HttpCorrelationClientOptions options, 
+            IHttpCorrelationInfoAccessor correlationInfoAccessor,
+            HttpCorrelationClientOptions options,
             ILogger<HttpCorrelationMessageHandler> logger)
         {
             _correlationInfoAccessor = correlationInfoAccessor ?? throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a HTTP context accessor to retrieve the current HTTP correlation");
@@ -52,7 +54,7 @@ namespace Arcus.WebApi.Logging.Core.Correlation
 
             CorrelationInfo correlation = DetermineCorrelationInfo();
             request.Headers.Add(_options.TransactionIdHeaderName, correlation.TransactionId);
-            
+
             using (var measurement = DurationMeasurement.Start())
             {
                 try
@@ -64,7 +66,9 @@ namespace Arcus.WebApi.Logging.Core.Correlation
                 }
                 finally
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     _logger.LogHttpDependency(request, statusCode, measurement, dependencyId, _options.TelemetryContext);
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }
         }
@@ -75,8 +79,8 @@ namespace Arcus.WebApi.Logging.Core.Correlation
             if (correlation is null)
             {
                 throw new InvalidOperationException(
-                    "Cannot enrich the HTTP request with HTTP correlation because no HTTP correlation was registered in the application, " 
-                    + "make sure that you register the HTTP correlation services with 'services.AddHttpCorrelation()' " 
+                    "Cannot enrich the HTTP request with HTTP correlation because no HTTP correlation was registered in the application, "
+                    + "make sure that you register the HTTP correlation services with 'services.AddHttpCorrelation()' "
                     + "and that you use the HTTP correlation middleware 'app.UseHttpCorrelation()' in API scenario's");
             }
 

--- a/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
@@ -1,9 +1,11 @@
-﻿using System.Threading.Tasks;
-using Arcus.Observability.Correlation;
+﻿using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.WebApi.Logging.Core.Correlation;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+
+using System.Threading.Tasks;
 
 // ReSharper disable once CheckNamespace
 namespace System.Net.Http
@@ -114,9 +116,9 @@ namespace System.Net.Http
         ///     Thrown when the <paramref name="client"/>, <paramref name="request"/>, <paramref name="correlationInfo"/>, <paramref name="logger"/> is <c>null</c>.
         /// </exception>
         public static async Task<HttpResponseMessage> SendAsync(
-            this HttpClient client, 
-            HttpRequestMessage request, 
-            CorrelationInfo correlationInfo, 
+            this HttpClient client,
+            HttpRequestMessage request,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             Action<HttpCorrelationClientOptions> configureOptions)
         {
@@ -159,8 +161,10 @@ namespace System.Net.Http
                 }
                 finally
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     logger.LogHttpDependency(request, statusCode, measurement, dependencyId, options.TelemetryContext);
-                } 
+#pragma warning restore CS0618 // Type or member is obsolete
+                }
             }
         }
     }

--- a/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
+++ b/src/Arcus.WebApi.Logging.Core/Extensions/HttpClientExtensions.cs
@@ -1,11 +1,9 @@
-﻿using Arcus.Observability.Correlation;
+using System.Threading.Tasks;
+using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.WebApi.Logging.Core.Correlation;
-
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-
-using System.Threading.Tasks;
 
 // ReSharper disable once CheckNamespace
 namespace System.Net.Http

--- a/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
+++ b/src/Arcus.WebApi.Logging/Arcus.WebApi.Logging.csproj
@@ -26,10 +26,8 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[3.0.0,4.0.0)" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[3.1.1,4.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="[3.1.1,4.0.0)" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
   </ItemGroup>
 

--- a/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
@@ -1,14 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Arcus.Observability.Telemetry.Core;
+﻿using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Core.Logging;
 using Arcus.WebApi.Logging.Core.RequestTracking;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Arcus.WebApi.Logging
 {
@@ -173,7 +176,7 @@ namespace Arcus.WebApi.Logging
                         if (AllowedToTrackStatusCode(httpContext.Response.StatusCode, attributeTrackedStatusCodes, _logger))
                         {
                             string responseBody = await GetPotentialResponseBodyAsync(httpContext, includeResponseBody);
-                            
+
                             LogRequest(requestBody, responseBody, httpContext, duration);
                         }
 
@@ -228,7 +231,12 @@ namespace Arcus.WebApi.Logging
 
             var operationName = DetermineRequestOperationName(httpContext);
 
-            _logger.LogRequest(httpContext.Request, httpContext.Response, operationName, duration, telemetryContext);
+            var request = httpContext.Request;
+            _logger.LogWarning(MessageFormats.RequestFormat,
+#pragma warning disable CS0618 // Type or member is obsolete
+                RequestLogEntry.CreateForHttpRequest(
+#pragma warning restore CS0618 // Type or member is obsolete
+                    request.Method, request.Scheme, request.Host.ToString(), request.Path, operationName, httpContext.Response.StatusCode, duration.StartTime, duration.Elapsed, telemetryContext));
         }
 
         private static string DetermineRequestOperationName(HttpContext httpContext)

--- a/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
+++ b/src/Arcus.WebApi.Logging/RequestTrackingMiddleware.cs
@@ -1,17 +1,15 @@
-﻿using Arcus.Observability.Telemetry.Core;
-using Arcus.Observability.Telemetry.Core.Logging;
-using Arcus.WebApi.Logging.Core.RequestTracking;
-
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Logging;
-
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Core.Logging;
+using Arcus.WebApi.Logging.Core.RequestTracking;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 
 namespace Arcus.WebApi.Logging
 {

--- a/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
+++ b/src/Arcus.WebApi.Tests.Integration/Arcus.WebApi.Tests.Integration.csproj
@@ -19,7 +19,6 @@
   </ItemGroup>
  
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="3.0.0" />
     <PackageReference Include="Arcus.Security.Core" Version="2.0.0" />
     <PackageReference Include="Arcus.Testing.Logging" Version="0.4.0" />
     <PackageReference Include="Arcus.Testing.Security.Providers.InMemory" Version="0.4.0" />


### PR DESCRIPTION
Use most recent version of the Arcus.Observability package as a last hotfix release to help with migration and moving away from Arcus.WebAPI.